### PR TITLE
add data migration script

### DIFF
--- a/dataactcore/scripts/migrateDataBroker.py
+++ b/dataactcore/scripts/migrateDataBroker.py
@@ -1,0 +1,68 @@
+# migrate data using pg_dump and pg_restore
+# data copied from tables:
+# error_data:
+#   error_metadata
+#   file
+# job_tracker:
+#   job
+#   submission
+#   job_dependency
+# user_manager;
+#   users
+#   email_token
+# validator:
+#   appropriation
+#   award_financial
+#   award_financial_assistance
+#   object_class_program_activity
+
+# run on command line: python migrateDataBroker.py
+
+from dataactcore.config import CONFIG_DB
+import subprocess
+
+c = 'postgresql://{}:{}@{}/'.format(
+    CONFIG_DB['username'], CONFIG_DB['password'], CONFIG_DB['host'])
+target = '{}data_broker'.format(c)
+
+# error_data
+db = 'error_data'
+source = '{}{}'.format(c, db)
+print('migrating {}'.format(db))
+cmd = 'pg_dump -d {} -t error_metadata -t file --data-only --format=c | ' \
+    'pg_restore -d {} --data-only'.format(source, target)
+p = subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
+print('return code = {}\n'.format(p))
+
+# job_tracker
+db = 'job_tracker'
+source = '{}{}'.format(c, db)
+print('migrating {}'.format(db))
+cmd = 'pg_dump -d {} -t job_dependency -t job -t submission --data-only --format=c | ' \
+    'pg_restore -d {} --data-only'.format(source, target)
+p = subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
+print('return code = {}\n'.format(p))
+
+# user_manager
+db = 'user_manager'
+source = '{}{}'.format(c, db)
+print('migrating {}'.format(db))
+cmd = 'pg_dump -d {} -t users -t email_token --data-only --format=c | ' \
+    'pg_restore -d {} --data-only'.format(source, target)
+p = subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
+print('return code = {}\n'.format(p))
+
+# validation - these tables are larger, so do individually
+db = 'validation'
+source = '{}{}'.format(c, db)
+tables = ['appropriation', 'object_class_program_activity',
+          'award_financial', 'award_financial_assistance']
+
+for t in tables:
+    print('migrating {}: {}'.format(db, t))
+    cmd = 'pg_dump -d {} -t {} --data-only --format=c | ' \
+        'pg_restore -d {} --data-only'.format(source, t, target)
+    p = subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
+    print('return code = {}\n'.format(p))
+
+


### PR DESCRIPTION
I know we discussed not using a script for the data migration, but I still felt more comfortable putting together something repeatable and programmatic. This uses `pg_dump` and `pg_restore` to grab data from our old databases and insert it into its new home.

The script is in python simply so that we can grab the database credentials from `DB_CONFIG`. Otherwise, it's just executing postgres shell commands. It should be safe to run the shell commands and pipe data from the dump to the restore, since we're controlling the input.

Lastly, the script is repeatable. If you run it multiple times, it will throw errors on primary key violations.