### PR TITLE
B14 and B15 updated to sum for each tas, unit tests updated to match

### DIFF
--- a/dataactvalidator/config/sqlrules/b14_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b14_object_class_program_activity.sql
@@ -1,35 +1,36 @@
 SELECT
-    op.row_number,
-    op.ussgl480100_undelivered_or_cpe,
-    op.ussgl480100_undelivered_or_fyb,
-    op.ussgl480200_undelivered_or_cpe,
-    op.ussgl480200_undelivered_or_fyb,
-    op.ussgl488100_upward_adjustm_cpe,
-    op.ussgl488200_upward_adjustm_cpe,
-    op.ussgl490100_delivered_orde_cpe,
-    op.ussgl490100_delivered_orde_fyb,
-    op.ussgl490200_delivered_orde_cpe,
-    op.ussgl490800_authority_outl_cpe,
-    op.ussgl490800_authority_outl_fyb,
-    op.ussgl498100_upward_adjustm_cpe,
-    op.ussgl498200_upward_adjustm_cpe,
+    DISTINCT NULL as row_number,
+    SUM(op.ussgl480100_undelivered_or_cpe) as ussgl480100_undelivered_or_cpe_sum,
+    SUM(op.ussgl480100_undelivered_or_fyb) as ussgl480100_undelivered_or_fyb_sum,
+    SUM(op.ussgl480200_undelivered_or_cpe) as ussgl480200_undelivered_or_cpe_sum,
+    SUM(op.ussgl480200_undelivered_or_fyb) as ussgl480200_undelivered_or_fyb_sum,
+    SUM(op.ussgl488100_upward_adjustm_cpe) as ussgl488100_upward_adjustm_cpe_sum,
+    SUM(op.ussgl488200_upward_adjustm_cpe) as ussgl488200_upward_adjustm_cpe_sum,
+    SUM(op.ussgl490100_delivered_orde_cpe) as ussgl490100_delivered_orde_cpe_sum,
+    SUM(op.ussgl490100_delivered_orde_fyb) as ussgl490100_delivered_orde_fyb_sum,
+    SUM(op.ussgl490200_delivered_orde_cpe) as ussgl490200_delivered_orde_cpe_sum,
+    SUM(op.ussgl490800_authority_outl_cpe) as ussgl490800_authority_outl_cpe_sum,
+    SUM(op.ussgl490800_authority_outl_fyb) as ussgl490800_authority_outl_fyb_sum,
+    SUM(op.ussgl498100_upward_adjustm_cpe) as ussgl498100_upward_adjustm_cpe_sum,
+    SUM(op.ussgl498200_upward_adjustm_cpe) as ussgl498200_upward_adjustm_cpe_sum,
     sf.amount as sf_133_amount
 FROM object_class_program_activity as op
     INNER JOIN sf_133 as sf ON op.tas = sf.tas
     INNER JOIN submission as sub ON op.submission_id = sub.submission_id AND
         sf.period = sub.reporting_fiscal_period AND
         sf.fiscal_year = sub.reporting_fiscal_year
-WHERE op.submission_id = {} AND
-    sf.line = 2004 AND
-    LOWER(op.by_direct_reimbursable_fun) = 'd' AND
+WHERE op.submission_id = {} AND sf.line = 2004 AND
+    LOWER(op.by_direct_reimbursable_fun) = 'd'
+GROUP BY op.tas, sf.amount
+HAVING
     (
-        (op.ussgl480100_undelivered_or_cpe - op.ussgl480100_undelivered_or_fyb) +
-        (op.ussgl480200_undelivered_or_cpe - op.ussgl480200_undelivered_or_fyb) +
-        op.ussgl488100_upward_adjustm_cpe +
-        op.ussgl488200_upward_adjustm_cpe +
-        (op.ussgl490100_delivered_orde_cpe - op.ussgl490100_delivered_orde_fyb) +
-        op.ussgl490200_delivered_orde_cpe +
-        (op.ussgl490800_authority_outl_cpe - op.ussgl490800_authority_outl_fyb) +
-        op.ussgl498100_upward_adjustm_cpe +
-        op.ussgl498200_upward_adjustm_cpe
+        (SUM(ussgl480100_undelivered_or_cpe) - SUM(ussgl480100_undelivered_or_fyb)) +
+        (SUM(ussgl480200_undelivered_or_cpe) - SUM(ussgl480200_undelivered_or_fyb)) +
+        SUM(ussgl488100_upward_adjustm_cpe) +
+        SUM(ussgl488200_upward_adjustm_cpe) +
+        (SUM(ussgl490100_delivered_orde_cpe) - SUM(ussgl490100_delivered_orde_fyb)) +
+        SUM(ussgl490200_delivered_orde_cpe) +
+        (SUM(ussgl490800_authority_outl_cpe) - SUM(ussgl490800_authority_outl_fyb)) +
+        SUM(ussgl498100_upward_adjustm_cpe) +
+        SUM(ussgl498200_upward_adjustm_cpe)
     ) <> sf.amount

