### PR TITLE
Mock out SES for py.test integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,9 @@
+from unittest.mock import Mock
+
+from dataactbroker.handlers.aws.sesEmail import sesEmail
+
+
+def pytest_runtest_setup(item):
+    """Big-ol hack. For the sake of our integration tests, mock out sesEmail.
+    Ideally, we can be pin-point our mocks in the future"""
+    sesEmail.send = Mock()


### PR DESCRIPTION
This is a hack, but will should fix the immediate problem of integration tests
sending out email. Previously, we had fixed if a user ran `runTests.py`
directly, but if using `py.test`, tests outside the scope of `runTests` will
be auto-discovered (and not use the mock)