### PR TITLE
Create a file with lookup values used by the broker

### DIFF
--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -1,0 +1,90 @@
+# This file defines a series of constants that represent the values used in the
+# broker's "helper" tables. Rather than define the values in the db setup scripts
+# and then make db calls to lookup the surrogate keys, we'll define everything
+# here, in a file that can be used by the db setup scripts *and* the application
+# code.
+# todo: replace getIdFromDict and getNameFromDict baseInterface functions with these constants
+
+from collections import namedtuple
+
+LookupType = namedtuple('LookupType', ['id', 'name', 'desc'])
+LookupFileType = namedtuple('LookupFileType', ['id', 'name', 'desc', 'letter', 'order'])
+
+FILE_STATUS = []
+FILE_STATUS.append(LookupType(1, 'complete', 'File has been processed'))
+FILE_STATUS.append(LookupType(2, 'header_error', 'The file has errors in the header row'))
+FILE_STATUS.append(LookupType(3, 'unknown_error', 'An unknown error has occurred with this file'))
+FILE_STATUS.append(LookupType(4, 'single_row_error', 'Error occurred in job manager'))
+FILE_STATUS.append(LookupType(5, 'job_error', 'File has not yet been validated'))
+FILE_STATUS.append(LookupType(6, 'incomplete', 'File has not yet been validated'))
+FILE_STATUS_DICT = {item.id: item.name for item in FILE_STATUS}
+
+ERROR_TYPE = []
+ERROR_TYPE.append(LookupType(1, 'type_error', 'The value provided was of the wrong type'))
+ERROR_TYPE.append(LookupType(2, 'required_error', 'A required value was not provided'))
+ERROR_TYPE.append(LookupType(3, 'value_error', 'The value provided was invalid'))
+ERROR_TYPE.append(LookupType(4, 'read_error', 'Could not parse this record correctly'))
+ERROR_TYPE.append(LookupType(5, 'write_error', 'Could not write this record into the staging table'))
+ERROR_TYPE.append(LookupType(6, 'rule_failed', 'A rule failed for this value'))
+ERROR_TYPE.append(LookupType(7, 'length_error', 'Value was longer than allowed length'))
+ERROR_TYPE_DICT = {item.id: item.name for item in ERROR_TYPE}
+
+JOB_STATUS = []
+JOB_STATUS.append(LookupType(1, 'waiting', 'check dependency table'))
+JOB_STATUS.append(LookupType(2, 'ready', 'can be assigned'))
+JOB_STATUS.append(LookupType(3, 'running', 'job is currently in progress'))
+JOB_STATUS.append(LookupType(4, 'finished', 'job is complete'))
+JOB_STATUS.append(LookupType(5, 'invalid', 'job is invalid'))
+JOB_STATUS.append(LookupType(6, 'failed', 'job failed to complete'))
+JOB_STATUS_DICT = {item.id: item.name for item in JOB_STATUS}
+
+JOB_TYPE = []
+JOB_TYPE.append(LookupType(1, 'file_upload', 'file must be uploaded to S3'))
+JOB_TYPE.append(LookupType(2, 'csv_record_validation', 'do record level validation and add to staging table'))
+JOB_TYPE.append(LookupType(3, 'db_transfer', 'information must be moved from production DB to staging table'))
+JOB_TYPE.append(LookupType(4, 'validation', 'new information must be validated'))
+JOB_TYPE.append(LookupType(5, 'external_validation', 'new information must be validated against external sources'))
+JOB_TYPE_DICT = {item.id: item.name for item in JOB_TYPE}
+
+PUBLISH_STATUS = []
+PUBLISH_STATUS.append(LookupType(1, 'unpublished', 'Has not yet been moved to data store'))
+PUBLISH_STATUS.append(LookupType(2, 'published', 'Has been moved to data store'))
+PUBLISH_STATUS.append(LookupType(3, 'updated', 'Submission was updated after being published'))
+PUBLISH_STATUS_DICT = {item.id: item.name for item in PUBLISH_STATUS}
+
+FILE_TYPE = []
+FILE_TYPE.append(LookupFileType(1, 'appropriations', '', 'A', 1))
+FILE_TYPE.append(LookupFileType(2, 'program_activity', '', 'B', 2))
+FILE_TYPE.append(LookupFileType(3, 'award_financial', '', 'C', 3))
+FILE_TYPE.append(LookupFileType(4, 'award', '', 'D2', 4))
+FILE_TYPE.append(LookupFileType(5, 'award_procurement', '', 'D1', 5))
+FILE_TYPE.append(LookupFileType(6, 'awardee_attributes', '', 'E', None))
+FILE_TYPE.append(LookupFileType(7, 'sub_award', '', 'F', None))
+FILE_TYPE_DICT = {item.id: item.name for item in FILE_TYPE}
+
+USER_STATUS = []
+USER_STATUS.append(LookupType(1, 'awaiting_confirmation', 'User has entered email but not confirmed'))
+USER_STATUS.append(LookupType(2, 'email_confirmed', 'User email has been confirmed'))
+USER_STATUS.append(LookupType(3, 'awaiting_approval', 'User has registered their information and is waiting for approval'))
+USER_STATUS.append(LookupType(4, 'approved', 'User has been approved'))
+USER_STATUS.append(LookupType(5, 'denied', 'User registration was denied'))
+USER_STATUS_DICT = {item.id: item.name for item in USER_STATUS}
+
+PERMISSION_TYPE = []
+PERMISSION_TYPE.append(LookupType(0, 'agency_user', 'This user is allowed to upload data to be validated'))
+PERMISSION_TYPE.append(LookupType(1, 'website_admin', 'This user is allowed to manage user accounts'))
+PERMISSION_TYPE.append(LookupType(2, 'agency_admin', 'This user is allowed to manage user accounts within their agency'))
+PERMISSION_TYPE_DICT = {item.id: item.name for item in PERMISSION_TYPE}
+
+FIELD_TYPE = []
+FIELD_TYPE.append(LookupType(1, 'INT', 'integer type'))
+FIELD_TYPE.append(LookupType(2, 'DECIMAL', 'decimal type '))
+FIELD_TYPE.append(LookupType(3, 'BOOLEAN', 'yes/no'))
+FIELD_TYPE.append(LookupType(4, 'STRING', 'string type'))
+FIELD_TYPE.append(LookupType(5, 'LONG', 'long integer'))
+FIELD_TYPE_DICT = {item.id: item.name for item in FIELD_TYPE}
+
+RULE_SEVERITY = []
+RULE_SEVERITY.append(LookupType(1, 'warning', 'warning'))
+RULE_SEVERITY.append(LookupType(2, 'fatal', 'fatal error'))
+RULE_SEVERITY_DICT = {item.id: item.name for item in RULE_SEVERITY}

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -10,81 +10,91 @@ from collections import namedtuple
 LookupType = namedtuple('LookupType', ['id', 'name', 'desc'])
 LookupFileType = namedtuple('LookupFileType', ['id', 'name', 'desc', 'letter', 'order'])
 
