### PR TITLE
db connection refactor part 2: unit tests

### DIFF
--- a/dataactbroker/scripts/loadFSRS.py
+++ b/dataactbroker/scripts/loadFSRS.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-from dataactcore.models.baseInterface import databaseSession
+from dataactcore.interfaces.db import databaseSession
 from dataactbroker.fsrs import (
     configValid, fetchAndReplaceBatch, GRANT, PROCUREMENT)
 

--- a/dataactcore/migrations/env.py
+++ b/dataactcore/migrations/env.py
@@ -2,10 +2,9 @@ from __future__ import with_statement
 from alembic import context
 # Load all DB tables into metadata object
 # @todo - load these dynamically
-from dataactcore.models import (
-    baseModel, domainModels, fsrs, errorModels, jobModels, stagingModels,
-    userModel, validationModels)
+from dataactcore.models import baseModel
 from dataactcore.config import CONFIG_DB
+from dataactcore.interfaces.db import dbURI
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig
 import logging
@@ -50,15 +49,11 @@ for name in re.split(r',\s*', db_names):
 target_metadata = {key: value[1].Base.metadata for (key, value) in db_dict.items()}
 
 # Set up database URLs based on config file
-username = str(CONFIG_DB['username'])
-password = str(CONFIG_DB['password'])
-host = str(CONFIG_DB['host'])
-port = str(CONFIG_DB['port'])
 for (key, value) in db_dict.items():
     # key = db-related names expected by Alembic config/scripts
     # value[0] = actual db names as set in broker config file
-    baseUrl = 'postgres://' + username + ':' + password + '@' + host + ':' + port
-    config.set_section_option(key, 'sqlalchemy.url', baseUrl + '/' + value[0])
+    baseUrl = dbURI(value[0])
+    config.set_section_option(key, 'sqlalchemy.url', baseUrl)
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import dataactcore.config
 from dataactcore.scripts.databaseSetup import (
     createDatabase, dropDatabase, runMigrations)
-from dataactvalidator.interfaces.interfaceHolder import InterfaceHolder
+from dataactcore.interfaces.db import dbConnection
 
 
 @pytest.fixture(scope='session')
@@ -19,9 +19,9 @@ def database():
 
     createDatabase(config['db_name'])
     runMigrations()
-    interface = InterfaceHolder()
+    db = dbConnection()
 
-    yield interface
+    yield db
 
-    interface.close()
+    db.close()
     dropDatabase(config['db_name'])

--- a/tests/unit/dataactbroker/test_fsrs.py
+++ b/tests/unit/dataactbroker/test_fsrs.py
@@ -134,7 +134,7 @@ def test_flattenSoapDict():
 
 @pytest.fixture()
 def no_award_db(database):
-    sess = database.validationDb.session
+    sess = database.session
     sess.query(FSRSProcurement).delete(synchronize_session=False)
     sess.query(FSRSGrant).delete(synchronize_session=False)
     sess.commit()

--- a/tests/unit/dataactcore/test_utils_fileF.py
+++ b/tests/unit/dataactcore/test_utils_fileF.py
@@ -43,7 +43,7 @@ def test_valueFromMapping_tuple():
 def test_relevantFainPiids(database):
     """We should be retrieving a pair of all FAINs and PIIDs associated with a
     particular submission"""
-    sess = database.stagingDb.session
+    sess = database.session
     award1 = AwardFinancialFactory()
     award2 = AwardFinancialFactory(submission_id=award1.submission_id,
                                    piid=None)
@@ -59,7 +59,7 @@ def test_generateFRows(database, monkeypatch):
     """generateFRows should find and convert subaward data relevant to a
     specific submission id. We'll compare the resulting DUNs values for
     uniqueness"""
-    sess = database.stagingDb.session
+    sess = database.session
 
     mock_fn = Mock(return_value=({'fain1', 'fain2'}, {'piid1'}))
     monkeypatch.setattr(fileF, 'relevantFainsPiids', mock_fn)

