### PR TITLE
change fiscal_year and period sf133 cols to int

### DIFF
--- a/dataactcore/migrations/versions/5a9051f9bfc5_update_sf133_datatypes.py
+++ b/dataactcore/migrations/versions/5a9051f9bfc5_update_sf133_datatypes.py
@@ -1,0 +1,44 @@
+"""update-sf133-datatypes
+
+Revision ID: 5a9051f9bfc5
+Revises: a0a4f1ef56ae
+Create Date: 2016-08-11 11:44:49.640398
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5a9051f9bfc5'
+down_revision = 'a0a4f1ef56ae'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+def upgrade_data_broker():
+    op.alter_column('sf_133', 'fiscal_year', nullable=False)
+    op.execute('ALTER TABLE sf_133 ALTER COLUMN fiscal_year TYPE INTEGER USING (fiscal_year::integer)')
+
+    op.alter_column('sf_133', 'period', nullable=False)
+    op.execute('ALTER TABLE sf_133 ALTER COLUMN period TYPE INTEGER USING (period::integer)')
+
+
+def downgrade_data_broker():
+    op.alter_column('sf_133', 'period',
+               existing_type=sa.Integer(),
+               type_=sa.TEXT(),
+               nullable=True)
+    op.alter_column('sf_133', 'fiscal_year',
+               existing_type=sa.Integer(),
+               type_=sa.TEXT(),
+               nullable=True)
+

--- a/dataactcore/models/domainModels.py
+++ b/dataactcore/models/domainModels.py
@@ -47,8 +47,8 @@ class SF133(Base):
     main_account_code = Column(Text, nullable=False)
     sub_account_code = Column(Text, nullable=False)
     tas = Column(Text, nullable=False, default=concatTas, onupdate=concatTas)
-    fiscal_year = Column(Text)
-    period = Column(Text)
+    fiscal_year = Column(Integer, nullable=False)
+    period = Column(Integer, nullable=False)
     line = Column(Integer,nullable=False)
     amount = Column(Numeric,nullable=False,default=0,server_default="0")
 


### PR DESCRIPTION
Update the `period` and `fiscal_year` columns in `sf_133`:
* don't allow NULLs
* change datetype from text to integer

*Note:* you'll see some bespoke `op.execute` statements in the migration..that's to make the datatype change work if the table has existing data.