-FILE_STATUS = []
-FILE_STATUS.append(LookupType(1, 'complete', 'File has been processed'))
-FILE_STATUS.append(LookupType(2, 'header_error', 'The file has errors in the header row'))
-FILE_STATUS.append(LookupType(3, 'unknown_error', 'An unknown error has occurred with this file'))
-FILE_STATUS.append(LookupType(4, 'single_row_error', 'Error occurred in job manager'))
-FILE_STATUS.append(LookupType(5, 'job_error', 'File has not yet been validated'))
-FILE_STATUS.append(LookupType(6, 'incomplete', 'File has not yet been validated'))
+FILE_STATUS = [
+    LookupType(1, 'complete', 'File has been processed'),
+    LookupType(2, 'header_error', 'The file has errors in the header row'),
+    LookupType(3, 'unknown_error', 'An unknown error has occurred with this file'),
+    LookupType(4, 'single_row_error', 'Error occurred in job manager'),
+    LookupType(5, 'job_error', 'File has not yet been validated'),
+    LookupType(6, 'incomplete', 'File has not yet been validated')
+]
 FILE_STATUS_DICT = {item.id: item.name for item in FILE_STATUS}
 
-ERROR_TYPE = []
-ERROR_TYPE.append(LookupType(1, 'type_error', 'The value provided was of the wrong type'))
-ERROR_TYPE.append(LookupType(2, 'required_error', 'A required value was not provided'))
-ERROR_TYPE.append(LookupType(3, 'value_error', 'The value provided was invalid'))
-ERROR_TYPE.append(LookupType(4, 'read_error', 'Could not parse this record correctly'))
-ERROR_TYPE.append(LookupType(5, 'write_error', 'Could not write this record into the staging table'))
-ERROR_TYPE.append(LookupType(6, 'rule_failed', 'A rule failed for this value'))
-ERROR_TYPE.append(LookupType(7, 'length_error', 'Value was longer than allowed length'))
+ERROR_TYPE = [
+    LookupType(1, 'type_error', 'The value provided was of the wrong type'),
+    LookupType(2, 'required_error', 'A required value was not provided'),
+    LookupType(3, 'value_error', 'The value provided was invalid'),
+    LookupType(4, 'read_error', 'Could not parse this record correctly'),
+    LookupType(5, 'write_error', 'Could not write this record into the staging table'),
+    LookupType(6, 'rule_failed', 'A rule failed for this value'),
+    LookupType(7, 'length_error', 'Value was longer than allowed length')
+]
 ERROR_TYPE_DICT = {item.id: item.name for item in ERROR_TYPE}
 
