### PR TITLE
Fixed B18 test to fill object classes up to three digits

### DIFF
--- a/tests/unit/dataactvalidator/test_b18_object_class_program_activity_1.py
+++ b/tests/unit/dataactvalidator/test_b18_object_class_program_activity_1.py
@@ -14,7 +14,7 @@ def test_success(database):
     """ Test that a four digit object class with no flag is a success, and a three digit object class with a flag is a success"""
     not_req_ocpa = ObjectClassProgramActivityFactory(object_class = randint(1000,9999),
         by_direct_reimbursable_fun = "")
-    req_present_ocpa = ObjectClassProgramActivityFactory(object_class = randint(0,999),
+    req_present_ocpa = ObjectClassProgramActivityFactory(object_class = str(randint(0,999)).zfill(3),
         by_direct_reimbursable_fun = "d")
 
     errors = number_of_errors(_FILE, database, models=[not_req_ocpa, req_present_ocpa])
@@ -23,7 +23,7 @@ def test_success(database):
 
 def test_failure(database):
     """ Test that a three digit object class with no flag is an error"""
-    req_absent_ocpa = ObjectClassProgramActivityFactory(object_class = randint(0,999),
+    req_absent_ocpa = ObjectClassProgramActivityFactory(object_class = str(randint(0,999)).zfill(3),
         by_direct_reimbursable_fun = "")
 
     errors = number_of_errors(_FILE, database, models=[req_absent_ocpa])

--- a/tests/unit/dataactvalidator/test_b18_object_class_program_activity_2.py
+++ b/tests/unit/dataactvalidator/test_b18_object_class_program_activity_2.py
@@ -11,7 +11,7 @@ def test_column_headers(database):
     assert expected_subset <= actual
 
 def test_skip_three_digits(database):
-    check_query(database, ObjectClassProgramActivityFactory(object_class = randint(0,999),
+    check_query(database, ObjectClassProgramActivityFactory(object_class = str(randint(0,999)).zfill(3),
         by_direct_reimbursable_fun = "d"), 0)
 
 def test_skip_blank_flags(database):


### PR DESCRIPTION
This fixes object class handling for B18 to avoid failures that were occurring for object classes under 100