### PR TITLE
Refactor database connection manager

### DIFF
--- a/dataactbroker/scripts/initialize.py
+++ b/dataactbroker/scripts/initialize.py
@@ -63,7 +63,7 @@ def createAdmin():
                 adminEmail, adminPass, Bcrypt(), permission=2)
             user = userDb.getUserByEmail(adminEmail)
             userDb.addUserInfo(user, "Admin", "SYS", "System Admin")
-    userDb.session.close()
+    userDb.close()
 
 
 def setupSessionTable():

--- a/dataactcore/scripts/clearErrors.py
+++ b/dataactcore/scripts/clearErrors.py
@@ -8,7 +8,7 @@ def clearErrors():
     errorDb.session.query(ErrorMetadata).delete()
     errorDb.session.query(File).delete()
     errorDb.session.commit()
-    errorDb.session.close()
+    errorDb.close()
 
 
 def clearErrorsByJobId(jobId):
@@ -17,7 +17,7 @@ def clearErrorsByJobId(jobId):
     errorDb.session.query(ErrorMetadata).filter(job_id == jobId).delete()
     errorDb.session.query(File).filter(job_id == jobId).delete()
     errorDb.session.commit()
-    errorDb.session.close()
+    errorDb.close()
 
 
 if __name__ == '__main__':

--- a/dataactcore/scripts/clearJobs.py
+++ b/dataactcore/scripts/clearJobs.py
@@ -8,7 +8,7 @@ def clearJobs():
     jobDb.session.query(Job).delete()
     jobDb.session.query(Submission).delete()
     jobDb.session.commit()
-    jobDb.session.close()
+    jobDb.close()
 
 if __name__ == '__main__':
     clearJobs()

--- a/dataactcore/scripts/setupErrorDB.py
+++ b/dataactcore/scripts/setupErrorDB.py
@@ -37,7 +37,7 @@ def insertCodes():
         errorDb.session.merge(error)
 
     errorDb.session.commit()
-    errorDb.session.close()
+    errorDb.close()
 
 if __name__ == '__main__':
     setupErrorDB()

--- a/dataactcore/scripts/setupJobTrackerDB.py
+++ b/dataactcore/scripts/setupJobTrackerDB.py
@@ -53,7 +53,7 @@ def insertCodes():
         jobDb.session.merge(fileType)
 
     jobDb.session.commit()
-    jobDb.session.close()
+    jobDb.close()
 
 if __name__ == '__main__':
     setupJobTrackerDB()

--- a/dataactcore/scripts/setupUserDB.py
+++ b/dataactcore/scripts/setupUserDB.py
@@ -34,7 +34,7 @@ def insertCodes():
         userDb.session.merge(type)
 
     userDb.session.commit()
-    userDb.session.close()
+    userDb.close()
 
 if __name__ == '__main__':
     setupUserDB()

--- a/dataactcore/scripts/setupValidationDB.py
+++ b/dataactcore/scripts/setupValidationDB.py
@@ -45,7 +45,7 @@ def insertCodes():
         validatorDb.session.merge(ruleSeverity)
 
     validatorDb.session.commit()
-    validatorDb.session.close()
+    validatorDb.close()
 
 if __name__ == '__main__':
     setupValidationDB()

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -241,7 +241,6 @@ class FileTests(BaseTestAPI):
         """Test broker status route response."""
         postJson = {"submission_id": self.status_check_submission_id}
         # Populating error info before calling route to avoid changing last update time
-        submission = self.interfaces.jobDb.getSubmissionById(self.status_check_submission_id)
 
         self.interfaces.jobDb.populateSubmissionErrorInfo(self.status_check_submission_id)
 
@@ -325,6 +324,7 @@ class FileTests(BaseTestAPI):
         self.assertEqual(json["number_of_rows"],667)
         # Check number of errors and warnings in submission table
 
+        submission = self.interfaces.jobDb.getSubmissionById(self.status_check_submission_id)
         self.assertEqual(submission.number_of_errors, 17)
         self.assertEqual(submission.number_of_warnings, 7)
 


### PR DESCRIPTION
One step towards centralizing database connection management. This uses `flask.g` where available to resolve some threading issues while also pulling database connection info into a separate class. Ideally, we'll remove all of the database information from `BaseInterface` and instead pass it along explicitly or grab it from the thread-safe context, `flask.g`.