-JOB_STATUS = []
-JOB_STATUS.append(LookupType(1, 'waiting', 'check dependency table'))
-JOB_STATUS.append(LookupType(2, 'ready', 'can be assigned'))
-JOB_STATUS.append(LookupType(3, 'running', 'job is currently in progress'))
-JOB_STATUS.append(LookupType(4, 'finished', 'job is complete'))
-JOB_STATUS.append(LookupType(5, 'invalid', 'job is invalid'))
-JOB_STATUS.append(LookupType(6, 'failed', 'job failed to complete'))
+JOB_STATUS = [
+    LookupType(1, 'waiting', 'check dependency table'),
+    LookupType(2, 'ready', 'can be assigned'),
+    LookupType(3, 'running', 'job is currently in progress'),
+    LookupType(4, 'finished', 'job is complete'),
+    LookupType(5, 'invalid', 'job is invalid'),
+    LookupType(6, 'failed', 'job failed to complete')
+]
 JOB_STATUS_DICT = {item.id: item.name for item in JOB_STATUS}
 
-JOB_TYPE = []
-JOB_TYPE.append(LookupType(1, 'file_upload', 'file must be uploaded to S3'))
-JOB_TYPE.append(LookupType(2, 'csv_record_validation', 'do record level validation and add to staging table'))
-JOB_TYPE.append(LookupType(3, 'db_transfer', 'information must be moved from production DB to staging table'))
-JOB_TYPE.append(LookupType(4, 'validation', 'new information must be validated'))
-JOB_TYPE.append(LookupType(5, 'external_validation', 'new information must be validated against external sources'))
+JOB_TYPE = [
+    LookupType(1, 'file_upload', 'file must be uploaded to S3'),
+    LookupType(2, 'csv_record_validation', 'do record level validation and add to staging table'),
+    LookupType(3, 'db_transfer', 'information must be moved from production DB to staging table'),
+    LookupType(4, 'validation', 'new information must be validated'),
+    LookupType(5, 'external_validation', 'new information must be validated against external sources')
+]
 JOB_TYPE_DICT = {item.id: item.name for item in JOB_TYPE}
 
-PUBLISH_STATUS = []
-PUBLISH_STATUS.append(LookupType(1, 'unpublished', 'Has not yet been moved to data store'))
-PUBLISH_STATUS.append(LookupType(2, 'published', 'Has been moved to data store'))
-PUBLISH_STATUS.append(LookupType(3, 'updated', 'Submission was updated after being published'))
+PUBLISH_STATUS = [
+    LookupType(1, 'unpublished', 'Has not yet been moved to data store'),
+    LookupType(2, 'published', 'Has been moved to data store'),
+    LookupType(3, 'updated', 'Submission was updated after being published')
+]
 PUBLISH_STATUS_DICT = {item.id: item.name for item in PUBLISH_STATUS}
 