--- a/tests/unit/dataactvalidator/test_a10_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a10_appropriations.py
@@ -23,7 +23,7 @@ def test_success(database):
 
     models = [sf_1, sf_2, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 0
+    assert number_of_errors(_FILE, database, models=models) == 0
 
 
 def test_failure(database):
@@ -39,4 +39,4 @@ def test_failure(database):
 
     models = [sf_1, sf_2, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 1
+    assert number_of_errors(_FILE, database, models=models) == 1

--- a/tests/unit/dataactvalidator/test_a11_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a11_appropriations.py
@@ -20,7 +20,7 @@ def test_success(database):
 
     models = [sf_1, sf_2, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 0
+    assert number_of_errors(_FILE, database, models=models) == 0
 
 
 def test_failure(database):
@@ -36,4 +36,4 @@ def test_failure(database):
 
     models = [sf_1, sf_2, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 1
+    assert number_of_errors(_FILE, database, models=models) == 1

--- a/tests/unit/dataactvalidator/test_a12_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a12_appropriations.py
@@ -22,7 +22,7 @@ def test_success(database):
 
     models = [sf_1, sf_2, sf_3, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 0
+    assert number_of_errors(_FILE, database, models=models) == 0
 
 
 def test_failure(database):
@@ -40,4 +40,4 @@ def test_failure(database):
 
     models = [sf_1, sf_2, sf_3, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 1
+    assert number_of_errors(_FILE, database, models=models) == 1

--- a/tests/unit/dataactvalidator/test_a14_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a14_appropriations.py
@@ -16,7 +16,7 @@ def test_success(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, gross_outlay_amount_by_tas_cpe=1)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 0
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
 
 
 def test_failure(database):
@@ -28,4 +28,4 @@ def test_failure(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, gross_outlay_amount_by_tas_cpe=0)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a15_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a15_appropriations.py
@@ -16,7 +16,7 @@ def test_success(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, unobligated_balance_cpe=1)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 0
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
 
 
 def test_failure(database):
@@ -28,4 +28,4 @@ def test_failure(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, unobligated_balance_cpe=0)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a16_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a16_appropriations.py
@@ -7,15 +7,15 @@ _FILE = 'a16_appropriations'
 
 def test_success(database):
     award = Appropriation(job_id=1, row_number=1)
-    assert error_rows(_FILE, database.stagingDb, models=[award]) == []
+    assert error_rows(_FILE, database, models=[award]) == []
 
 
 def test_null_authority(database):
     award = Appropriation(job_id=1, row_number=1, is_first_quarter=True)
-    assert number_of_errors(_FILE, database.stagingDb, models=[award]) == 1
+    assert number_of_errors(_FILE, database, models=[award]) == 1
 
 
 def test_nonnull_authority(database):
     award = Appropriation(job_id=1, row_number=1, is_first_quarter=True,
                           budget_authority_unobligat_fyb=5)
-    assert error_rows(_FILE, database.stagingDb, models=[award]) == []
+    assert error_rows(_FILE, database, models=[award]) == []

--- a/tests/unit/dataactvalidator/test_a18_cross_file.py
+++ b/tests/unit/dataactvalidator/test_a18_cross_file.py
@@ -15,7 +15,7 @@ def test_column_headers(database):
         'availability_type_code', 'main_account_code', 'sub_account_code',
         'gross_outlay_amount_by_tas_cpe', 'gross_outlay_amount_by_pro_cpe_sum'
     ])
-    actual = set(query_columns(_FILE, database.stagingDb))
+    actual = set(query_columns(_FILE, database))
     assert (actual & expected_subset) == expected_subset
 
 
@@ -35,7 +35,7 @@ def test_sum_matches(database):
     op2 = ObjectClassProgramActivity(gross_outlay_amount_by_pro_cpe=op2_val)
     approp = Appropriation(gross_outlay_amount_by_tas_cpe=approp_val)
     set_shared_values(op1, op2, approp)
-    assert number_of_errors(_FILE, database.stagingDb,
+    assert number_of_errors(_FILE, database,
                             models=[approp, op1, op2]) == 0
 
 
@@ -46,5 +46,5 @@ def test_sum_does_not_match(database):
     op2 = ObjectClassProgramActivity(gross_outlay_amount_by_pro_cpe=op2_val)
     approp = Appropriation(gross_outlay_amount_by_tas_cpe=approp_val)
     set_shared_values(op1, op2, approp)
-    assert number_of_errors(_FILE, database.stagingDb,
+    assert number_of_errors(_FILE, database,
                             models=[approp, op1, op2]) == 1

--- a/tests/unit/dataactvalidator/test_a19_cross_file.py
+++ b/tests/unit/dataactvalidator/test_a19_cross_file.py
@@ -15,7 +15,7 @@ def test_column_headers(database):
         'availability_type_code', 'main_account_code', 'sub_account_code',
         'obligations_incurred_total_cpe', 'obligations_incurred_by_pr_cpe_sum'
     ])
-    actual = set(query_columns(_FILE, database.stagingDb))
+    actual = set(query_columns(_FILE, database))
     assert (actual & expected_subset) == expected_subset
 
 
@@ -35,7 +35,7 @@ def test_sum_matches(database):
     op2 = ObjectClassProgramActivity(obligations_incurred_by_pr_cpe=op2_val)
     approp = Appropriation(obligations_incurred_total_cpe=approp_val)
     set_shared_values(op1, op2, approp)
-    assert number_of_errors(_FILE, database.stagingDb,
+    assert number_of_errors(_FILE, database,
                             models=[approp, op1, op2]) == 0
 
 
@@ -46,5 +46,5 @@ def test_sum_does_not_match(database):
     op2 = ObjectClassProgramActivity(obligations_incurred_by_pr_cpe=op2_val)
     approp = Appropriation(obligations_incurred_total_cpe=approp_val)
     set_shared_values(op1, op2, approp)
-    assert number_of_errors(_FILE, database.stagingDb,
+    assert number_of_errors(_FILE, database,
                             models=[approp, op1, op2]) == 1

--- a/tests/unit/dataactvalidator/test_a22_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a22_appropriations.py
@@ -16,7 +16,7 @@ def test_success(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, obligations_incurred_total_cpe=1)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 0
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
 
 
 def test_failure(database):
@@ -28,4 +28,4 @@ def test_failure(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, obligations_incurred_total_cpe=0)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a23_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a23_appropriations.py
@@ -16,7 +16,7 @@ def test_success(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, status_of_budgetary_resour_cpe=1)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 0
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
 
 
 def test_failure(database):
@@ -28,4 +28,4 @@ def test_failure(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, status_of_budgetary_resour_cpe=0)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a29_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a29_appropriations.py
@@ -20,7 +20,7 @@ def test_success(database):
 
     models = [sf_1, sf_2, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 0
+    assert number_of_errors(_FILE, database, models=models) == 0
 
 
 def test_failure(database):
@@ -36,4 +36,4 @@ def test_failure(database):
 
     models = [sf_1, sf_2, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 1
+    assert number_of_errors(_FILE, database, models=models) == 1

--- a/tests/unit/dataactvalidator/test_a30_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a30_appropriations.py
@@ -11,7 +11,7 @@ def test_column_headers(database):
     expected_subset = {'row_number', 'allocation_transfer_agency', 'agency_identifier',
         'beginning_period_of_availa', 'ending_period_of_availabil',
         'availability_type_code', 'main_account_code', 'sub_account_code'}
-    actual = set(query_columns(_FILE, database.stagingDb))
+    actual = set(query_columns(_FILE, database))
     assert (actual & expected_subset) == expected_subset
 
 
@@ -23,7 +23,7 @@ def test_success(database):
 
     op = ObjectClassProgramActivity(job_id=1, row_number=1, tas=tas)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[ap, op]) == 0
+    assert number_of_errors(_FILE, database, models=[ap, op]) == 0
 
 
 def test_failure(database):
@@ -34,4 +34,4 @@ def test_failure(database):
 
     op = ObjectClassProgramActivity(job_id=1, row_number=1, tas='1')
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[ap, op]) == 1
+    assert number_of_errors(_FILE, database, models=[ap, op]) == 1

--- a/tests/unit/dataactvalidator/test_a30_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_a30_object_class_program_activity.py
@@ -11,7 +11,7 @@ def test_column_headers(database):
     expected_subset = {'row_number', 'allocation_transfer_agency', 'agency_identifier',
         'beginning_period_of_availa', 'ending_period_of_availabil',
         'availability_type_code', 'main_account_code', 'sub_account_code'}
-    actual = set(query_columns(_FILE, database.stagingDb))
+    actual = set(query_columns(_FILE, database))
     assert (actual & expected_subset) == expected_subset
 
 
@@ -23,7 +23,7 @@ def test_success(database):
 
     ap = Appropriation(job_id=1, row_number=1, tas=tas)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[op, ap]) == 0
+    assert number_of_errors(_FILE, database, models=[op, ap]) == 0
 
 
 def test_failure(database):
@@ -34,4 +34,4 @@ def test_failure(database):
 
     ap = Appropriation(job_id=1, row_number=1, tas='1')
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[op, ap]) == 1
+    assert number_of_errors(_FILE, database, models=[op, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a32_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a32_appropriations.py
@@ -10,7 +10,7 @@ def test_column_headers(database):
     expected_subset = {'row_number', 'allocation_transfer_agency', 'agency_identifier',
         'beginning_period_of_availa', 'ending_period_of_availabil',
         'availability_type_code', 'main_account_code', 'sub_account_code'}
-    actual = set(query_columns(_FILE, database.stagingDb))
+    actual = set(query_columns(_FILE, database))
     assert (actual & expected_subset) == expected_subset
 
 
@@ -22,7 +22,7 @@ def test_success(database):
 
     ap2 = Appropriation(job_id=1, row_number=2, tas='1')
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[ap1,ap2]) == 0
+    assert number_of_errors(_FILE, database, models=[ap1,ap2]) == 0
 
 
 def test_failure(database):
@@ -33,4 +33,4 @@ def test_failure(database):
 
     ap2 = Appropriation(job_id=1, row_number=2, tas=tas)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[ap1,ap2]) == 2
+    assert number_of_errors(_FILE, database, models=[ap1,ap2]) == 2

--- a/tests/unit/dataactvalidator/test_a33_appropriations_1.py
+++ b/tests/unit/dataactvalidator/test_a33_appropriations_1.py
@@ -14,7 +14,7 @@ def test_column_headers(database):
     expected_subset = {'row_number', 'allocation_transfer_agency', 'agency_identifier',
                        'beginning_period_of_availa', 'ending_period_of_availabil',
                        'availability_type_code', 'main_account_code', 'sub_account_code'}
-    actual = set(query_columns(_FILE, database.stagingDb))
+    actual = set(query_columns(_FILE, database))
     assert (actual & expected_subset) == expected_subset
 
 
@@ -31,7 +31,7 @@ def test_success(database):
         reporting_fiscal_year=year, cgac_code=code)
     ap = AppropriationFactory(tas=tas, submission_id=submission_id)
 
-    errors = number_of_errors(_FILE, database.stagingDb,
+    errors = number_of_errors(_FILE, database,
                               models=[sf1, sf2, ap], submission=submission)
     assert errors == 0
 
@@ -50,6 +50,6 @@ def test_failure(database):
     ap = AppropriationFactory(tas='a-different-tas',
                               submission_id=submission_id)
 
-    errors = number_of_errors(_FILE, database.stagingDb,
+    errors = number_of_errors(_FILE, database,
                               models=[sf1, sf2, ap], submission=submission)
     assert errors == 2

--- a/tests/unit/dataactvalidator/test_a33_appropriations_2.py
+++ b/tests/unit/dataactvalidator/test_a33_appropriations_2.py
@@ -11,7 +11,7 @@ def test_column_headers(database):
     expected_subset = {'row_number', 'allocation_transfer_agency', 'agency_identifier',
                        'beginning_period_of_availa', 'ending_period_of_availabil',
                        'availability_type_code', 'main_account_code', 'sub_account_code'}
-    actual = set(query_columns(_FILE, database.stagingDb))
+    actual = set(query_columns(_FILE, database))
     assert (actual & expected_subset) == expected_subset
 
 
@@ -25,7 +25,7 @@ def test_success(database):
     sf = SF133(line=1021, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                main_account_code="000", sub_account_code="000")
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[ap1, ap2, sf]) == 0
+    assert number_of_errors(_FILE, database, models=[ap1, ap2, sf]) == 0
 
 
 def test_failure(database):
@@ -38,4 +38,4 @@ def test_failure(database):
     sf = SF133(line=1021, tas='1', period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                main_account_code="000", sub_account_code="000")
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[ap1, ap2, sf]) == 2
+    assert number_of_errors(_FILE, database, models=[ap1, ap2, sf]) == 2

--- a/tests/unit/dataactvalidator/test_a6_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a6_appropriations.py
@@ -17,7 +17,7 @@ def test_success(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_available_cpe=1)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 0
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
 
 
 def test_failure(database):
@@ -29,4 +29,4 @@ def test_failure(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_available_cpe=0)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a7_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a7_appropriations.py
@@ -16,7 +16,7 @@ def test_success(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_unobligat_fyb=1)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 0
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
 
 
 def test_failure(database):
@@ -28,4 +28,4 @@ def test_failure(database):
                main_account_code="000", sub_account_code="000")
     ap = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_unobligat_fyb=0)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, ap]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a8_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a8_appropriations.py
