### PR TITLE
Post repo-merge doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The DATA Act broker backend is a collection of services that power the DATA Act's central data submission platform.
 
-The website that runs on these services is here: [https://alpha-broker-staging.usaspending.gov/](https://alpha-broker-staging.usaspending.gov/ "DATA Act Broker website").
+The website that runs on these services is here: [https://alpha-broker-staging.usaspending.gov/](https://alpha-broker.usaspending.gov/ "DATA Act Broker website").
 
 ## Background
 
@@ -23,7 +23,7 @@ The first three items compose the broker's backend and are maintained in this re
 
 ### Using Treasury's Hosted Broker
 
-If you're from a federal agency that will use Treasury's hosted DATA Act broker, you can probably stop reading here. Instead, visit the [broker's website](https://alpha-broker-staging.usaspending.gov/ "DATA Act Broker") to request a user account.
+If you're from a federal agency that will use Treasury's hosted DATA Act broker, you can probably stop reading here. Instead, visit the [broker's website](https://alpha-broker.usaspending.gov/ "DATA Act Broker") to request a user account.
 
 ### Using a Broker Virtual Image (Coming Soon)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The DATA Act broker backend is a collection of services that power the DATA Act's central data submission platform.
 
-The website that runs on these services is here: [https://alpha-broker-staging.usaspending.gov/](https://alpha-broker.usaspending.gov/ "DATA Act Broker website").
+The website that runs on these services is here: [https://alpha-broker.usaspending.gov/](https://alpha-broker.usaspending.gov/ "DATA Act Broker website").
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ If you want to run the broker locally, the easiest way to get started is to use 
 
 ### Installing the Broker Locally
 
-If you want to install the software on your own machine, follow the instructions on our DATA Broker [contributing guide](doc/CONTRIBUTING.md "DATA Act contributing guide"). If you're a developer on the DATA Act team or if you want to contribute to the project, this is the option you want.
+If you want to install the software on your own machine, follow the instructions on our DATA Broker [contributing guide](doc/CONTRIBUTING.md#data-act-broker-setup-for-developers "DATA Act contributing guide"). If you're a developer on the DATA Act team or if you want to contribute to the project, this is the option you want.
 
-**[Local installation directions](doc/CONTRIBUTING.md "DATA Act contributing guide")**
+**[Local installation directions](doc/CONTRIBUTING.md#data-act-broker-setup-for-developers "DATA Act contributing guide")**

--- a/README.md
+++ b/README.md
@@ -1,7 +1,37 @@
-# DATA Act Broker Backend Documentation
+# DATA Act Broker Backend
 
-## [DATA Act Core](dataactcore/)
+The DATA Act broker backend is a collection of services that power the DATA Act's central data submission platform.
 
-## [DATA Act Broker API](dataactbroker/)
+The website that runs on these services is here: [https://alpha-broker-staging.usaspending.gov/](https://alpha-broker-staging.usaspending.gov/ "DATA Act Broker website").
 
-## [DATA Act Validator](dataactvalidator/)
+## Background
+
+The U.S. Department of the Treasury is building a suite of open-source tools to help federal agencies comply with the [DATA Act](http://fedspendingtransparency.github.io/about/ "Federal Spending Transparency Background") and to deliver the resulting standardized federal spending information back to agencies and to the public.
+
+One of these tools is the DATA Act Broker (broker). The broker ingests federal spending data from agency award and financial systems, validates it, and standardizes it against the [common DATA Act model](http://fedspendingtransparency.github.io/data-model/ "data model"). Treasury will make a hosted version of the broker freely available to agencies. Alternately, agencies can take this code and run the broker locally.
+
+The broker contains:
+
+* **The [DATA Act core](dataactcore/ "DATA Act core"):** common models and services used by the broker
+* **The [broker's application programming interface (API)](dataactbroker/ "DATA Act broker API"):** data submission API
+* **The [DATA Act validator](dataactvalidator/ "DATA Act validator"):** data validation service
+* **The [broker website](https://github.com/fedspendingtransparency/data-act-broker-web-app "DATA Act Broker website"):** data submission and reporting website powered by the above
+
+The first three items compose the broker's backend and are maintained in this repository. For details about any of the above, please follow the links to their individual README files.
+
+## Using the DATA Act Broker
+
+### Using Treasury's Hosted Broker
+
+If you're from a federal agency that will use Treasury's hosted DATA Act broker, you can probably stop reading here. Instead, visit the [broker's website](https://alpha-broker-staging.usaspending.gov/ "DATA Act Broker") to request a user account.
+
+### Using a Broker Virtual Image (Coming Soon)
+
+If you want to run the broker locally, the easiest way to get started is to use the self-contained package that includes all code, servers, and dependencies in an isolated virtual image.
+**Coming soon.**
+
+### Installing the Broker Locally
+
+If you want to install the software on your own machine, follow the instructions on our DATA Broker [contributing guide](doc/CONTRIBUTING.md "DATA Act contributing guide"). If you're a developer on the DATA Act team or if you want to contribute to the project, this is the option you want.
+
+**[Local installation directions](doc/CONTRIBUTING.md "DATA Act contributing guide")**

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1,12 +1,14 @@
-# The DATA Act Broker Repository
+# The DATA Act Broker Application Programming Interface (API)
 
-The DATA Act Broker repository is the API, which communicates to the web front end.
+The DATA Act Broker API powers the DATA Act's data submission process.
 
-## Installation
+## Background
 
-For instructions on contributing to this project or running your own copy of the DATA Act broker, please refer to the [documentation in the DATA Act core responsitory](https://github.com/fedspendingtransparency/data-act-broker-backend/blob/master/doc/INSTALL.md "DATA Act broker installation guide").
+The U.S. Department of the Treasury is building a suite of open-source tools to help federal agencies comply with the [DATA Act](http://fedspendingtransparency.github.io/about/ "Federal Spending Transparency Background") and to deliver the resulting standardized federal spending information back to agencies and to the public.
 
-## Project Layout
+For more information about the DATA Act Broker codebase, please visit this repository's [main README](../README.md "DATA Act Broker Backend README").
+
+## Broker API Project Layout
 
 The repository has two major directories: scripts and handlers.
 
@@ -561,4 +563,3 @@ To generate a test coverage report from the command line:
 1. Make sure you're in the main project folder (`data-act-broker`).
 2. Run the tests using the `coverage` command: `coverage run tests/runTests.py`.
 3. After the tests are done running, view the coverage report by typing `coverage report`. To exclude third-party libraries from the report, you can tell it to ignore the `site-packages` folder: `coverage report --omit=*/site-packages*`.
-

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -10,7 +10,7 @@ For more information about the DATA Act Broker codebase, please visit this repos
 
 ## Broker API Project Layout
 
-The repository has two major directories: scripts and handlers.
+The Broker API has two major directories: scripts and handlers.
 
 ```
 dataactbroker/
@@ -28,7 +28,7 @@ The `dataactbroker\handlers` folder contains the logic to handle requests that a
 
 `fileHandler.py` contains functions for managing user file interaction. It creates all of the jobs that are part of the user submission and has query methods to get the status of a submission. In addition, this class creates downloadable links to error reports created by the DATA Act Validator.
 
-In addition to these helper objects, the following sub classes also exist within the directory: `UserHandler`, `JobHandler`, `ErrorHandler`, and 'InterfaceHolder'. These classes extend the database connection objects that are located in the Core Repository. Extra query methods exist in these classes that are used exclusively by the Broker API.
+In addition to these helper objects, the following sub classes also exist within the directory: `UserHandler`, `JobHandler`, `ErrorHandler`, and 'InterfaceHolder'. These classes extend the database connection objects that are located in the DATA Act Core. Extra query methods exist in these classes that are used exclusively by the Broker API.
 
 ## DATA Act Broker Route Documentation
 

--- a/dataactcore/README.md
+++ b/dataactcore/README.md
@@ -6,22 +6,7 @@ The DATA Act Core is a collection of common components used by other DATA Act re
 
 The U.S. Department of the Treasury is building a suite of open-source tools to help federal agencies comply with the [DATA Act](http://fedspendingtransparency.github.io/about/ "Federal Spending Transparency Background") and to deliver the resulting standardized federal spending information back to agencies and to the public.
 
-One of these tools is the DATA Act Broker (broker). The broker ingests federal spending data from agency award and financial systems, validates it, and standardizes it against the [common DATA Act model](http://fedspendingtransparency.github.io/data-model/ "data model"). Treasury will make a hosted version of the broker freely available to agencies. Alternately, agencies can take this code and run the broker locally.
-
-The broker comprises:
-
-* The DATA Act core (you are here)
-* The [broker's application programming interface (API)](https://github.com/fedspendingtransparency/data-act-broker-backend/tree/master/dataactbroker "DATA Act broker API")
-* The [DATA Act validator](https://github.com/fedspendingtransparency/data-act-broker-backend/tree/master/dataactvalidator "DATA Act validator")
-* The [broker website](https://github.com/fedspendingtransparency/data-act-broker-web-app "DATA Act broker website")
-
-## What Do I Need to Know?
-
-If you're from a federal agency that will use Treasury's hosted DATA Act broker, you can probably stop reading here. Instead, visit the [broker's website (coming soon)](# "DATA Act broker").
-
-If you want to install and run the broker locally, read the [installation and setup directions](https://github.com/fedspendingtransparency/data-act-broker-backend/blob/master/doc/INSTALL.md "DATA Act broker installation and setup").
-
-If you're doing either of the above but are also interested in the sofware's under-the-hood details, refer to the README.md files in [each project's respository](https://github.com/fedspendingtransparency "fedspendingtransparency repos").
+For more information about the DATA Act Broker codebase, please visit this repository's [main README](../README.md "DATA Act Broker Backend README").
 
 ## DATA Act Core Details
 
@@ -174,4 +159,3 @@ from a REST request. Users are able to pass dictionary objects that will be
 automatically converted to JSON with the correct application headers added.
 
 In addition, the static `error` method will auto create a JSON response with the current exception stack trace encoded. This is useful in the development environment, but should be disabled in production by setting the static class variable `printDebug` to `false`.
-

--- a/dataactcore/README.md
+++ b/dataactcore/README.md
@@ -1,6 +1,6 @@
 # DATA Act Core
 
-The DATA Act Core is a collection of common components used by other DATA Act repositories.
+The DATA Act Core is a collection of common components used by other DATA Act packages.
 
 ## Background
 
@@ -20,8 +20,8 @@ The DATA Act broker uses the following databases; the models and setup scripts f
 
 ## DATA Act Core Project Layout
 
-The DATA Act Core repository is a collection of common components used by other
-DATA Act repositories.  The structure for the repository is as follows:
+The DATA Act Core is a collection of common components used by other
+DATA Act packages.  The directory structure is as follows:
 
 ```
 dataactcore/
@@ -63,8 +63,7 @@ Database interfaces are defined for each database used within the project. Each 
 
 #### Scripts
 
-The `scripts/` folder contains various python scripts to setup parts of the DATA Act Core
-repository for local installation. Database creation scripts are located in this folder. When run directly, the following scripts take no parameters and stand up all required tables within each database:
+The `scripts/` folder contains various python scripts used in the DATA Act broker backend install process, including database creation scripts. When run directly, the following scripts take no parameters and stand up all required tables within each database:
 
 - setupJobTrackerDB (Creates job_tracker database)
 - setupErrorDB      (Creates the error database)
@@ -83,7 +82,7 @@ These scripts should **not** be used in a live production environment, as existi
 #### Utils
 
 The `utils/` folder contains common REST requests and error handling objects.
-These provide a common way for other repositories to handle requests.
+These provide a common way for other broker components to handle requests.
 
 The `RequestDictionary` class is used throughout the DATA Act repositories to provide a
 seamless method to access both the JSON Body and POST FormData from a REST request.

--- a/dataactcore/README.md
+++ b/dataactcore/README.md
@@ -59,7 +59,7 @@ Note that all new ORM objects must inherit from the `declarative_base` object an
 
 Additional fields exist on some of the models to enable the automatic population of foreign key relationships. These fields use the `relationship` function to signify a mapping to another table.  More information on SQLAlchemy ORM objects can be found on the [official website](http://docs.sqlalchemy.org/en/latest/orm/tutorial.html#create-a-schema).
 
-Database interfaces are defined for each database used within the project. Each interface inherits base functionality from `BaseInterface` and defines both the database name and credentials file location. Where required, interfaces are extended in the other repositories to add additional functionality.
+Database interfaces are defined for each database used within the project. Each interface inherits base functionality from `BaseInterface` and defines both the database name and credentials file location. Where required, interfaces are extended in the other packages to add additional functionality.
 
 #### Scripts
 

--- a/dataactcore/README.md
+++ b/dataactcore/README.md
@@ -8,53 +8,9 @@ The U.S. Department of the Treasury is building a suite of open-source tools to 
 
 For more information about the DATA Act Broker codebase, please visit this repository's [main README](../README.md "DATA Act Broker Backend README").
 
-## DATA Act Core Details
+## Data Broker Core Database Reference
 
-The sections below provide some technical details about this repo and about some of the files and databases created during the broker initialization. If you already have the broker up and running (see the [install instructions](https://github.com/fedspendingtransparency/data-act-broker-backend/blob/master/doc/INSTALL.md "Install the DATA Act broker")), you won't have to create any of the files or run any of the scripts below. The information is here for those interested in what's happening under-the-hood.
-
-### Database Credentials
-
-Information about this database is placed in a JSON file in your data-act-core installation: `dataactcore/credentials/dbCred.json`. It contains a JSON dictionary with keys `username`, `password`, `host`, and `port`. Below is an example of what should be in this file:
-
-```json
-{
-    "username":"postgres",
-    "password":"pass",
-    "host":"localhost",
-    "port":"5432"
-}
-```
-
-### Setup Scripts
-
-After creating the Postgres database and credentials file, several setup scripts should be run to create the databases and tables that will be used by the broker. In your data-act-core installation, there will be a folder [dataactcore/scripts/](https://github.com/fedspendingtransparency/data-act-broker-backend/tree/master/dataactcore/scripts). From within this folder, run the following commands:
-
-```bash
-$ python setupJobTrackerDB.py
-$ python setupErrorDB.py
-```
-
-Finally, to prepare the validator to run checks against a specified set of fields and rules, your `data-act-validator` installation will have a [scripts/](https://github.com/fedspendingtransparency/data-act-broker-backend/tree/master/dataactvalidator/scripts) folder containing scripts to create the rule sets for testing, as well as the following database setup scripts that must be run.
-
-```bash
-$ python setupStaging.py
-$ python setupValidationDB.py
-```
-
-For example: `loadApprop.py` may be run to create the included rule set for testing an appropriations file, or you may replace `appropriationsFields.csv` and `appropriationsRules.csv` with custom versions to run a different set of rules.
-
-If you want to use an updated list of Treasury Account Symbols for the validator checks, you'll need to get the updated [`all_tas_betc.csv`](https://www.sam.fms.treas.gov/SAMPublicApp/all_tas_betc.csv) file and place that in the [scripts/](https://github.com/fedspendingtransparency/data-act-broker-backend/tree/master/dataactvalidator/scripts) folder before running:
-
-```bash
-$ python loadTas.py
-$ python setupTASIndexs.py
-```
-
-Once these scripts have been run, the databases will contain everything they need to validate appropriations files.
-
-### Data Broker Database Reference
-
-After broker setup, there will be five databases:
+The DATA Act broker uses the following databases; the models and setup scripts for all of them live in the DATA Act core project.
 
 * `error_data` - Holds file level errors in the `file_status` table, along with information about number of row level errors of each type in the `error_data` table. A complete list of every separate occurrence can be found in the error report csv file.
 * `job_tracker` - Holds information on all validation and upload jobs, including status of jobs and relations between jobs. The `job_status` table is the main place to get this information and provides file name/type, status of the job, the job's associated submission, and the table in which the results are located. The `job_dependency` table details precedence constraints between jobs, giving the job IDs for both the prerequisite and the dependent job.
@@ -62,7 +18,7 @@ After broker setup, there will be five databases:
 * `user_manager` - Holds a mapping between user names and user IDs to be used for providing submission history information to a user.
 * `validation` - Contains all the information a submitted file is validated against. The `file_columns` table details what columns are expected in each file type, and the rule table maps all defined single-field rules to one of the columns specified in `file_columns`. The `multi_field_rule` table stores rules that involve a set of fields, but are still checked against a single record at a time. Finally, the `tas_lookup` table holds the set of valid TAS combinations, taken from the TAS csv file discussed in the setup section.
 
-### How It Works
+## DATA Act Core Project Layout
 
 The DATA Act Core repository is a collection of common components used by other
 DATA Act repositories.  The structure for the repository is as follows:
@@ -108,13 +64,7 @@ Database interfaces are defined for each database used within the project. Each 
 #### Scripts
 
 The `scripts/` folder contains various python scripts to setup parts of the DATA Act Core
-repository for local installation. These scripts are used by the pip install process
-to provide a seamless setup. See the [DATA Act installation guide](https://github.com/fedspendingtransparency/data-act-broker-backend/blob/master/doc/INSTALL.md) for more details.
-If needed, these scripts can be run manually to setup an environment.
-
-`configure.py` provides interactive command line prompts to set the S3 bucket JSON and database access credentials. The S3 JSON format can be found in [AWS Setup](#aws-setup).  The databases credentials format can be found in the [Database Setup Guide](#database-setup-guide).
-
-In addition to the JSON configuration scripts, database creation scripts are located in this folder. When run directly, the following scripts take no parameters and stand up all required tables within each database:
+repository for local installation. Database creation scripts are located in this folder. When run directly, the following scripts take no parameters and stand up all required tables within each database:
 
 - setupJobTrackerDB (Creates job_tracker database)
 - setupErrorDB      (Creates the error database)

--- a/dataactvalidator/README.md
+++ b/dataactvalidator/README.md
@@ -1,10 +1,12 @@
 # DATA Act Validator
 
-The validator is used to check files submitted by users against a set of rules specified in a CSV file, to ensure that data submitted is correctly formatted with reasonable values, and is not inconsistent with other sources.
+The DATA Act validator checks submitted DATA Act files against a set of rules to ensure that data submitted is correctly formatted with reasonable values and is not inconsistent with other sources.
 
-## Installation
+## Background
 
-For instructions on contributing to this project or running your own copy of the DATA Act broker, please refer to the [documentation in the DATA Act core responsitory](https://github.com/fedspendingtransparency/data-act-broker-backend/blob/master/doc/INSTALL.md "DATA Act broker installation guide").
+The U.S. Department of the Treasury is building a suite of open-source tools to help federal agencies comply with the [DATA Act](http://fedspendingtransparency.github.io/about/ "Federal Spending Transparency Background") and to deliver the resulting standardized federal spending information back to agencies and to the public.
+
+For more information about the DATA Act Broker codebase, please visit this repository's [main README](../README.md "DATA Act Broker Backend README").
 
 ## Validator API Routes
 

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -75,13 +75,13 @@ If you already have a Python development environment on your machine and a prefe
 6. You should see some output that looks similar to the example below. Essentially, this command creates and activates a new virtualenv named `data-act` with its own set of Python libraries.  Anything you pip install from this point forward will be installed into the *data-act* environment rather than your machine's global Python environment. Your command line prompt indicates which (if any) virtualenv is active.
 
         rebeccasweger@GSA-xs-MacBook-Pro-4 ~
-        $ mkvirtualenv --python=/usr/local/bin/python2.7 data-act-test
+        $ mkvirtualenv --python=/usr/local/bin/python2.7 data-act
         Running virtualenv with interpreter /usr/local/bin/python2.7
         New python executable in data-act-test/bin/python2.7
         Also creating executable in data-act-test/bin/python
         Installing setuptools, pip...done.
 
-        (data-act-test)
+        (data-act)
         rebeccasweger@GSA-xs-MacBook-Pro-4 ~
 
 7. This new environment will be active until you run the `deactivate` command. You can re-activate the environment again at any time by typing `workon data-act`.
@@ -104,23 +104,22 @@ If you're not using AWS tools when running the broker, you'll need to install a 
 
 Don't worry about setting DynamoDB endpoints or creating tables: the broker's code handles this.
 
-**Note:** The local version of DynamoDB is not recommend for production.
+**Note:** The local version of DynamoDB is not recommended for production.
 
 ### Clone Broker Backend Code Repositories
 
 Now we're ready to install the DATA Act broker itself. Before starting:
 
 * These directions involve the command line. If you're on Windows, use the Git shell that comes with the Windows git install or the GitHub desktop install. Don't use the Windows command prompt.
-* Decide where on your machine you want the DATA Act code to live. Throughout these directions, we'll refer to this directory as your `project home` and use it as your starting point.
 * Make sure that your DATA Act Python environment is activated:
 
-        $ activate data-act
+        $ workon data-act
 
 #### DATA Act Broker Backend
 
-Navigate to your DATA Act project home. From the command line, clone the DATA Act Broker Backend repository from GitHub to your local environment:
+Decide where on your machine you want the DATA Act broker code to live. From the command line, navigate there and clone the DATA Act Broker Backend repository from GitHub to your local environment:
 
-        $ git clone git@github.com:fedspendingtransparency/data-act-broker-backend.git
+        $ git clone https://github.com/fedspendingtransparency/data-act-broker-backend.git
 
 Navigate to the DATA Act Broker Backend's main folder:
 
@@ -146,10 +145,9 @@ The backend components import Python modules from one another. Therefore, the lo
 
 Before running the broker, you'll need to provide a few configuration options. Use the provided sample config file as a starting point:
 
-1. Navigate to the location of the data-act-broker-backend code.
-2. From the `data-act-broker-backend` directory, go to `dataactcore` and open the file called `config_example.yml` in a text editor.
-3. Save `config_example.yml` as `config.yml`.
-4. Update the values in `config.yml` as appropriate for your environment. In many cases the default values will work just fine. The most important config values to change when getting started are:
+1. From the `data-act-broker-backend` directory, go to `dataactcore` and open the file called `config_example.yml` in a text editor.
+2. Save `config_example.yml` as `config.yml`.
+3. Update the values in `config.yml` as appropriate for your environment. In many cases the default values will work just fine. The most important config values to change when getting started are:
 
     * under _broker_:
         * `full_url`
@@ -164,14 +162,14 @@ Before running the broker, you'll need to provide a few configuration options. U
         * `password`
     * under _logging_:
         * `log_files`
-5. Save your changes to config.yml
+4. Save your changes to config.yml
 
 ### Initialize Broker Backend Applications
 
-You will need to run two scripts to setup the broker's backend components. These create the necessary databases and data. From your DATA Act project home:
+You will need to run two scripts to setup the broker's backend components. These create the necessary databases and data. From the `data-act-broker-backend` directory:
 
-        $ python data-act-broker-backend/dataactbroker/scripts/initialize.py -i
-        $ python data-act-broker-backend/dataactvalidator/scripts/initialize.py -i
+        $ python dataactbroker/scripts/initialize.py -i
+        $ python dataactvalidator/scripts/initialize.py -i
 
 **Note:** If you're using a local DynamoDB, make sure it's running before executing these scripts.
 

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -106,7 +106,7 @@ Don't worry about setting DynamoDB endpoints or creating tables: the broker's co
 
 **Note:** The local version of DynamoDB is not recommended for production.
 
-### Clone Broker Backend Code Repositories
+### Clone Broker Backend Code Repository
 
 Now we're ready to install the DATA Act broker itself. Before starting:
 


### PR DESCRIPTION
Update of the docs after the great repo merge of April, 2016:

* Move background info from dataactcore README to main README
* Remove vestiges of old install directions in favor of the consolidated version
* Install direction updates/fixes
* Add background blurb and link to main README in each of the individual READMES (core, api, validator)
* Replace "coming soon" with a link to the alpha website, hooray!