-FILE_TYPE = []
-FILE_TYPE.append(LookupFileType(1, 'appropriations', '', 'A', 1))
-FILE_TYPE.append(LookupFileType(2, 'program_activity', '', 'B', 2))
-FILE_TYPE.append(LookupFileType(3, 'award_financial', '', 'C', 3))
-FILE_TYPE.append(LookupFileType(4, 'award', '', 'D2', 4))
-FILE_TYPE.append(LookupFileType(5, 'award_procurement', '', 'D1', 5))
-FILE_TYPE.append(LookupFileType(6, 'awardee_attributes', '', 'E', None))
-FILE_TYPE.append(LookupFileType(7, 'sub_award', '', 'F', None))
+FILE_TYPE = [
+    LookupFileType(1, 'appropriations', '', 'A', 1),
+    LookupFileType(2, 'program_activity', '', 'B', 2),
+    LookupFileType(3, 'award_financial', '', 'C', 3),
+    LookupFileType(4, 'award', '', 'D2', 4),
+    LookupFileType(5, 'award_procurement', '', 'D1', 5),
+    LookupFileType(6, 'awardee_attributes', '', 'E', None),
+    LookupFileType(7, 'sub_award', '', 'F', None)
+]
 FILE_TYPE_DICT = {item.id: item.name for item in FILE_TYPE}
 
-USER_STATUS = []
-USER_STATUS.append(LookupType(1, 'awaiting_confirmation', 'User has entered email but not confirmed'))
-USER_STATUS.append(LookupType(2, 'email_confirmed', 'User email has been confirmed'))
-USER_STATUS.append(LookupType(3, 'awaiting_approval', 'User has registered their information and is waiting for approval'))
-USER_STATUS.append(LookupType(4, 'approved', 'User has been approved'))
-USER_STATUS.append(LookupType(5, 'denied', 'User registration was denied'))
+USER_STATUS = [
+    LookupType(1, 'awaiting_confirmation', 'User has entered email but not confirmed'),
+    LookupType(2, 'email_confirmed', 'User email has been confirmed'),
+    LookupType(3, 'awaiting_approval', 'User has registered their information and is waiting for approval'),
+    LookupType(4, 'approved', 'User has been approved'),
+    LookupType(5, 'denied', 'User registration was denied')
+]
 USER_STATUS_DICT = {item.id: item.name for item in USER_STATUS}
 
-PERMISSION_TYPE = []
-PERMISSION_TYPE.append(LookupType(0, 'agency_user', 'This user is allowed to upload data to be validated'))
-PERMISSION_TYPE.append(LookupType(1, 'website_admin', 'This user is allowed to manage user accounts'))
-PERMISSION_TYPE.append(LookupType(2, 'agency_admin', 'This user is allowed to manage user accounts within their agency'))
+PERMISSION_TYPE = [
+    LookupType(0, 'agency_user', 'This user is allowed to upload data to be validated'),
+    LookupType(1, 'website_admin', 'This user is allowed to manage user accounts'),
+    LookupType(2, 'agency_admin', 'This user is allowed to manage user accounts within their agency')
+]
 PERMISSION_TYPE_DICT = {item.id: item.name for item in PERMISSION_TYPE}
 
-FIELD_TYPE = []
-FIELD_TYPE.append(LookupType(1, 'INT', 'integer type'))
-FIELD_TYPE.append(LookupType(2, 'DECIMAL', 'decimal type '))
-FIELD_TYPE.append(LookupType(3, 'BOOLEAN', 'yes/no'))
-FIELD_TYPE.append(LookupType(4, 'STRING', 'string type'))
-FIELD_TYPE.append(LookupType(5, 'LONG', 'long integer'))
+FIELD_TYPE = [
+    LookupType(1, 'INT', 'integer type'),
+    LookupType(2, 'DECIMAL', 'decimal type '),
+    LookupType(3, 'BOOLEAN', 'yes/no'),
+    LookupType(4, 'STRING', 'string type'),
+    LookupType(5, 'LONG', 'long integer')
+]
 FIELD_TYPE_DICT = {item.id: item.name for item in FIELD_TYPE}
 