@@ -25,7 +25,7 @@ def test_success(database):
 
     models = [sf_1, sf_2, sf_3, sf_4, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 0
+    assert number_of_errors(_FILE, database, models=models) == 0
 
 
 def test_failure(database):
@@ -45,4 +45,4 @@ def test_failure(database):
 
     models = [sf_1, sf_2, sf_3, sf_4, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 1
+    assert number_of_errors(_FILE, database, models=models) == 1

--- a/tests/unit/dataactvalidator/test_a9_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a9_appropriations.py
@@ -20,7 +20,7 @@ def test_success(database):
 
     models = [sf_1, sf_2, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 0
+    assert number_of_errors(_FILE, database, models=models) == 0
 
 
 def test_failure(database):
@@ -36,4 +36,4 @@ def test_failure(database):
 
     models = [sf_1, sf_2, ap]
 
-    assert number_of_errors(_FILE, database.stagingDb, models=models) == 1
+    assert number_of_errors(_FILE, database, models=models) == 1

--- a/tests/unit/dataactvalidator/test_b14_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b14_object_class_program_activity.py
@@ -24,7 +24,7 @@ def test_success(database):
                                     ussgl490800_authority_outl_fyb=1, ussgl498100_upward_adjustm_cpe=1,
                                     ussgl498200_upward_adjustm_cpe=1)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, op]) == 0
