### PR TITLE
Add some sql-rule validations + skeleton for more

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,27 @@
+from random import randint
+
+import pytest
+
+import dataactcore.config
+from dataactcore.scripts.databaseSetup import (
+    createDatabase, dropDatabase, runMigrations)
+from dataactvalidator.interfaces.interfaceHolder import InterfaceHolder
+
+
+@pytest.yield_fixture(scope='module')
+def database():
+    """Sets up a clean database, yielding a relevant interface holder"""
+    rand_id = str(randint(1, 9999))
+
+    config = dataactcore.config.CONFIG_DB
+    config['db_name'] = 'unittest{}_data_broker'.format(rand_id)
+    dataactcore.config.CONFIG_DB = config
+
+    createDatabase(config['db_name'])
+    runMigrations()
+    interface = InterfaceHolder()
+
+    yield interface
+
+    interface.close()
+    dropDatabase(config['db_name'])

--- a/tests/unit/dataactvalidator/test_a16_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a16_appropriations.py
@@ -1,0 +1,21 @@
+from dataactcore.models.stagingModels import Appropriation
+from tests.unit.dataactvalidator.utils import models_are_valid
+
+
+_FILE = 'a16_appropriations'
+
+
+def test_success(database):
+    award = Appropriation(job_id=1, row_number=1)
+    assert models_are_valid(_FILE, database.stagingDb, award)
+
+
+def test_null_authority(database):
+    award = Appropriation(job_id=1, row_number=1, is_first_quarter=True)
+    assert not models_are_valid(_FILE, database.stagingDb, award)
+
+
+def test_nonnull_authority(database):
+    award = Appropriation(job_id=1, row_number=1, is_first_quarter=True,
+                          budget_authority_unobligat_fyb=5)
+    assert models_are_valid(_FILE, database.stagingDb, award)

--- a/tests/unit/dataactvalidator/test_sql_validations.py
+++ b/tests/unit/dataactvalidator/test_sql_validations.py
@@ -1,7 +1,0 @@
-class TestSqlValidations:
-
-    def setup_class(self):
-        """ Setup for class """
-
-    def teardown_class(self):
-        """ Teardown for class """

--- a/tests/unit/dataactvalidator/utils.py
+++ b/tests/unit/dataactvalidator/utils.py
@@ -1,0 +1,26 @@
+import os.path
+from random import randint
+
+from dataactvalidator.filestreaming.sqlLoader import SQLLoader
+
+
+# @todo: There's extra logic in SQLLoader around FieldCleaning which we may
+# need to run through here, too
+def fetch_sql_tpl(filename):
+    filename = os.path.join(SQLLoader.sql_rules_path, filename + ".sql")
+    with open(filename, "rU") as f:
+        return f.read()
+
+
+def models_are_valid(rule_file, staging_db, *models):
+    """Insert the models into the database (with a random submission id), then
+    run the rule SQL against those models"""
+    submission_id = randint(1, 9999)
+    sql = fetch_sql_tpl(rule_file).format(submission_id)
+
+    for model in models:
+        model.submission_id = submission_id
+        staging_db.session.add(model)
+
+    staging_db.session.commit()
+    return staging_db.connection.execute(sql).rowcount == 0


### PR DESCRIPTION
Rough cut; we'll probably want to need to add more setup information, but this
should get us started. See test_a16_appropriations for example usage.

conftest.py adds a fixture related to database setup (monkeying what is in the
baseTestValidator.py). We'll probably also want to use something like
factory-boy to make generating example models easier.