-RULE_SEVERITY = []
-RULE_SEVERITY.append(LookupType(1, 'warning', 'warning'))
-RULE_SEVERITY.append(LookupType(2, 'fatal', 'fatal error'))
+RULE_SEVERITY = [
+    LookupType(1, 'warning', 'warning'),
+    LookupType(2, 'fatal', 'fatal error')
+]
 RULE_SEVERITY_DICT = {item.id: item.name for item in RULE_SEVERITY}

--- a/dataactcore/scripts/setupErrorDB.py
+++ b/dataactcore/scripts/setupErrorDB.py
@@ -1,38 +1,29 @@
+from dataactbroker.app import createApp
+from dataactcore.interfaces.db import GlobalDB
+from dataactcore.models import lookups
 from dataactcore.models.errorModels import FileStatus, ErrorType
-from dataactcore.interfaces.db import databaseSession
 
 
 def setupErrorDB():
     """Create error tables from model metadata."""
-    with databaseSession() as sess:
+
+    with createApp().app_context():
+        sess = GlobalDB.db().session
         insertCodes(sess)
         sess.commit()
+
 
 def insertCodes(sess):
     """Insert static data."""
 
     # insert file status types
-
-    statusList = [(1, 'complete', 'File has been processed'),
-        (2, 'header_error', 'The file has errors in the header row'),
-        (3, 'unknown_error', 'An unknown error has occurred with this file'),
-        (4, 'single_row_error', 'CSV file must have a header row and at least one record'),
-        (5, 'job_error', 'Error occurred in job manager'),
-        (6, 'incomplete', 'File has not yet been validated')]
-    for s in statusList:
-        status = FileStatus(file_status_id=s[0], name=s[1], description=s[2])
+    for s in lookups.FILE_STATUS:
+        status = FileStatus(file_status_id=s.id, name=s.name, description=s.desc)
         sess.merge(status)
 
     # insert error types
-    errorList = [(1, 'type_error', 'The value provided was of the wrong type'),
-        (2, 'required_error', 'A required value was not provided'),
-        (3, 'value_error', 'The value provided was invalid'),
-        (4, 'read_error', 'Could not parse this record correctly'),
-        (5, 'write_error', 'Could not write this record into the staging table'),
-        (6, 'rule_failed', 'A rule failed for this value'),
-        (7, 'length_error', 'Value was longer than allowed length')]
-    for e in errorList:
-        error = ErrorType(error_type_id=e[0], name=e[1], description=e[2])
+    for e in lookups.ERROR_TYPE:
+        error = ErrorType(error_type_id=e.id, name=e.name, description=e.desc)
         sess.merge(error)
 
 

--- a/dataactcore/scripts/setupJobTrackerDB.py
+++ b/dataactcore/scripts/setupJobTrackerDB.py
@@ -1,10 +1,13 @@
+from dataactbroker.app import createApp
+from dataactcore.interfaces.db import GlobalDB
+from dataactcore.models import lookups
 from dataactcore.models.jobModels import JobStatus, JobType, FileType, PublishStatus
-from dataactcore.interfaces.db import databaseSession
 
 
 def setupJobTrackerDB():
     """Create job tracker tables from model metadata."""
-    with databaseSession() as sess:
+    with createApp().app_context():
+        sess = GlobalDB.db().session
         insertCodes(sess)
         sess.commit()
 
@@ -14,41 +17,23 @@ def insertCodes(sess):
 
     # TODO: define these codes as enums in the data model?
     # insert status types
