### PR TITLE
Update docs to match environment-specific broker config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .cache/*
 dataactcore/.idea/*
 dataactcore/dbErrors.log
-config.yml
+*config.yml
+*secrets.yml
 dataactcore/scripts/dbSpec.txt
 dataactcore/scripts/createEmpty.py
 dataactbroker/logFile.dat

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -9,7 +9,7 @@ broker:
     # For a local installation this will most likely be localhost or the 
     # location where the /public files are located. If a port is required, 
     # it should be appended to the URL.
-    full_url: http://localhost:3000 
+    full_url: http://dataactbroker.domain.com
 
 
     # Set the key (string) used to serialize tokens for email validations.
@@ -17,14 +17,7 @@ broker:
 
     # Specify valid email address to be used as reply-to for
     # administrative emails sent by the broker.
-    reply_to_email: valid.email@domain.com 
-
-    # Set valid email address and password to be used as the DATA Act
-    # broker's admin account. This is what you will use to log into
-    # the broker website. The password should contain a combination
-    # of letters, numbers, and special characters.
-    admin_email: valid.email@domain.com
-    admin_password: AdminP@ssw0rd!
+    reply_to_email: valid.email@domain.com
 
     # The path where the broker will store submitted files and emails
     # when the broker is not using an AWS S3 bucket.
@@ -55,40 +48,10 @@ broker:
     sub_award_url: https://sample.gov
     sub_award_file_name: sub_award_data.csv
 
-    ## AWS Configuration Settings ##
-
-    # If set to true the application will use AWS for the storage of files 
-    # submitted to the broker, to send e-mail, AND to access the dynamo db
-    # for session handling.
-    # Note that you must have the aws cli installed and credentials set in  
-    # order to use AWS (see install instructions for more information).
-    use_aws: false 
-
-    # If using AWS, set your region here
-    aws_region: us-east-1
-
-    # Add your AWS Key to use for sending SES emails
-    aws_access_key_id: ACCESSKEYID123
-    aws_secret_access_key: test123abc/123testsecretkeY
-
-    # Name of AWS S3 bucket for uploaded broker files. Ignored if use_aws
-    # is false. NOTE: the dummy value below MUST be changed to the correct
-    # value if use_aws is true.
-    aws_bucket: sample-aws-bucket-name
-
     # Include folder and filename of RSS file if running on AWS, if running locally the RSS folder and file should be in
     # the broker_files directory specified above
     rss_folder: rss
     rss_file: rss_file.xls
-
-    # Name of the AWS role you're using to upload broker files. Ignored if
-    # use_aws is false. NOTE: the dummy value below MUST be changed to the
-    # correct value if use_aws is true.
-    aws_role: arn:aws:iam::123456789012:role/roleName
- 
-    # Set the following to true to allow the broker to create temporary
-    # AWS credentials for uploading files. Ignored if use_aws is false.
-    aws_create_temp_credentials: true
 
     # S3 filenames for SF-133 file, only required if planning to load SF-133 table
     sf_133_folder: config
@@ -105,12 +68,12 @@ services:
     server_debug: true
 
     # URL/IP address that hosts the broker API
-    broker_api_host: 127.0.0.1
-    broker_api_port: 3333
+    broker_api_host: http://dataactbroker-api.domain.com
+    broker_api_port: 443
 
     # URL/IP address that hosts the validator API
-    validator_host: 127.0.0.1
-    validator_port: 3334
+    validator_host: http://dataactbroker-validator-api.domain.com
+    validator_port: 80
 
     # If you would like to restrict access from other origins, set the
     # allowed origins here. Otherwise, leave as '*'.
@@ -146,12 +109,8 @@ db:
 
     # Host and port of db instance. Set to localhost if running locally or set 
     # the remote address
-    host: localhost
+    host: dataactbroker.postgreshost.domain.com
     port: 5432
-
-    # Set your username and password for the db instance
-    username: yourusername
-    password: yourpassword
 
     # Set the names for each of the application databases
     base_db_name: postgres #This is the default db on the instance. 
@@ -185,14 +144,9 @@ logging:
     logstash_port: 514
 
 job-queue:
-    # RabbitMQ username
-    username: guest
 
-    # RabbitMQ password
-    password: guest
-
-    # URL for the job queue server
-    url: 127.0.0.1
+    # URL for the job queue server (do not add http)
+    url: dataactbroker.jobqueue.host.domain.com
 
     # Port on which Celery is listening
     port: 5672

--- a/dataactcore/local_config_example.yml
+++ b/dataactcore/local_config_example.yml
@@ -1,0 +1,44 @@
+#######################################################
+### Sample Local Data Act Broker Configuration.     ###
+### Values here will override values in config.yml. ###
+#######################################################
+
+broker:
+
+    use_aws: false
+    full_url: http://localhost:3000
+    reply_to_email: valid.developer.email@domain.com
+    broker_files: /full/path/to/local/broker/files
+    d_file_storage_path: /full/path/to/local/d/file/storage
+
+services:
+
+    broker_api_host: 127.0.0.1
+    broker_api_port: 3333
+    validator_host: 127.0.0.1
+    validator_port: 3334
+    error_report_path: error_report_path: /full/path/to/local/error/reports
+
+db:
+
+    base_db_name: postgres
+    scheme: postgres
+    host: localhost
+    port: 5432
+    base_db_name: postgres #This is the default db on the instance.
+    job_queue_db_name: da_job_queue # Job queue db
+    db_name: data_broker
+    dynamo_host: 127.0.0.1
+    dynamo_port: 8000
+
+logging:
+
+    use_logstash: false
+    log_files: /full/path/to/local/logfiles
+
+job-queue:
+
+    url: localhost
+    port: 5672
+    broker_scheme: amqp
+

--- a/dataactcore/local_config_example.yml
+++ b/dataactcore/local_config_example.yml
@@ -21,7 +21,6 @@ services:
 
 db:
 
-    base_db_name: postgres
     scheme: postgres
     host: localhost
     port: 5432
@@ -41,4 +40,3 @@ job-queue:
     url: localhost
     port: 5672
     broker_scheme: amqp
-

--- a/dataactcore/local_secrets_example.yml
+++ b/dataactcore/local_secrets_example.yml
@@ -1,0 +1,57 @@
+###############################################################
+### Sample Local Secrets Data Act Broker Configuration.     ###
+### This file stores sensitive information, not             ###
+### intended to live with the codebase. Values here         ###
+### will override values in config.yml and local_config.yml ###
+###############################################################
+
+broker:
+
+    # Set valid email address and password to be used as the DATA Act
+    # broker's admin account. This is what you will use to log into
+    # the broker website. The password should contain a combination
+    # of letters, numbers, and special characters.
+    admin_email: valid.email@domain.com
+    admin_password: AdminP@ssw0rd!
+
+    ## AWS Configuration Settings ##
+
+    # If set to true the application will use AWS for the storage of files
+    # submitted to the broker, to send e-mail, AND to access the dynamo db
+    # for session handling.
+    # Note that you must have the aws cli installed and credentials set in
+    # order to use AWS (see install instructions for more information).
+    use_aws: false
+
+    # If using AWS, set your region here
+    aws_region: us-east-1
+
+    # Add your AWS Key to use for sending SES emails
+    aws_access_key_id: ACCESSKEYID123
+    aws_secret_access_key: test123abc/123testsecretkeY
+
+    # Name of AWS S3 bucket for uploaded broker files. Ignored if use_aws
+    # is false. NOTE: the dummy value below MUST be changed to the correct
+    # value if use_aws is true.
+    aws_bucket: sample-aws-bucket-name
+
+    # Name of the AWS role you're using to upload broker files. Ignored if
+    # use_aws is false. NOTE: the dummy value below MUST be changed to the
+    # correct value if use_aws is true.
+    aws_role: arn:aws:iam::123456789012:role/roleName
+
+    # Set the following to true to allow the broker to create temporary
+    # AWS credentials for uploading files. Ignored if use_aws is false.
+    aws_create_temp_credentials: true
+
+ db:
+
+    # Set your username and password for the db instance
+    username: yourusername
+    password: yourpassword
+
+job-queue:
+
+    # RabbitMQ username and password
+    username: guest
+    password: guest

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Assumptions:
 [PostgreSQL](https://en.wikipedia.org/wiki/PostgreSQL) is an object-relational database management system (ORDBMS) with an emphasis on extensibility and standards-compliance.
 
 1. Download the correct PostgreSQL installer for your operating system from [EnterpriseDB](http://www.enterprisedb.com/products-services-training/pgdownload) (we recommend PostgreSQL 9.4.x).
-2. Run the installer. As you proceed through the installation wizard, note your choices for port number, username, and password. You will need those when creating the broker's configuration file.
+2. Run the installer. As you proceed through the installation wizard, note your choices for port number, username, and password. You will need those when creating the broker's configuration files.
 
 More complete install documentation is available on the PostgreSQL [wiki](https://wiki.postgresql.org/wiki/Detailed_installation_guides).
 
@@ -121,7 +121,7 @@ Don't worry about setting DynamoDB endpoints or creating tables: the broker's co
 RabbitMQ is used to pass jobs to the validator, and requires Erlang to be installed before RabbitMQ.
 
 1.  Install Erlang based on the [download instructions](https://www.erlang.org/downloads)
-2.  Choose an installation guide based on your OS for [RabbitMQ](https://www.rabbitmq.com/download.html).  Be sure to install Erlang before installing RabbitMQ.  The default user and password is "guest"/"guest", if you change these you'll need to keep that information to be placed in the config file later in the process.
+2.  Choose an installation guide based on your OS for [RabbitMQ](https://www.rabbitmq.com/download.html).  Be sure to install Erlang before installing RabbitMQ.  The default user and password is "guest"/"guest", if you change these you'll need to keep that information to be placed in the config files later in the process.
 
 ### Clone Broker Backend Code Repository
 
@@ -159,28 +159,24 @@ If you are using virtualenvwrapper-powershell in Windows, the following command 
 
         $ add2virtualenv [location of your code]/data-act-broker-backend
 
-### Create Broker Config File
+### Create Broker Config Files
 
-Before running the broker, you'll need to provide a few configuration options. Use the provided sample config file as a starting point:
+Before running the broker, you'll need to provide a few configuration options. The broker uses three config files:
 
-1. From the `data-act-broker-backend` directory, go to `dataactcore` and open the file called `config_example.yml` in a text editor.
-2. Save `config_example.yml` as `config.yml`.
-3. Update the values in `config.yml` as appropriate for your environment. In many cases the default values will work just fine. The most important config values to change when getting started are:
+* `config.yml`: Config parameters shared across broker instances (_e.g._, production, staging, development, local).
+* `[instance]_config.yml`: Config parameters specific to a broker instance (_e.g._, location of the development database, url for the development broker instance). Values in this file override their corresponding values in `config.yml`.
+* `[instance]_secrets.yml`: Sensitive config values specific to a broker instance (_e.g._, database passwords).
 
-    * under _broker_:
-        * `full_url`
-        * `reply_to_email`
-        * `admin_email`
-        * `admin_password`
-        * `broker_files`
-    * under _services_:
-        * `error_report_path`
-    * under _db_:
-        * `username`
-        * `password`
-    * under _logging_:
-        * `log_files`
-4. Save your changes to config.yml
+At startup, the broker looks for an environment variable called `env` and will use that to set the instance name. If there is no `env` environment variable, the broker will set the instance name to `local` and look for `local_config.yml` and `local_secrets.yml`.
+
+There are sample config files in `data-act-broker-backend/dataactcore`. Use these as a starting point when setting up the broker. The instructions below assume that you're installing the broker for local development.
+
+1. Open `config_example.yml` in a text editor and save it as `config.yml`.
+2. Update the values in `config.yml` as appropriate for your installation and save. In many cases the default values will work just fine. The most important config values to change will be in `local_config.yml` and `local_secrets.yml`
+3. Open `local_config_example.yml` in a text editor and save it as `local_config.yml`.
+4. Update the values in `local_config.yml` as appropriate for your installation and save.
+5. Open `local_secrets_example.yml` in a text editor and save it as `local_secrets.yml`.
+6. Update the values in `local_secrets.yml` as appropriate for your installation and save.
 
 ### Initialize Broker Backend Applications
 


### PR DESCRIPTION
Create two new config samples (local_config_example.yml and
local_secrets_example.yml) to match the changes to the broker's
config handling. Also update the install docs to explain how
these files are used.

Took my best guess at a reasonable way of splitting up values between the three sample files. Happy to go back and forth on this. Ultimately, though, I think the sample files matching our particular use is less important than making sure that folks reading the install docs know what to do.