### PR TITLE
Remove db interfaces from the fileTests suite of integration tests

### DIFF
--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -77,8 +77,7 @@ def sumNumberOfErrorsForJobList(submissionId, errorType='fatal'):
 def checkNumberOfErrorsByJobId(jobId, errorType='fatal'):
     """Get the number of errors for a specified job and severity."""
     sess = GlobalDB.db().session
-    errors = sess.query(
-        func.sum(ErrorMetadata.occurrences)).join(
-        ErrorMetadata.severity).filter(
-        ErrorMetadata.job_id == jobId, RuleSeverity.name == errorType).scalar()
+    errors = sess.query(func.sum(ErrorMetadata.occurrences)).\
+        join(ErrorMetadata.severity).\
+        filter(ErrorMetadata.job_id == jobId, RuleSeverity.name == errorType).scalar()
     return errors or 0

--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -68,7 +68,6 @@ def sumNumberOfErrorsForJobList(submissionId, errorType='fatal'):
             job.number_of_errors = jobErrors
         elif errorType == 'warning':
             job.number_of_warnings = jobErrors
-        sess.add(job)
         errorSum += jobErrors
     sess.commit()
     return errorSum

--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -79,4 +79,8 @@ def checkNumberOfErrorsByJobId(jobId, errorType='fatal'):
     errors = sess.query(func.sum(ErrorMetadata.occurrences)).\
         join(ErrorMetadata.severity).\
         filter(ErrorMetadata.job_id == jobId, RuleSeverity.name == errorType).scalar()
+    # error_metadata table tallies total errors by job/file/field/error type. jobs that
+    # don't have errors or warnings won't be in the table at all. thus, if the above query
+    # returns an empty value that means the job didn't have any errors that matched
+    # the specified severity type, so return 0
     return errors or 0

--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -1,6 +1,11 @@
 import uuid
 
+from sqlalchemy.sql import func
+
+from dataactcore.models.errorModels import ErrorMetadata
+from dataactcore.models.jobModels import Job, Submission
 from dataactcore.models.userModel import User, UserStatus
+from dataactcore.models.validationModels import RuleSeverity
 from dataactcore.interfaces.db import GlobalDB
 
 
@@ -41,3 +46,39 @@ def getPasswordHash(password, bcrypt):
     hash = bcrypt.generate_password_hash(password + salt, HASH_ROUNDS)
     password_hash = hash.decode("utf-8")
     return salt, password_hash
+
+
+def populateSubmissionErrorInfo(submissionId):
+    """Set number of errors and warnings for submission."""
+    sess = GlobalDB.db().session
+    submission = sess.query(Submission).filter(Submission.submission_id == submissionId).one()
+    submission.number_of_errors = sumNumberOfErrorsForJobList(submissionId)
+    submission.number_of_warnings = sumNumberOfErrorsForJobList(submissionId, errorType='warning')
+    sess.commit()
+
+
+def sumNumberOfErrorsForJobList(submissionId, errorType='fatal'):
+    """Add number of errors for all jobs in list."""
+    sess = GlobalDB.db().session
+    errorSum = 0
+    jobs = sess.query(Job).filter(Job.submission_id == submissionId).all()
+    for job in jobs:
+        jobErrors = checkNumberOfErrorsByJobId(job.job_id, errorType)
+        if errorType == 'fatal':
+            job.number_of_errors = jobErrors
+        elif errorType == 'warning':
+            job.number_of_warnings = jobErrors
+        sess.add(job)
+        errorSum += jobErrors
+    sess.commit()
+    return errorSum
+
+
+def checkNumberOfErrorsByJobId(jobId, errorType='fatal'):
+    """Get the number of errors for a specified job and severity."""
+    sess = GlobalDB.db().session
+    errors = sess.query(
+        func.sum(ErrorMetadata.occurrences)).join(
+        ErrorMetadata.severity).filter(
+        ErrorMetadata.job_id == jobId, RuleSeverity.name == errorType).scalar()
+    return errors or 0

--- a/dataactcore/models/errorInterface.py
+++ b/dataactcore/models/errorInterface.py
@@ -57,14 +57,7 @@ class ErrorInterface(BaseInterface):
         return self.runUniqueQuery(query,"No file for that job ID", "Multiple files have been associated with that job ID").file_status.name
 
     def checkNumberOfErrorsByJobId(self, jobId, valDb, errorType = "fatal"):