+    assert number_of_errors(_FILE, database, models=[sf, op]) == 0
 
 
 def test_failure(database):
@@ -43,4 +43,4 @@ def test_failure(database):
                                     ussgl490800_authority_outl_fyb=1, ussgl498100_upward_adjustm_cpe=1,
                                     ussgl498200_upward_adjustm_cpe=1)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, op]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, op]) == 1

--- a/tests/unit/dataactvalidator/test_b15_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b15_object_class_program_activity.py
@@ -24,7 +24,7 @@ def test_success(database):
                                     ussgl490800_authority_outl_fyb=1, ussgl498100_upward_adjustm_cpe=1,
                                     ussgl498200_upward_adjustm_cpe=1)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, op]) == 0
+    assert number_of_errors(_FILE, database, models=[sf, op]) == 0
 
 
 def test_failure(database):
@@ -44,4 +44,4 @@ def test_failure(database):
                                     ussgl490800_authority_outl_fyb=1, ussgl498100_upward_adjustm_cpe=1,
                                     ussgl498200_upward_adjustm_cpe=1)
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[sf, op]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, op]) == 1

--- a/tests/unit/dataactvalidator/test_b19_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b19_object_class_program_activity.py
@@ -10,7 +10,7 @@ def test_column_headers(database):
                        'agency_identifier', 'allocation_transfer_agency', 'availability_type_code',
                        'main_account_code', 'sub_account_code', 'object_class', 'program_activity_code',
                        'by_direct_reimbursable_fun'}
