### PR TITLE
Use debug setting in config.yml when creating Flask apps

### DIFF
--- a/dataactbroker/app.py
+++ b/dataactbroker/app.py
@@ -28,6 +28,7 @@ def createApp():
         local = CONFIG_BROKER['local']
         app.config.from_object(__name__)
         app.config['LOCAL'] = local
+        app.debug = CONFIG_SERVICES['server_debug']
         app.config['REST_TRACE'] = CONFIG_SERVICES['rest_trace']
         app.config['SYSTEM_EMAIL'] = CONFIG_BROKER['reply_to_email']
 
@@ -123,9 +124,7 @@ def checkDynamo():
 def runApp():
     """runs the application"""
     app = createApp()
-    debugFlag = CONFIG_SERVICES['server_debug']
     app.run(
-        debug=debugFlag,
         threaded=True,
         host=CONFIG_SERVICES['broker_api_host'],
         port=CONFIG_SERVICES['broker_api_port']

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -17,6 +17,7 @@ def createApp():
     """Create the Flask app."""
     try:
         app = Flask(__name__)
+        app.debug = CONFIG_SERVICES['server_debug']
         local = CONFIG_BROKER['local']
         error_report_path = CONFIG_SERVICES['error_report_path']
         app.config.from_object(__name__)
@@ -136,7 +137,6 @@ def runApp():
     """Run the application."""
     app = createApp()
     app.run(
-        debug=CONFIG_SERVICES['server_debug'],
         threaded=True,
         host=CONFIG_SERVICES['validator_host'],
         port=CONFIG_SERVICES['validator_port']


### PR DESCRIPTION
Setting the debug on app.run wasn't working. Do it when we create
the app. To turn off debug, set server_debug = false in config.yml.