### PR TITLE
Introduction of Factory Boy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ SQLAlchemy-Utils==0.32.1
 xmlrunner==1.7.7
 pytest==2.9.2
 pytest-cov==2.3.1
+factory-boy==2.7.0

--- a/tests/unit/dataactcore/factories/domain.py
+++ b/tests/unit/dataactcore/factories/domain.py
@@ -1,0 +1,23 @@
+import factory
+from factory import fuzzy
+
+from dataactcore.models import domainModels
+
+
+class SF133Factory(factory.Factory):
+    class Meta:
+        model = domainModels.SF133
+
+    sf133_id = None
+    agency_identifier = fuzzy.FuzzyText()
+    allocation_transfer_agency = fuzzy.FuzzyText()
+    availability_type_code = fuzzy.FuzzyText()
+    beginning_period_of_availa = fuzzy.FuzzyText()
+    ending_period_of_availabil = fuzzy.FuzzyText()
+    main_account_code = fuzzy.FuzzyText()
+    sub_account_code = fuzzy.FuzzyText()
+    tas = fuzzy.FuzzyText()
+    fiscal_year = fuzzy.FuzzyInteger(2010, 2040)
+    period = fuzzy.FuzzyInteger(1, 4)
+    line = fuzzy.FuzzyInteger(1, 9999)
+    amount = 0

--- a/tests/unit/dataactcore/factories/staging.py
+++ b/tests/unit/dataactcore/factories/staging.py
@@ -1,0 +1,36 @@
+import factory
+from factory import fuzzy
+
+from dataactcore.models import stagingModels
+
+
+class AppropriationFactory(factory.Factory):
+    class Meta:
+        model = stagingModels.Appropriation
+
+    appropriation_id = None
+    submission_id = fuzzy.FuzzyInteger(9999)
+    job_id = fuzzy.FuzzyInteger(9999)
+    row_number = fuzzy.FuzzyInteger(1, 9999)
+    adjustments_to_unobligated_cpe = fuzzy.FuzzyDecimal(9999)
+    agency_identifier = fuzzy.FuzzyText()
+    allocation_transfer_agency = fuzzy.FuzzyText()
+    availability_type_code = fuzzy.FuzzyText()
+    beginning_period_of_availa = fuzzy.FuzzyText()
+    borrowing_authority_amount_cpe = fuzzy.FuzzyDecimal(9999)
+    budget_authority_appropria_cpe = fuzzy.FuzzyDecimal(9999)
+    budget_authority_available_cpe = fuzzy.FuzzyDecimal(9999)
+    budget_authority_unobligat_fyb = fuzzy.FuzzyDecimal(9999)
+    contract_authority_amount_cpe = fuzzy.FuzzyDecimal(9999)
+    deobligations_recoveries_r_cpe = fuzzy.FuzzyDecimal(9999)
+    ending_period_of_availabil = fuzzy.FuzzyText()
+    gross_outlay_amount_by_tas_cpe = fuzzy.FuzzyDecimal(9999)
+    main_account_code = fuzzy.FuzzyText()
+    obligations_incurred_total_cpe = fuzzy.FuzzyDecimal(9999)
+    other_budgetary_resources_cpe = fuzzy.FuzzyDecimal(9999)
+    spending_authority_from_of_cpe = fuzzy.FuzzyDecimal(9999)
+    status_of_budgetary_resour_cpe = fuzzy.FuzzyDecimal(9999)
+    sub_account_code = fuzzy.FuzzyText()
+    unobligated_balance_cpe = fuzzy.FuzzyDecimal(9999)
+    tas = fuzzy.FuzzyText()
+    is_first_quarter = False

--- a/tests/unit/dataactvalidator/test_a10_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a10_appropriations.py
@@ -1,10 +1,13 @@
-from dataactcore.models.stagingModels import Appropriation
-from dataactcore.models.domainModels import SF133
+from tests.unit.dataactcore.factories.domain import SF133Factory
+from tests.unit.dataactcore.factories.staging import AppropriationFactory
 from tests.unit.dataactvalidator.utils import number_of_errors
 
 
 _FILE = 'a10_appropriations'
 _TAS = 'a10_appropriations_tas'
+
+# @todo: that a10 sql joins to a submission on particular values which aren't
+# being set up here?
 
 
 def test_success(database):
@@ -12,11 +15,11 @@ def test_success(database):
         for the specified fiscal year and period """
     tas = "".join([_TAS, "_success"])
 
-    sf_1 = SF133(line=1340, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
-    sf_2 = SF133(line=1440, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
-    ap = Appropriation(job_id=1, row_number=1, tas=tas, borrowing_authority_amount_cpe=2)
+    sf_1 = SF133Factory(line=1340, tas=tas, period=1, fiscal_year=2016,
+                        amount=1)
+    sf_2 = SF133Factory(line=1440, tas=tas, period=1, fiscal_year=2016,
+                        amount=1)
+    ap = AppropriationFactory(tas=tas, borrowing_authority_amount_cpe=2)
 
     models = [sf_1, sf_2, ap]
 
@@ -28,13 +31,12 @@ def test_failure(database):
         for the specified fiscal year and period """
     tas = "".join([_TAS, "_failure"])
 
-    sf_1 = SF133(line=1340, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
-    sf_2 = SF133(line=1440, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
-    ap = Appropriation(job_id=1, row_number=1, tas=tas, borrowing_authority_amount_cpe=1)
+    sf_1 = SF133Factory(line=1340, tas=tas, period=1, fiscal_year=2016,
+                        amount=1)
+    sf_2 = SF133Factory(line=1440, tas=tas, period=1, fiscal_year=2016,
+                        amount=1)
+    ap = AppropriationFactory(tas=tas, borrowing_authority_amount_cpe=1)
 
     models = [sf_1, sf_2, ap]
 
     assert number_of_errors(_FILE, database.stagingDb, models=models) == 1
-


### PR DESCRIPTION
Factories should make generating nonsense data a little bit easier, which means our tests can focus on only the essential information. This includes factories for SF133 and Appropriations and uses them in one of the unittests as a demonstration.