-    actual = set(query_columns(_FILE, database.stagingDb))
+    actual = set(query_columns(_FILE, database))
     assert (actual & expected_subset) == expected_subset
 
 
@@ -84,7 +84,7 @@ def test_success(database):
                                      main_account_code='1', sub_account_code='1', object_class='1',
                                      program_activity_code='1', by_direct_reimbursable_fun='d')
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[op1, op2, op3, op4, op5, op6,
+    assert number_of_errors(_FILE, database, models=[op1, op2, op3, op4, op5, op6,
                                                                op7, op8, op9, op10, op11]) == 0
 
 
@@ -102,7 +102,7 @@ def test_optionals(database):
                                      availability_type_code='1', main_account_code='1', sub_account_code='1',
                                      object_class='1', program_activity_code='1', by_direct_reimbursable_fun='r')
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[op1, op2]) == 1
+    assert number_of_errors(_FILE, database, models=[op1, op2]) == 1
 
 
 def test_failure(database):
@@ -121,4 +121,4 @@ def test_failure(database):
                                      main_account_code='1', sub_account_code='1', object_class='1',
                                      program_activity_code='1', by_direct_reimbursable_fun='r')
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[op1, op2]) == 1
+    assert number_of_errors(_FILE, database, models=[op1, op2]) == 1