-    statusList = [(1, 'waiting', 'check dependency table'),
-        (2, 'ready', 'can be assigned'),
-        (3, 'running', 'job is currently in progress'),
-        (4, 'finished', 'job is complete'),
-        (5, 'invalid', 'job is invalid'),
-        (6, 'failed', 'job failed to complete')]
-    for s in statusList:
-        status = JobStatus(job_status_id=s[0], name=s[1], description=s[2])
+    for s in lookups.JOB_STATUS:
+        status = JobStatus(job_status_id=s.id, name=s.name, description=s.desc)
         sess.merge(status)
 
-    typeList = [(1, 'file_upload', 'file must be uploaded to S3'),
-        (2, 'csv_record_validation', 'do record level validation and add to staging table'),
-        (3, 'db_transfer', 'information must be moved from production DB to staging table'),
-        (4, 'validation', 'new information must be validated'),
-        (5, 'external_validation', 'new information must be validated against external sources')]
-    for t in typeList:
-        thisType = JobType(job_type_id=t[0],name=t[1], description=t[2])
+    # insert job types
+    for t in lookups.JOB_TYPE:
+        thisType = JobType(job_type_id=t.id, name=t.name, description=t.desc)
         sess.merge(thisType)
 
-    publishStatusList = [(1, 'unpublished', 'Has not yet been moved to data store'),
-        (2,'published', 'Has been moved to data store'),
-        (3, 'updated', 'Submission was updated after being published')]
-    for ps in publishStatusList:
-        status = PublishStatus(publish_status_id=ps[0], name=ps[1], description=ps[2])
+    # insert publish status
+    for ps in lookups.PUBLISH_STATUS:
+        status = PublishStatus(publish_status_id=ps.id, name=ps.name, description=ps.desc)
         sess.merge(status)
 
-    fileTypeList = [(1, 'appropriations', '', 'A'),
-        (2,'program_activity', '', 'B'),
-        (3, 'award_financial', '', 'C'),
-        (4, 'award', '', 'D2'),
-        (5, 'award_procurement', '', 'D1'),
-        (6, "awardee_attributes", "", 'E'),
-        (7, "sub_award", "", 'F')]
-    for ft in fileTypeList:
-        fileType = FileType(file_type_id=ft[0], name=ft[1], description=ft[2], letter_name=ft[3])
+    # insert file types
+    for ft in lookups.FILE_TYPE:
+        fileType = FileType(file_type_id=ft.id, name=ft.name, description=ft.desc, letter_name=ft.letter)
         sess.merge(fileType)
 
 

--- a/dataactcore/scripts/setupUserDB.py
+++ b/dataactcore/scripts/setupUserDB.py
@@ -1,34 +1,27 @@
+from dataactbroker.app import createApp
+from dataactcore.interfaces.db import GlobalDB
+from dataactcore.models import lookups
 from dataactcore.models.userModel import PermissionType, UserStatus
-from dataactcore.interfaces.db import databaseSession
 
 
 def setupUserDB():
     """Create user tables from model metadata."""
-    with databaseSession() as sess:
+    with createApp().app_context():
+        sess = GlobalDB.db().session
         insertCodes(sess)
         sess.commit()
 
 
 def insertCodes(sess):
     """Create job tracker tables from model metadata."""
-    # TODO: define these codes as enums in the data model?
     # insert status types
-    statusList = [(1, 'awaiting_confirmation', 'User has entered email but not confirmed'),
-        (2, 'email_confirmed', 'User email has been confirmed'),
-        (3, 'awaiting_approval', 'User has registered their information and is waiting for approval'),
-        (4, 'approved', 'User has been approved'),
-        (5, 'denied', 'User registration was denied')]
-    for s in statusList:
-        status = UserStatus(user_status_id=s[0], name=s[1], description=s[2])
+    for s in lookups.USER_STATUS:
+        status = UserStatus(user_status_id=s.id, name=s.name, description=s.desc)
         sess.merge(status)
 
     # insert user permission types
