### PR TITLE
Not including 'u' for unicode in the map put in the staging table

### DIFF
--- a/dataactvalidator/interfaces/stagingTable.py
+++ b/dataactvalidator/interfaces/stagingTable.py
@@ -83,7 +83,7 @@ class StagingTable(object):
             else:
                 classFieldDict[newKey] = Column(fieldTypeName)
             # First record will hold field names
-            fieldNameMap[newKey] = key
+            fieldNameMap[str(newKey)] = str(key)
         # Add column for row number
         classFieldDict["row"] = Column(Integer, nullable=False)
 


### PR DESCRIPTION
Small hotfix to the staging table change to not include 'u' in front of every field name.