--- a/tests/unit/dataactvalidator/test_b20_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b20_object_class_program_activity.py
@@ -11,7 +11,7 @@ def test_column_headers(database):
     expected_subset = {'row_number', 'allocation_transfer_agency', 'agency_identifier',
                        'beginning_period_of_availa', 'ending_period_of_availabil', 'availability_type_code',
                        'main_account_code', 'sub_account_code', 'program_activity_code', 'object_class'}
-    actual = set(query_columns(_FILE, database.stagingDb))
+    actual = set(query_columns(_FILE, database))
     assert (actual & expected_subset) == expected_subset
 
 
@@ -23,7 +23,7 @@ def test_success(database):
 
     af = AwardFinancial(job_id=1, row_number=1, tas=tas, program_activity_code='1', object_class='1')
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[op, af]) == 0
+    assert number_of_errors(_FILE, database, models=[op, af]) == 0
 
 
 def test_failure(database):
@@ -37,4 +37,4 @@ def test_failure(database):
     af3 = AwardFinancial(job_id=1, row_number=1, tas=tas, program_activity_code='2', object_class='1')
     af4 = AwardFinancial(job_id=1, row_number=1, tas=tas, program_activity_code='1', object_class='2')
 
-    assert number_of_errors(_FILE, database.stagingDb, models=[op, af1, af2, af3, af4]) == 3
+    assert number_of_errors(_FILE, database, models=[op, af1, af2, af3, af4]) == 3


### PR DESCRIPTION
This PR mainly updates the unit tests to get a database fixture using the functions in `dataactcore/interfaces/db.py` instead of baseInterface + interface holder.

A few miscellaneous items included:
* Update the FSRS loader (another one I forgot in PR #272)
* Migrations now use the common URI function in db.py instead of repeating the code to create a URI string

@mab6bf @jworcestBAH @nmonga91 @cmc333333: heads-up that once this is merged, the syntax for referencing the pytest database fixture will change slightly.

Old: `database.stagingDb`
New: `database`