-        """ Get the total number of errors for a specified job
-
-        Args:
-            jobId: job to get errors for
-
-        Returns:
-            Number of errors for specified job
-        """
+        """Deprecated: moved to function_bag.py."""
         queryResult = self.session.query(ErrorMetadata).filter(ErrorMetadata.job_id == jobId).all()
         numErrors = 0
         for result in queryResult:
@@ -85,7 +78,7 @@ class ErrorInterface(BaseInterface):
         self.session.commit()
 
     def sumNumberOfErrorsForJobList(self,jobIdList, valDb, errorType = "fatal"):
-        """ Add number of errors for all jobs in list """
+        """Deprecated: moved to function_bag.py."""
         errorSum = 0
         for jobId in jobIdList:
             jobErrors = self.checkNumberOfErrorsByJobId(jobId, valDb, errorType)

--- a/dataactcore/models/jobTrackerInterface.py
+++ b/dataactcore/models/jobTrackerInterface.py
@@ -305,7 +305,7 @@ class JobTrackerInterface(BaseInterface):
         return self.runUniqueQuery(query, "No submission with that ID", "Multiple submissions with that ID")
 
     def populateSubmissionErrorInfo(self, submissionId):
-        """ Set number of errors and warnings for submission """
+        """Deprecated: moved to function_bag.py."""
         submission = self.getSubmissionById(submissionId)
         # TODO find where interfaces is set as an instance variable which overrides the static variable, fix that and then remove this line
         self.interfaces = BaseInterface.interfaces
@@ -314,14 +314,7 @@ class JobTrackerInterface(BaseInterface):
         self.session.commit()
 
     def setJobNumberOfErrors(self, jobId, numberOfErrors, errorType):
-        """ Label nuber of errors or warnings for specified job
-
-        Args:
-            jobId: Job to set number for
-            numberOfErrors: Number to be set
-            errorType: Type of error to set, can be either 'fatal' or 'warning'
-
-        """
+        """Deprecated: moved to sumNumberOfErrorsForJobList in function_bag.py."""
         job = self.getJobById(jobId)
         if errorType == "fatal":
             job.number_of_errors = numberOfErrors

--- a/tests/integration/baseTestAPI.py
+++ b/tests/integration/baseTestAPI.py
@@ -167,6 +167,7 @@ class BaseTestAPI(unittest.TestCase):
         cls.fileStatusDict = lookups.FILE_STATUS_DICT
         cls.ruleSeverityDict = lookups.RULE_SEVERITY_DICT
         cls.errorTypeDict = lookups.ERROR_TYPE_DICT
+        cls.publishStatusDict = lookups.PUBLISH_STATUS_DICT
 
         # set up info needed by the individual test classes
         cls.test_users = test_users

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -13,7 +13,6 @@ from dataactcore.models.userModel import User
 from dataactcore.config import CONFIG_BROKER
 from dataactbroker.app import createApp
 from dataactbroker.handlers.jobHandler import JobHandler
-from dataactbroker.handlers.interfaceHolder import InterfaceHolder
 from shutil import copy
 
 class FileTests(BaseTestAPI):
@@ -71,8 +70,6 @@ class FileTests(BaseTestAPI):
         super(FileTests, self).setUp()
         self.login_other_user(
             self.test_users["submission_email"], self.user_password)
-        # Here to repopulate BaseInterface.interfaces after login route clears them
-        InterfaceHolder()
 
     def call_file_submission(self):
         """Call the broker file submission route."""

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -140,7 +140,7 @@ class FileTests(BaseTestAPI):
             submission = sess.query(Submission).filter(Submission.submission_id == submissionId).one()
         self.assertEqual(submission.user_id, self.submission_user_id)
         # Check that new submission is unpublished
-        self.assertEqual(submission.publish_status_id, self.interfaces.jobDb.getPublishStatusId("unpublished"))
+        self.assertEqual(submission.publish_status_id, self.publishStatusDict['unpublished'])
 
         # Call upload complete route
         finalizeResponse = self.check_upload_complete(
@@ -553,7 +553,6 @@ class FileTests(BaseTestAPI):
         sess.commit()
         return fs.file_id
 
-    #@staticmethod
     @classmethod
     def insertRowLevelError(cls, sess, job_id):
         """Insert one error into error database."""


### PR DESCRIPTION
This PR completes the removal of the old db interfaces from the fileTests.py suite of integration tests.

The changes might make more sense when reviewing commit by commit.
