### PR TITLE
fix for out-of-sync valid_record column

### DIFF
--- a/dataactcore/scripts/migrateDataBroker.py
+++ b/dataactcore/scripts/migrateDataBroker.py
@@ -30,7 +30,7 @@ db = 'error_data'
 source = '{}{}'.format(c, db)
 print('migrating {}'.format(db))
 cmd = 'pg_dump -d {} -t error_metadata -t file --data-only --format=c | ' \
-    'pg_restore -d {} --data-only'.format(source, target)
+    'pg_restore -d {} --data-only --single-transaction'.format(source, target)
 p = subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
 print('return code = {}\n'.format(p))
 
@@ -39,7 +39,7 @@ db = 'job_tracker'
 source = '{}{}'.format(c, db)
 print('migrating {}'.format(db))
 cmd = 'pg_dump -d {} -t job_dependency -t job -t submission --data-only --format=c | ' \
-    'pg_restore -d {} --data-only'.format(source, target)
+    'pg_restore -d {} --data-only --single-transaction'.format(source, target)
 p = subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
 print('return code = {}\n'.format(p))
 
@@ -48,7 +48,7 @@ db = 'user_manager'
 source = '{}{}'.format(c, db)
 print('migrating {}'.format(db))
 cmd = 'pg_dump -d {} -t users -t email_token --data-only --format=c | ' \
-    'pg_restore -d {} --data-only'.format(source, target)
+    'pg_restore -d {} --data-only --single-transaction'.format(source, target)
 p = subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
 print('return code = {}\n'.format(p))
 
@@ -60,8 +60,11 @@ tables = ['appropriation', 'object_class_program_activity',
 
 for t in tables:
     print('migrating {}: {}'.format(db, t))
+    # old db still has valid_record column; drop it
+    cmd = 'psql {} -c "ALTER TABLE {} DROP COLUMN IF EXISTS valid_record"'.format(source, t)
+    p = subprocess.call(cmd, shell=True)
     cmd = 'pg_dump -d {} -t {} --data-only --format=c | ' \
-        'pg_restore -d {} --data-only'.format(source, t, target)
+        'pg_restore -d {} --data-only --single-transaction'.format(source, t, target)
     p = subprocess.call(cmd, shell=True, stdout=subprocess.PIPE)
     print('return code = {}\n'.format(p))
 


### PR DESCRIPTION
The data migration script failed on sandbox because migration that runs against the old staging tables to drop `valid_record` was removed from the migration history and never runs.

Thus, the old tables have that column and the new ones do not, causing the migration script to error. Added a patch that just removes that column in the old db if it's there. 

Also added the `--single-transaction` flag to the`pg_restore` command to ensure that we don't end up with any half-migrated tables.

Again, this script will only work if the target tables are empty, so we'll have to coordinate with @klrBAH when in the deploy process it should run.