### PR TITLE
hotfix for overriding job db name

### DIFF
--- a/dataactcore/models/jobTrackerInterface.py
+++ b/dataactcore/models/jobTrackerInterface.py
@@ -18,9 +18,8 @@ class JobTrackerInterface(BaseInterface):
     session = None
 
     def __init__(self):
-        super(JobTrackerInterface,self).__init__()
-        self.jobQueue = JobQueue()
         self.dbName = self.dbConfig['job_db_name']
+        self.jobQueue = JobQueue()
         super(JobTrackerInterface, self).__init__()
 
     @staticmethod


### PR DESCRIPTION
@nmonga91 Can you take a look at this, since you're the most familiar with the job queue? Didn't catch this before, but it turns out that the changes introduced for the job queue break the overriding of the database name (for instance, when unit tests are running). This didn't come to light until I was changing the database names as part of another story.

Will this updated code work with the queue logic?