### PR TITLE
fix bug in alembic metadata setup

### DIFF
--- a/dataactcore/migrations/env.py
+++ b/dataactcore/migrations/env.py
@@ -51,7 +51,7 @@ for name in re.split(r',\s*', db_names):
 #       'engine1':mymodel.metadata1,
 #       'engine2':mymodel.metadata2
 #}
-target_metadata = {value[0]: value[1].Base.metadata for (key, value) in db_dict.items()}
+target_metadata = {key: value[1].Base.metadata for (key, value) in db_dict.items()}
 
 # Set up database URLs based on config file
 username = str(CONFIG_DB['username'])


### PR DESCRIPTION
This PR fixes a bug that was, in some cases, preventing data model metadata from being passed to the Alembic context. This problem was only occurring in cases where the database names in the broker's config.yml don't match the original database names that were hard-coded into the app back in the day.