--- a/dataactvalidator/config/sqlrules/b14_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b14_object_class_program_activity.sql
@@ -1,5 +1,6 @@
 SELECT
     DISTINCT NULL as row_number,
+    op.tas,
     SUM(op.ussgl480100_undelivered_or_cpe) as ussgl480100_undelivered_or_cpe_sum,
     SUM(op.ussgl480100_undelivered_or_fyb) as ussgl480100_undelivered_or_fyb_sum,
     SUM(op.ussgl480200_undelivered_or_cpe) as ussgl480200_undelivered_or_cpe_sum,

--- a/dataactvalidator/config/sqlrules/b15_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b15_object_class_program_activity.sql
@@ -1,5 +1,6 @@
 SELECT
     DISTINCT NULL as row_number,
+    op.tas,
     SUM(op.ussgl480100_undelivered_or_cpe) as ussgl480100_undelivered_or_cpe_sum,
     SUM(op.ussgl480100_undelivered_or_fyb) as ussgl480100_undelivered_or_fyb_sum,
     SUM(op.ussgl480200_undelivered_or_cpe) as ussgl480200_undelivered_or_cpe_sum,

--- a/dataactvalidator/config/sqlrules/b15_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b15_object_class_program_activity.sql
@@ -1,35 +1,36 @@
 SELECT
-    op.row_number,
-    op.ussgl480100_undelivered_or_cpe,
-    op.ussgl480100_undelivered_or_fyb,
-    op.ussgl480200_undelivered_or_cpe,
-    op.ussgl480200_undelivered_or_fyb,
-    op.ussgl488100_upward_adjustm_cpe,
-    op.ussgl488200_upward_adjustm_cpe,
-    op.ussgl490100_delivered_orde_cpe,
-    op.ussgl490100_delivered_orde_fyb,
-    op.ussgl490200_delivered_orde_cpe,
-    op.ussgl490800_authority_outl_cpe,
-    op.ussgl490800_authority_outl_fyb,
-    op.ussgl498100_upward_adjustm_cpe,
-    op.ussgl498200_upward_adjustm_cpe,
+    DISTINCT NULL as row_number,
+    SUM(op.ussgl480100_undelivered_or_cpe) as ussgl480100_undelivered_or_cpe_sum,
+    SUM(op.ussgl480100_undelivered_or_fyb) as ussgl480100_undelivered_or_fyb_sum,
+    SUM(op.ussgl480200_undelivered_or_cpe) as ussgl480200_undelivered_or_cpe_sum,
+    SUM(op.ussgl480200_undelivered_or_fyb) as ussgl480200_undelivered_or_fyb_sum,
+    SUM(op.ussgl488100_upward_adjustm_cpe) as ussgl488100_upward_adjustm_cpe_sum,
+    SUM(op.ussgl488200_upward_adjustm_cpe) as ussgl488200_upward_adjustm_cpe_sum,
+    SUM(op.ussgl490100_delivered_orde_cpe) as ussgl490100_delivered_orde_cpe_sum,
+    SUM(op.ussgl490100_delivered_orde_fyb) as ussgl490100_delivered_orde_fyb_sum,
+    SUM(op.ussgl490200_delivered_orde_cpe) as ussgl490200_delivered_orde_cpe_sum,
+    SUM(op.ussgl490800_authority_outl_cpe) as ussgl490800_authority_outl_cpe_sum,
+    SUM(op.ussgl490800_authority_outl_fyb) as ussgl490800_authority_outl_fyb_sum,
+    SUM(op.ussgl498100_upward_adjustm_cpe) as ussgl498100_upward_adjustm_cpe_sum,
+    SUM(op.ussgl498200_upward_adjustm_cpe) as ussgl498200_upward_adjustm_cpe_sum,
     sf.amount as sf_133_amount
 FROM object_class_program_activity as op
     INNER JOIN sf_133 as sf ON op.tas = sf.tas
     INNER JOIN submission as sub ON op.submission_id = sub.submission_id AND
         sf.period = sub.reporting_fiscal_period AND
         sf.fiscal_year = sub.reporting_fiscal_year
