### PR TITLE
Hotfix blank year

### DIFF
--- a/dataactvalidator/validation_handlers/validator.py
+++ b/dataactvalidator/validation_handlers/validator.py
@@ -486,6 +486,9 @@ class Validator(object):
                     blankSkip = False
             if "skip_if_below" in fieldMap[field]:
                 try:
+                    if record[field] is None or str(record[field]).strip() == "":
+                        # No year provided, so this should be skipped as not being checkable against post 2016 budgets
+                        return True
                     if int(record[field]) < fieldMap[field]["skip_if_below"]:
                         # Don't apply rule to records in this case (e.g. program activity before 2016)
                         return True

--- a/tests/fileTypeTests.py
+++ b/tests/fileTypeTests.py
@@ -108,7 +108,7 @@ class FileTypeTests(BaseTestValidator):
         """Test mixed job with some rows failing."""
         jobId = self.jobIdDict["programMixed"]
         self.passed = self.run_test(
-            jobId, 200, "finished", 21372, 4, "complete", 119, True)
+            jobId, 200, "finished", 21060, 4, "complete", 118, True)
 
     def test_award_fin_valid(self):
         """Test valid job."""
@@ -120,7 +120,7 @@ class FileTypeTests(BaseTestValidator):
         """Test mixed job with some rows failing."""
         jobId = self.jobIdDict["awardFinMixed"]
         self.passed = self.run_test(
-            jobId, 200, "finished", 17580, 5, "complete", 88, True)
+            jobId, 200, "finished", 17268, 5, "complete", 87, True)
 
     def test_award_valid(self):
         """Test valid job."""


### PR DESCRIPTION
Initial implementation of BPOA check fails the record if year cannot be cast to an int, but fails to make an exception for blank values