### PR TITLE
Update file F's write_csv

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -508,7 +508,7 @@ class FileHandler:
         elif file_type == 'F':
             generate_f_file.delay(
                 submission_id, job.job_id, InterfaceHolder, timestamped_name,
-                self.isLocal)
+                upload_file_name, self.isLocal)
         else:
             # TODO add generate calls for E
             jobDb.markJobStatus(job.job_id,"finished")

--- a/dataactcore/utils/jobQueue.py
+++ b/dataactcore/utils/jobQueue.py
@@ -44,7 +44,7 @@ def enqueue(jobID):
 
 @celery_app.task(name='jobQueue.generate_f_file')
 def generate_f_file(submission_id, job_id, interface_holder_class,
-                    timestamped_name, is_local):
+                    timestamped_name, upload_file_name, is_local):
     """Write rows from fileF.generateFRows to an appropriate CSV. Here the
     third parameter, interface_holder_class, is a bit of a hack. Importing
     InterfaceHolder directly causes cyclic dependency woes, so we're passing
@@ -61,7 +61,8 @@ def generate_f_file(submission_id, job_id, interface_holder_class,
             for row in rows_of_dicts:
                 body.append([row[key] for key in header])
 
-            write_csv(timestamped_name, is_local, header, body)
+            write_csv(timestamped_name, upload_file_name, is_local, header,
+                      body)
             job_manager.markJobStatus(job_id, "finished")
         except Exception as e:
             # Log the error

--- a/tests/unit/dataactcore/test_job_queue.py
+++ b/tests/unit/dataactcore/test_job_queue.py
@@ -1,0 +1,43 @@
+from collections import OrderedDict
+import csv
+import os
+from unittest.mock import Mock
+
+import pytest
+from pytest import raises
+
+from dataactcore.utils import jobQueue
+from dataactcore.config import CONFIG_BROKER
+from dataactcore.utils.responseException import ResponseException
+
+
+def read_f_file_rows(suffix, file_path):
+    jobQueue.generate_f_file(1, 1, Mock(), suffix, suffix, is_local=True)
+
+    assert os.path.isfile(file_path)
+
+    with open(file_path) as f:
+        return [row for row in csv.reader(f)]
+
+
+def test_generate_f_file(monkeypatch, mock_broker_config_paths):
+    """A CSV with fields in the right order should be written to the file
+    system"""
+    fileF_mock = Mock()
+    monkeypatch.setattr(jobQueue, 'fileF', fileF_mock)
+    fileF_mock.generateFRows.return_value = [
+        dict(key4='a', key11='b'), dict(key4='c', key11='d')
+    ]
+
+    fileF_mock.mappings = OrderedDict(
+        [('key4', 'mapping4'), ('key11', 'mapping11')])
+    file_path = str(mock_broker_config_paths['broker_files'].join('unique1'))
+    expected = [['key4', 'key11'], ['a', 'b'], ['c', 'd']]
+    assert read_f_file_rows('unique1', file_path) == expected
+
+    # re-order
+    fileF_mock.mappings = OrderedDict(
+        [('key11', 'mapping11'), ('key4', 'mapping4')])
+    file_path = str(mock_broker_config_paths['broker_files'].join('unique2'))
+    expected = [['key11', 'key4'], ['b', 'a'], ['d', 'c']]
+    assert read_f_file_rows('unique2', file_path) == expected


### PR DESCRIPTION
As the parameters to write_csv have changed, we need to modify their usage in file F generation, too. This also adds back a unit test which had been accidentally deleted to catch this sort of error in the future.