-WHERE op.submission_id = {} AND
-    sf.line = 2104 AND
-    LOWER(op.by_direct_reimbursable_fun) = 'r' AND
+WHERE op.submission_id = {} AND sf.line = 2104 AND
+    LOWER(op.by_direct_reimbursable_fun) = 'r'
+GROUP BY op.tas, sf.amount
+HAVING
     (
-        (op.ussgl480100_undelivered_or_cpe - op.ussgl480100_undelivered_or_fyb) +
-        (op.ussgl480200_undelivered_or_cpe - op.ussgl480200_undelivered_or_fyb) +
-        op.ussgl488100_upward_adjustm_cpe +
-        op.ussgl488200_upward_adjustm_cpe +
-        (op.ussgl490100_delivered_orde_cpe - op.ussgl490100_delivered_orde_fyb) +
-        op.ussgl490200_delivered_orde_cpe +
-        (op.ussgl490800_authority_outl_cpe - op.ussgl490800_authority_outl_fyb) +
-        op.ussgl498100_upward_adjustm_cpe +
-        op.ussgl498200_upward_adjustm_cpe
+        (SUM(ussgl480100_undelivered_or_cpe) - SUM(ussgl480100_undelivered_or_fyb)) +
+        (SUM(ussgl480200_undelivered_or_cpe) - SUM(ussgl480200_undelivered_or_fyb)) +
+        SUM(ussgl488100_upward_adjustm_cpe) +
+        SUM(ussgl488200_upward_adjustm_cpe) +
+        (SUM(ussgl490100_delivered_orde_cpe) - SUM(ussgl490100_delivered_orde_fyb)) +
+        SUM(ussgl490200_delivered_orde_cpe) +
+        (SUM(ussgl490800_authority_outl_cpe) - SUM(ussgl490800_authority_outl_fyb)) +
+        SUM(ussgl498100_upward_adjustm_cpe) +
+        SUM(ussgl498200_upward_adjustm_cpe)
     ) <> sf.amount

