### PR TITLE
Make sure alembic is aware of all models in use.

### DIFF
--- a/dataactcore/migrations/env.py
+++ b/dataactcore/migrations/env.py
@@ -2,7 +2,7 @@ from __future__ import with_statement
 from alembic import context
 # Load all DB tables into metadata object
 # @todo - load these dynamically
-from dataactcore.models import baseModel, domainModels, fsrs, errorModels, jobModels, stagingModels, userModel, validationModels
+from dataactcore.models import baseModel, domainModels, fsrs, errorModels, jobModels, stagingModels, userModel, validationModels # noqa
 from dataactcore.config import CONFIG_DB
 from dataactcore.interfaces.db import dbURI
 from sqlalchemy import engine_from_config, pool

--- a/dataactcore/migrations/env.py
+++ b/dataactcore/migrations/env.py
@@ -2,7 +2,7 @@ from __future__ import with_statement
 from alembic import context
 # Load all DB tables into metadata object
 # @todo - load these dynamically
-from dataactcore.models import baseModel
+from dataactcore.models import baseModel, domainModels, fsrs, errorModels, jobModels, stagingModels, userModel, validationModels
 from dataactcore.config import CONFIG_DB
 from dataactcore.interfaces.db import dbURI
 from sqlalchemy import engine_from_config, pool


### PR DESCRIPTION
I had removed some of these model imports  when making  unrelated changes
to env.py b/c the IDE was marking them as unused. They do need to be
there, however, else Alembic won't know which models to check when
autogenerating migrations.