### PR TITLE
Removing obsolete change_status route that has been replaced by updat…

### DIFF
--- a/dataactbroker/userRoutes.py
+++ b/dataactbroker/userRoutes.py
@@ -23,13 +23,6 @@ def add_user_routes(app,system_email,bcrypt):
         accountManager = AccountHandler(request,bcrypt = bcrypt)
         return RouteUtils.run_instance_function(accountManager,accountManager.register, getSystemEmail = True, getSession = True)
 
-    @app.route("/v1/change_status/", methods=["POST"])
-    @permissions_check(permissionList=["website_admin"])
-    def change_status():
-        """ Expects request to have keys 'user_email' and 'new_status' """
-        accountManager = AccountHandler(request, bcrypt=bcrypt)
-        return RouteUtils.run_instance_function(accountManager, accountManager.changeStatus, getSystemEmail=True)
-
     @app.route("/v1/update_user/", methods=["POST"])
     @permissions_check(permissionList=["website_admin", "agency_admin"])
     def update_user():


### PR DESCRIPTION
…e_user route

Frontend no longer uses this, we left it in during the PR last sprint to still work while frontend was transitioning.