--- a/tests/unit/dataactvalidator/test_b14_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b14_object_class_program_activity.py
@@ -12,6 +12,35 @@ def test_success(database):
         for the specified fiscal year and period """
     tas = "".join([_TAS, "_success"])
 
+    # This uses the default submission created in utils for 10/2015 which is period 1 of FY 2016
+    sf = SF133(line=2004, tas=tas, period=1, fiscal_year=2016, amount=15, agency_identifier="sys",
+               main_account_code="000", sub_account_code="000")
+
+    op = ObjectClassProgramActivity(job_id=1, row_number=1, tas=tas, by_direct_reimbursable_fun='d',
+                                    ussgl480100_undelivered_or_cpe=1, ussgl480100_undelivered_or_fyb=1,
+                                    ussgl480200_undelivered_or_cpe=1, ussgl480200_undelivered_or_fyb=1,
+                                    ussgl488100_upward_adjustm_cpe=1, ussgl488200_upward_adjustm_cpe=1,
+                                    ussgl490100_delivered_orde_cpe=1, ussgl490100_delivered_orde_fyb=1,
+                                    ussgl490200_delivered_orde_cpe=1, ussgl490800_authority_outl_cpe=1,
+                                    ussgl490800_authority_outl_fyb=1, ussgl498100_upward_adjustm_cpe=1,
+                                    ussgl498200_upward_adjustm_cpe=1)
+
+    op2 = ObjectClassProgramActivity(job_id=1, row_number=2, tas=tas, by_direct_reimbursable_fun='d',
+                                    ussgl480100_undelivered_or_cpe=2, ussgl480100_undelivered_or_fyb=2,
+                                    ussgl480200_undelivered_or_cpe=2, ussgl480200_undelivered_or_fyb=2,
+                                    ussgl488100_upward_adjustm_cpe=2, ussgl488200_upward_adjustm_cpe=2,
+                                    ussgl490100_delivered_orde_cpe=2, ussgl490100_delivered_orde_fyb=2,
+                                    ussgl490200_delivered_orde_cpe=2, ussgl490800_authority_outl_cpe=2,
+                                    ussgl490800_authority_outl_fyb=2, ussgl498100_upward_adjustm_cpe=2,
+                                    ussgl498200_upward_adjustm_cpe=2)
+
+    assert number_of_errors(_FILE, database, models=[sf, op, op2]) == 0
+
+
+def test_failure(database):
+    """ Tests that SF 133 amount sum for line 2004 does not match the calculation from Appropriation based on the fields below
+        for the specified fiscal year and period """
+    tas = "".join([_TAS, "_failure"])
     sf = SF133(line=2004, tas=tas, period=1, fiscal_year=2016, amount=5, agency_identifier="sys",
                main_account_code="000", sub_account_code="000")
 
@@ -24,23 +53,13 @@ def test_success(database):
                                     ussgl490800_authority_outl_fyb=1, ussgl498100_upward_adjustm_cpe=1,
                                     ussgl498200_upward_adjustm_cpe=1)
 
-    assert number_of_errors(_FILE, database, models=[sf, op]) == 0
+    op2 = ObjectClassProgramActivity(job_id=1, row_number=2, tas=tas, by_direct_reimbursable_fun='d',
+                                    ussgl480100_undelivered_or_cpe=2, ussgl480100_undelivered_or_fyb=2,
+                                    ussgl480200_undelivered_or_cpe=2, ussgl480200_undelivered_or_fyb=2,
+                                    ussgl488100_upward_adjustm_cpe=2, ussgl488200_upward_adjustm_cpe=2,
+                                    ussgl490100_delivered_orde_cpe=2, ussgl490100_delivered_orde_fyb=2,
+                                    ussgl490200_delivered_orde_cpe=2, ussgl490800_authority_outl_cpe=2,
+                                    ussgl490800_authority_outl_fyb=2, ussgl498100_upward_adjustm_cpe=2,
+                                    ussgl498200_upward_adjustm_cpe=2)
 
-
-def test_failure(database):
-    """ Tests that SF 133 amount sum for line 2004 does not match the calculation from Appropriation based on the fields below
-        for the specified fiscal year and period """
-    tas = "".join([_TAS, "_failure"])
-    sf = SF133(line=2004, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
-
-    op = ObjectClassProgramActivity(job_id=1, row_number=1, tas=tas, by_direct_reimbursable_fun='d',
-                                    ussgl480100_undelivered_or_cpe=1, ussgl480100_undelivered_or_fyb=1,
-                                    ussgl480200_undelivered_or_cpe=1, ussgl480200_undelivered_or_fyb=1,
-                                    ussgl488100_upward_adjustm_cpe=1, ussgl488200_upward_adjustm_cpe=1,
-                                    ussgl490100_delivered_orde_cpe=1, ussgl490100_delivered_orde_fyb=1,
-                                    ussgl490200_delivered_orde_cpe=1, ussgl490800_authority_outl_cpe=1,
-                                    ussgl490800_authority_outl_fyb=1, ussgl498100_upward_adjustm_cpe=1,
-                                    ussgl498200_upward_adjustm_cpe=1)
-
-    assert number_of_errors(_FILE, database, models=[sf, op]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, op, op2]) == 1

--- a/tests/unit/dataactvalidator/test_b15_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b15_object_class_program_activity.py
@@ -11,6 +11,46 @@ def test_success(database):
     """ Tests that SF 133 amount sum for line 2104 matches the calculation from Appropriation based on the fields below
         for the specified fiscal year and period """
     tas = "".join([_TAS, "_success"])
+    tas2 = "".join([_TAS, "_other_tas"])
+
+    # This uses the default submission created in utils for 10/2015 which is period 1 of FY 2016
+    sf = SF133(line=2104, tas=tas, period=1, fiscal_year=2016, amount=15, agency_identifier="sys",
+               main_account_code="000", sub_account_code="000")
+
+    op = ObjectClassProgramActivity(job_id=1, row_number=1, tas=tas, by_direct_reimbursable_fun='r',
+                                    ussgl480100_undelivered_or_cpe=1, ussgl480100_undelivered_or_fyb=1,
+                                    ussgl480200_undelivered_or_cpe=1, ussgl480200_undelivered_or_fyb=1,
+                                    ussgl488100_upward_adjustm_cpe=1, ussgl488200_upward_adjustm_cpe=1,
+                                    ussgl490100_delivered_orde_cpe=1, ussgl490100_delivered_orde_fyb=1,
+                                    ussgl490200_delivered_orde_cpe=1, ussgl490800_authority_outl_cpe=1,
+                                    ussgl490800_authority_outl_fyb=1, ussgl498100_upward_adjustm_cpe=1,
+                                    ussgl498200_upward_adjustm_cpe=1)
+    op2 = ObjectClassProgramActivity(job_id=1, row_number=2, tas=tas, by_direct_reimbursable_fun='r',
+                                    ussgl480100_undelivered_or_cpe=2, ussgl480100_undelivered_or_fyb=2,
+                                    ussgl480200_undelivered_or_cpe=2, ussgl480200_undelivered_or_fyb=2,
+                                    ussgl488100_upward_adjustm_cpe=2, ussgl488200_upward_adjustm_cpe=2,
+                                    ussgl490100_delivered_orde_cpe=2, ussgl490100_delivered_orde_fyb=2,
+                                    ussgl490200_delivered_orde_cpe=2, ussgl490800_authority_outl_cpe=2,
+                                    ussgl490800_authority_outl_fyb=2, ussgl498100_upward_adjustm_cpe=2,
+                                    ussgl498200_upward_adjustm_cpe=2)
+
+    # Record for other TAS should not be included in sum
+    op3 = ObjectClassProgramActivity(job_id=1, row_number=3, tas=tas2, by_direct_reimbursable_fun='r',
+                                    ussgl480100_undelivered_or_cpe=2, ussgl480100_undelivered_or_fyb=2,
+                                    ussgl480200_undelivered_or_cpe=2, ussgl480200_undelivered_or_fyb=2,
+                                    ussgl488100_upward_adjustm_cpe=2, ussgl488200_upward_adjustm_cpe=2,
+                                    ussgl490100_delivered_orde_cpe=2, ussgl490100_delivered_orde_fyb=2,
+                                    ussgl490200_delivered_orde_cpe=2, ussgl490800_authority_outl_cpe=2,
+                                    ussgl490800_authority_outl_fyb=2, ussgl498100_upward_adjustm_cpe=2,
+                                    ussgl498200_upward_adjustm_cpe=2)
+
+    assert number_of_errors(_FILE, database, models=[sf, op, op2, op3]) == 0
+
+
+def test_failure(database):
+    """ Tests that SF 133 amount sum for line 2104 does not match the calculation from Appropriation based on the fields below
+        for the specified fiscal year and period """
+    tas = "".join([_TAS, "_failure"])
 
     sf = SF133(line=2104, tas=tas, period=1, fiscal_year=2016, amount=5, agency_identifier="sys",
                main_account_code="000", sub_account_code="000")
@@ -24,24 +64,13 @@ def test_success(database):
                                     ussgl490800_authority_outl_fyb=1, ussgl498100_upward_adjustm_cpe=1,
                                     ussgl498200_upward_adjustm_cpe=1)
 
-    assert number_of_errors(_FILE, database, models=[sf, op]) == 0
+    op2 = ObjectClassProgramActivity(job_id=1, row_number=2, tas=tas, by_direct_reimbursable_fun='r',
+                                    ussgl480100_undelivered_or_cpe=2, ussgl480100_undelivered_or_fyb=2,
+                                    ussgl480200_undelivered_or_cpe=2, ussgl480200_undelivered_or_fyb=2,
+                                    ussgl488100_upward_adjustm_cpe=2, ussgl488200_upward_adjustm_cpe=2,
+                                    ussgl490100_delivered_orde_cpe=2, ussgl490100_delivered_orde_fyb=2,
+                                    ussgl490200_delivered_orde_cpe=2, ussgl490800_authority_outl_cpe=2,
+                                    ussgl490800_authority_outl_fyb=2, ussgl498100_upward_adjustm_cpe=2,
+                                    ussgl498200_upward_adjustm_cpe=2)
 
-
-def test_failure(database):
-    """ Tests that SF 133 amount sum for line 2104 does not match the calculation from Appropriation based on the fields below
-        for the specified fiscal year and period """
-    tas = "".join([_TAS, "_failure"])
-
-    sf = SF133(line=2104, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
-
-    op = ObjectClassProgramActivity(job_id=1, row_number=1, tas=tas, by_direct_reimbursable_fun='r',
-                                    ussgl480100_undelivered_or_cpe=1, ussgl480100_undelivered_or_fyb=1,
-                                    ussgl480200_undelivered_or_cpe=1, ussgl480200_undelivered_or_fyb=1,
-                                    ussgl488100_upward_adjustm_cpe=1, ussgl488200_upward_adjustm_cpe=1,
-                                    ussgl490100_delivered_orde_cpe=1, ussgl490100_delivered_orde_fyb=1,
-                                    ussgl490200_delivered_orde_cpe=1, ussgl490800_authority_outl_cpe=1,
-                                    ussgl490800_authority_outl_fyb=1, ussgl498100_upward_adjustm_cpe=1,
-                                    ussgl498200_upward_adjustm_cpe=1)
-
-    assert number_of_errors(_FILE, database, models=[sf, op]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, op, op2]) == 1


### PR DESCRIPTION
These rules were updated to check the sum for all records within a TAS against the sf-133 amount for that TAS rather than checking each record against the amount individually.