### PR TITLE
Hotfix interface closing dev

### DIFF
--- a/dataactbroker/app.py
+++ b/dataactbroker/app.py
@@ -61,11 +61,8 @@ def createApp():
         def clearInterfaces(response):
             try:
                 interfaces =BaseInterface.interfaces
-                interfaces.jobDb.close()
-                interfaces.validationDb.close()
-                interfaces.errorDb.close()
-                interfaces.userDb.close()
-                BaseInterface.interfaces = None
+                if interfaces is not None:
+                    interfaces.close()
             except Exception as e:
                 print("Could not close connections")
                 print(str(type(e)) + ": " + str(e))

--- a/dataactbroker/handlers/accountHandler.py
+++ b/dataactbroker/handlers/accountHandler.py
@@ -195,7 +195,7 @@ class AccountHandler:
                         newEmail.send()
 
             finally:
-                InterfaceHolder.closeOne(threadedDatabase)
+                threadedDatabase.close()
 
         requestFields = RequestDictionary(self.request)
         if(not (requestFields.exists("email") and requestFields.exists("name") and requestFields.exists("cgac_code") and requestFields.exists("title") and requestFields.exists("password"))):

--- a/dataactbroker/handlers/interfaceHolder.py
+++ b/dataactbroker/handlers/interfaceHolder.py
@@ -25,35 +25,5 @@ class InterfaceHolder:
 
     def close(self):
         """ Close all open connections """
-        InterfaceHolder.closeOne(self.jobDb)
-        InterfaceHolder.closeOne(self.errorDb)
-        InterfaceHolder.closeOne(self.userDb)
-        InterfaceHolder.closeOne(self.validationDb)
-
-    @staticmethod
-    def closeOne(interface):
-        """ Close all aspects of one interface """
-        if(interface == None):
-            # No need to close a nonexistent connection
-            return
-        try:
-            if(interface.session == None):
-                # If session is None, skip closing
-                return
-        except AttributeError as e:
-            # If interface has no session, skip closing
-            return
-
-        # Try to close the session and connection, on error try a rollback
-        try:
-            interface.session.close()
-        except:
-            try:
-                interface.session.rollback()
-                interface.session.close()
-            except Exception as e:
-                exc_type, exc_obj, exc_tb = sys.exc_info()
-                trace = traceback.extract_tb(exc_tb, 10)
-                CloudLogger.logError('Broker DB Interface Error: ', e, trace)
-                del exc_tb
-                raise
+        if self.jobDb is not None:
+            self.jobDb.close()

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -39,7 +39,7 @@ def permissions_check(f=None,permissionList=[]):
                                 break
 
                     finally:
-                        InterfaceHolder.closeOne(userDb)
+                        userDb.close()
                     if(validUser) :
                         return f(*args, **kwargs)
                     errorMessage  = "Wrong User Type"

--- a/dataactbroker/scripts/setupEmails.py
+++ b/dataactbroker/scripts/setupEmails.py
@@ -73,7 +73,7 @@ def setupEmails():
     template = "[REV_USER_NAME] has shared a DATA Act broker submission with you. Click <a href='[REV_URL]'>here</a> to review their submission. For questions or comments, please email the DATA Act Broker Helpdesk (DATABroker@fiscal.treasury.gov)."
     userDb.loadEmailTemplate("DATA Act Broker - Submission Ready for Review", template, "review_submission")
 
-    InterfaceHolder.closeOne(userDb)
+    userDb.close()
 
 if __name__ == '__main__':
     setupEmails()

--- a/dataactcore/models/baseInterface.py
+++ b/dataactcore/models/baseInterface.py
@@ -50,6 +50,7 @@ class BaseInterface(object):
             self.interfaces = None
         except (KeyError, AttributeError):
             # KeyError will occur in Python 3 on engine dispose
+            self.interfaces = None
             pass
 
     def getSession(self):

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -29,11 +29,8 @@ def createApp():
         def clearInterfaces(response):
             try:
                 interfaces =BaseInterface.interfaces
-                interfaces.jobDb.close()
-                interfaces.validationDb.close()
-                interfaces.errorDb.close()
-                interfaces.stagingDb.close()
-                BaseInterface.interfaces = None
+                if interfaces is not None:
+                    interfaces.close()
             except Exception as e:
                 print("Could not close connections")
                 print(str(type(e)) + ": " + str(e))

--- a/dataactvalidator/interfaces/interfaceHolder.py
+++ b/dataactvalidator/interfaces/interfaceHolder.py
@@ -23,31 +23,5 @@ class InterfaceHolder:
 
     def close(self):
         """ Close all open connections """
-        InterfaceHolder.closeOne(self.jobDb)
-        InterfaceHolder.closeOne(self.errorDb)
-        InterfaceHolder.closeOne(self.stagingDb)
-        InterfaceHolder.closeOne(self.validationDb)
-
-    @staticmethod
-    def closeOne(interface):
-        """ Close all aspects of one interface """
-        if(interface == None):
-            # No need to close a nonexistent connection
-            return
-        try:
-            if(interface.session == None):
-                # If session is None, skip closing
-                return
-        except AttributeError as e:
-            # If interface has no session, skip closing
-            return
-
-        # Try to close the session and connection, on error try a rollback
-        try:
-            interface.session.close()
-        except:
-            try:
-                interface.session.rollback()
-                interface.session.close()
-            except:
-                pass
+        if self.jobDb is not None:
+            self.jobDb.close()


### PR DESCRIPTION
Interface holder now calls close method of BaseInterface rather than duplicating the functionality.  This also resolves an issue where a new interface holder would attempt to reuse closed sessions.