-    typeList = [
-        (0, 'agency_user', 'This user is allowed to upload data to be validated'),
-        (1, 'website_admin', 'This user is allowed to manage user accounts'),
-        (2, 'agency_admin', 'This user is allowed to manage user accounts within their agency')]
-    for t in typeList:
-        type = PermissionType(permission_type_id=t[0], name=t[1], description=t[2])
+    for t in lookups.PERMISSION_TYPE:
+        type = PermissionType(permission_type_id=t.id, name=t.name, description=t.desc)
         sess.merge(type)
 
 

--- a/dataactcore/scripts/setupValidationDB.py
+++ b/dataactcore/scripts/setupValidationDB.py
@@ -17,7 +17,7 @@ def insertCodes(sess):
     # insert validation file type
     # todo: combine this table with file_types table
     for f in lookups.FILE_TYPE:
-        if f.order:
+        if f.order is not None:
             fileType = FileTypeValidation(file_id=f.id, name=f.name, description=f.desc, file_order=f.order)
             sess.merge(fileType)
 

--- a/dataactcore/scripts/setupValidationDB.py
+++ b/dataactcore/scripts/setupValidationDB.py
@@ -1,47 +1,34 @@
+from dataactbroker.app import createApp
+from dataactcore.interfaces.db import GlobalDB
+from dataactcore.models import lookups
 from dataactcore.models.validationModels import FileTypeValidation, FieldType, RuleSeverity
-from dataactcore.interfaces.db import databaseSession
 
 
 def setupValidationDB():
     """Create validation tables from model metadata and do initial inserts."""
-    with databaseSession() as sess:
+    with createApp().app_context():
+        sess = GlobalDB.db().session
         insertCodes(sess)
         sess.commit()
 
+
 def insertCodes(sess):
     """Insert static data."""
-
-    # insert file types
-    fileTypeList = [
-        (1, 'appropriations', 'appropriations file',1),
-        (2, 'program_activity','program activity and object class file',2),
-        (3, 'award_financial', 'award_financial file',3),
-        (4, 'award', 'award file',4),
-        (5, 'award_procurement', 'award procurement file', 5)
-        ]
-    for f in fileTypeList:
-        fileType = FileTypeValidation(file_id=f[0], name=f[1], description=f[2], file_order = f[3])
-        sess.merge(fileType)
+    # insert validation file type
+    # todo: combine this table with file_types table
+    for f in lookups.FILE_TYPE:
+        if f.order:
+            fileType = FileTypeValidation(file_id=f.id, name=f.name, description=f.desc, file_order=f.order)
+            sess.merge(fileType)
 
     # insert field types
-    fieldTypeList = [
-        (1, 'INT', 'integer type'),
-        (2, 'DECIMAL', 'decimal type '),
-        (3, 'BOOLEAN', 'yes/no'),
-        (4, 'STRING', 'string type'),
-        (5, 'LONG', 'long integer')
-        ]
-    for f in fieldTypeList:
-        fieldType = FieldType(field_type_id=f[0], name=f[1], description=f[2])
+    for f in lookups.FIELD_TYPE:
+        fieldType = FieldType(field_type_id=f.id, name=f.name, description=f.desc)
         sess.merge(fieldType)
 
     # insert rule severity
-    severityList = [
-        (1, 'warning', 'warning'),
-        (2, 'fatal', 'fatal error')
-    ]
-    for s in severityList:
-        ruleSeverity = RuleSeverity(rule_severity_id=s[0], name=s[1], description=s[2])
+    for s in lookups.RULE_SEVERITY:
+        ruleSeverity = RuleSeverity(rule_severity_id=s.id, name=s.name, description=s.desc)
         sess.merge(ruleSeverity)
 
 


### PR DESCRIPTION
This is a companion to PR #303. Based on suggestions from @jworcestBAH and @cmc333333, this moves our static helper values out of the database load scripts and into a common file. This way, they can be referenced as needed, which will:

1. make the in-application surrogate lookups more straightforward than the current methods in `baseInterface.py`
2. still allow the database load scripts to populate the helper tables

If this looks good, I'll cleanup up the integration test code in #303 to use these constants instead of dynamically populating dictionaries from the database (see: https://github.com/fedspendingtransparency/data-act-broker-backend/pull/303#discussion_r81338600)
