### PR TITLE
Hotfix cross file status

### DIFF
--- a/dataactvalidator/interfaces/validatorErrorInterface.py
+++ b/dataactvalidator/interfaces/validatorErrorInterface.py
@@ -26,7 +26,7 @@ class ValidatorErrorInterface(ErrorInterface):
         self.session.commit()
         return fileRec
 
-    def createFileIfNeeded(self, jobId, filename = ""):
+    def createFileIfNeeded(self, jobId, filename = None):
         """ Return the existing file object if it exists, or create a new one """
         try:
             fileRec = self.getFileByJobId(jobId)
@@ -73,7 +73,7 @@ class ValidatorErrorInterface(ErrorInterface):
         self.session.commit()
         return True
 
-    def markFileComplete(self, jobId, filename):
+    def markFileComplete(self, jobId, filename = None):
         """ Marks file's status as complete
 
         Args:

--- a/dataactvalidator/interfaces/validatorErrorInterface.py
+++ b/dataactvalidator/interfaces/validatorErrorInterface.py
@@ -26,7 +26,7 @@ class ValidatorErrorInterface(ErrorInterface):
         self.session.commit()
         return fileRec
 
-    def createFileIfNeeded(self, jobId, filename):
+    def createFileIfNeeded(self, jobId, filename = ""):
         """ Return the existing file object if it exists, or create a new one """
         try:
             fileRec = self.getFileByJobId(jobId)

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -537,7 +537,7 @@ class ValidationManager:
             interfaces.jobDb.setPublishableFlag(submissionId, True)
 
         # Mark validation complete
-        interfaces.errorDb.markFileComplete(jobId, "")
+        interfaces.errorDb.markFileComplete(jobId)
 
     def validateJob(self, request,interfaces):
         """ Gets file for job, validates each row, and sends valid rows to a staging table

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -536,6 +536,9 @@ class ValidationManager:
         if interfaces.jobDb.getSubmissionById(submissionId).number_of_errors == 0:
             interfaces.jobDb.setPublishableFlag(submissionId, True)
 
+        # Mark validation complete
+        interfaces.errorDb.markFileComplete(jobId, "")
+
     def validateJob(self, request,interfaces):
         """ Gets file for job, validates each row, and sends valid rows to a staging table
         Args:

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -473,6 +473,9 @@ class ValidationManager:
 
     def runCrossValidation(self, jobId, interfaces):
         """ Cross file validation job, test all rules with matching rule_timing """
+        # Create File Status object
+        interfaces.errorDb.createFileIfNeeded(jobId)
+        
         validationDb = interfaces.validationDb
         errorDb = interfaces.errorDb
         submissionId = interfaces.jobDb.getSubmissionId(jobId)


### PR DESCRIPTION
This adds a File object for cross-file jobs to allow the check_status route to report cross-file errors and warnings correctly