### PR TITLE
add fiscal year to SF_133 index

### DIFF
--- a/dataactcore/migrations/versions/c9090bf7f0a8_sf_133_add_index_year.py
+++ b/dataactcore/migrations/versions/c9090bf7f0a8_sf_133_add_index_year.py
@@ -1,0 +1,37 @@
+"""sf-133-add-index-year
+
+Revision ID: c9090bf7f0a8
+Revises: 73db7d2cc754
+Create Date: 2016-09-06 16:58:02.279630
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'c9090bf7f0a8'
+down_revision = '73db7d2cc754'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+
+
+
+def upgrade_data_broker():
+    op.drop_index('ix_sf_133_tas', table_name='sf_133')
+    op.create_index('ix_sf_133_tas', 'sf_133', ['tas', 'fiscal_year', 'period', 'line'], unique=True)
+
+
+def downgrade_data_broker():
+    op.drop_index('ix_sf_133_tas', table_name='sf_133')
+    op.create_index('ix_sf_133_tas', 'sf_133', ['tas', 'period', 'line'], unique=True)
+

--- a/dataactcore/models/domainModels.py
+++ b/dataactcore/models/domainModels.py
@@ -54,6 +54,7 @@ class SF133(Base):
 
 Index("ix_sf_133_tas",
   SF133.tas,
+  SF133.fiscal_year,
   SF133.period,
   SF133.line,
   unique=True)


### PR DESCRIPTION
Realized today that the unique index on the SF-133 is missing `fiscal_year`. We need to get that on there or the load file will fail in a few months.

Apologies for not noticing this until we had a few million rows loaded--the migration takes a few minutes to run.