### PR TITLE
Fixes cross file rule loading's use of common addRule function

### DIFF
--- a/dataactvalidator/filestreaming/schemaLoader.py
+++ b/dataactvalidator/filestreaming/schemaLoader.py
@@ -92,7 +92,7 @@ class SchemaLoader(object):
                 else:
                     targetFileId = None
                 validationDb.addRule(
-                    fileId, record["rule_type"], record["rule_text_one"],
+                    None, record["rule_type"], record["rule_text_one"],
                     record["rule_text_two"], record["description"], record["rule_timing"],
                     record["rule_label"], targetFileId, fileId = fileId)
 


### PR DESCRIPTION
File ID was being provided as a field ID when cross file rules were loaded, which caused a foreign key bug