### PR TITLE
Remove db interfaces from validator tests - part 3 and final

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -19,7 +19,7 @@ from dataactcore.models.jobModels import FileGenerationTask, JobDependency, Job
 from dataactcore.utils.cloudLogger import CloudLogger
 from dataactcore.utils.jobQueue import generate_e_file, generate_f_file
 from dataactcore.utils.jsonResponse import JsonResponse
-from dataactcore.utils.report import getReportPath
+from dataactcore.utils.report import getReportPath, getCrossReportName, getCrossWarningReportName
 from dataactcore.utils.requestDictionary import RequestDictionary
 from dataactcore.utils.responseException import ResponseException
 from dataactcore.utils.statusCode import StatusCode
@@ -111,9 +111,9 @@ class FileHandler:
                         continue
                     # Retrieve filename
                     if isWarning:
-                        reportName = self.interfaces.errorDb.getCrossWarningReportName(submissionId, source, target)
+                        reportName = getCrossWarningReportName(submissionId, source, target)
                     else:
-                        reportName = self.interfaces.errorDb.getCrossReportName(submissionId, source, target)
+                        reportName = getCrossReportName(submissionId, source, target)
                     # If not local, get a signed URL
                     if self.isLocal:
                         reportPath = os.path.join(self.serverPath,reportName)

--- a/dataactcore/models/errorInterface.py
+++ b/dataactcore/models/errorInterface.py
@@ -121,14 +121,6 @@ class ErrorInterface(BaseInterface):
         self.session.query(File).filter(File.job_id == jobId).delete()
         self.session.commit()
 
-    def getCrossReportName(self, submissionId, sourceFile, targetFile):
-        """ Create error report filename based on source and target file """
-        return "submission_{}_cross_{}_{}.csv".format(submissionId, sourceFile, targetFile)
-
-    def getCrossWarningReportName(self, submissionId, sourceFile, targetFile):
-        """ Create error report filename based on source and target file """
-        return "submission_{}_cross_warning_{}_{}.csv".format(submissionId, sourceFile, targetFile)
-
     def createFileIfNeeded(self, jobId, filename = None):
         """ Return the existing file object if it exists, or create a new one """
         try:

--- a/dataactcore/models/validationInterface.py
+++ b/dataactcore/models/validationInterface.py
@@ -261,14 +261,6 @@ class ValidationInterface(BaseInterface):
         return self.runUniqueQuery(column, "No field found with that name for that file type",
                                    "Multiple fields with that name for that file type")
 
-    def populateFile(self, column):
-        """ Populate file object in the ORM for the specified FileColumn object
-
-        Arguments:
-            column - FileColumn object to get File object for
-        """
-        column.file = self.session.query(FileTypeValidation).filter(FileTypeValidation.file_id == column.file_id)[0]
-
     def getFieldTypeById(self, id):
         """ Return name of field type based on id """
         return self.getNameFromDict(FieldType, "TYPE_DICT", "name", id, "field_type_id")

--- a/dataactcore/utils/report.py
+++ b/dataactcore/utils/report.py
@@ -5,3 +5,13 @@ def getReportPath(job, reportType):
     """
     path = 'submission_{}_{}_{}_report.csv'.format(job.submission_id, job.file_type.name, reportType)
     return path
+
+
+def getCrossReportName(submissionId, sourceFile, targetFile):
+    """Return filename for a cross file error report."""
+    return "submission_{}_cross_{}_{}.csv".format(submissionId, sourceFile, targetFile)
+
+
+def getCrossWarningReportName(submissionId, sourceFile, targetFile):
+    """Return filename for a cross file warning report."""
+    return "submission_{}_cross_warning_{}_{}.csv".format(submissionId, sourceFile, targetFile)

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -10,7 +10,7 @@ from dataactcore.models.baseInterface import BaseInterface
 from dataactcore.models.jobModels import Job
 from dataactcore.utils.responseException import ResponseException
 from dataactcore.utils.jsonResponse import JsonResponse
-from dataactcore.utils.report import getReportPath
+from dataactcore.utils.report import getReportPath, getCrossWarningReportName, getCrossReportName
 from dataactcore.utils.statusCode import StatusCode
 from dataactcore.utils.requestDictionary import RequestDictionary
 from dataactcore.utils.cloudLogger import CloudLogger
@@ -523,8 +523,8 @@ class ValidationManager:
             # send comboRules to validator.crossValidate sql
             failures = Validator.crossValidateSql(comboRules.all(),submissionId)
             # get error file name
-            reportFilename = self.getFileName(interfaces.errorDb.getCrossReportName(submissionId, row.first_file_name, row.second_file_name))
-            warningReportFilename = self.getFileName(interfaces.errorDb.getCrossWarningReportName(submissionId, row.first_file_name, row.second_file_name))
+            reportFilename = self.getFileName(getCrossReportName(submissionId, row.first_file_name, row.second_file_name))
+            warningReportFilename = self.getFileName(getCrossWarningReportName(submissionId, row.first_file_name, row.second_file_name))
 
             # loop through failures to create the error report
             with self.getWriter(regionName, bucketName, reportFilename, self.crossFileReportHeaders) as writer, \

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -390,7 +390,7 @@ class ValidationManager:
                         passedValidations = True
                         valid = True
                     else:
-                        passedValidations, failures, valid = Validator.validate(record,csvSchema,fileType,interfaces)
+                        passedValidations, failures, valid = Validator.validate(record, csvSchema)
                     if valid:
                         skipRow = self.writeToStaging(record, jobId, submissionId, passedValidations, interfaces, writer, rowNumber, fileType)
                         if skipRow:

--- a/dataactvalidator/validation_handlers/validator.py
+++ b/dataactvalidator/validation_handlers/validator.py
@@ -49,7 +49,7 @@ class Validator(object):
         return failures
 
     @classmethod
-    def validate(cls,record,csvSchema, fileType, interfaces):
+    def validate(cls, record, csvSchema):
         """
         Run initial set of single file validation:
         - check if required fields are present
@@ -59,7 +59,6 @@ class Validator(object):
         Args:
         record -- dict representation of a single record of data
         csvSchema -- dict of schema for the current file.
-        fileType -- name of file type to check against
 
         Returns:
         Tuple of three values:

--- a/tests/integration/baseTestValidator.py
+++ b/tests/integration/baseTestValidator.py
@@ -10,7 +10,6 @@ from boto.s3.key import Key
 from dataactvalidator.app import createApp
 from dataactcore.interfaces.function_bag import checkNumberOfErrorsByJobId
 from dataactcore.interfaces.db import GlobalDB
-from dataactcore.interfaces.interfaceHolder import InterfaceHolder
 from dataactcore.models.lookups import JOB_STATUS_DICT, FILE_STATUS_DICT
 from dataactcore.scripts.databaseSetup import dropDatabase
 from dataactcore.scripts.setupJobTrackerDB import setupJobTrackerDB
@@ -18,7 +17,6 @@ from dataactcore.scripts.setupErrorDB import setupErrorDB
 from dataactcore.scripts.setupValidationDB import setupValidationDB
 from dataactcore.utils.report import getReportPath
 from dataactcore.aws.s3UrlHandler import s3UrlHandler
-from dataactcore.models.baseInterface import BaseInterface
 from dataactcore.models.jobModels import Job, Submission
 from dataactcore.models.errorModels import File
 from dataactcore.config import CONFIG_SERVICES, CONFIG_BROKER, CONFIG_DB
@@ -64,24 +62,14 @@ class BaseTestValidator(unittest.TestCase):
         # drop and re-create test validation db
         setupValidationDB()
 
-        cls.interfaces = InterfaceHolder()
-        cls.jobTracker = cls.interfaces.jobDb
-        cls.stagingDb = cls.interfaces.stagingDb
-        cls.errorInterface = cls.interfaces.errorDb
-        cls.validationDb = cls.interfaces.validationDb
         cls.userId = 1
         # constants to use for default submission start and end dates
         cls.SUBMISSION_START_DEFAULT = datetime(2015, 10, 1)
         cls.SUBMISSION_END_DEFAULT = datetime(2015, 10, 31)
 
-    def setUp(self):
-        """Set up broker unit tests."""
-        self.interfaces = InterfaceHolder()
-
     @classmethod
     def tearDownClass(cls):
         """Tear down class-level resources."""
-        cls.interfaces.close()
         dropDatabase(CONFIG_DB['db_name'])
 
     def tearDown(self):

--- a/tests/integration/fileTypeTests.py
+++ b/tests/integration/fileTypeTests.py
@@ -100,31 +100,28 @@ class FileTypeTests(BaseTestValidator):
                 print('{}: {}'.format(job_type, job_id))
 
             # Load fields and rules
-            FileTypeTests.load_definitions(cls.interfaces, force_tas_load)
+            FileTypeTests.load_definitions(sess, force_tas_load)
 
             cls.jobDict = jobDict
 
     @staticmethod
-    def load_definitions(interfaces, force_tas_load, ruleList = None):
+    def load_definitions(sess, force_tas_load, ruleList=None):
         """Load file definitions."""
-        SchemaLoader.loadAllFromPath(os.path.join(CONFIG_BROKER["path"],"dataactvalidator","config"))
+        SchemaLoader.loadAllFromPath(os.path.join(CONFIG_BROKER["path"], "dataactvalidator", "config"))
         SQLLoader.loadSql("sqlRules.csv")
 
         if ruleList is not None:
             # If rule list provided, drop all other rules
-            to_delete = interfaces.validationDb.session.query(RuleSql).filter(not_(
-                RuleSql.rule_label.in_(ruleList)))
-            for rule in to_delete:
-                interfaces.validationDb.session.delete(rule)
-            interfaces.validationDb.session.commit()
+            sess.query(RuleSql).filter(not_(
+                RuleSql.rule_label.in_(ruleList))).delete(synchronize_session='fetch')
+            sess.commit()
 
         # Load domain values tables
         loadDomainValues(
             os.path.join(CONFIG_BROKER["path"],"dataactvalidator","config"),
             os.path.join(CONFIG_BROKER["path"], "tests", "integration", "data"),
             os.path.join(CONFIG_BROKER["path"], "tests", "integration", "data", "program_activity.csv"))
-        if (interfaces.validationDb.session.query(TASLookup).count() == 0
-                or force_tas_load):
+        if sess.query(TASLookup).count() == 0 or force_tas_load:
             # TAS table is empty, load it
             loadTas(tasFile=os.path.join(CONFIG_BROKER["path"], "tests", "integration", "data", "all_tas_betc.csv"))
 

--- a/tests/integration/mixedFileTests.py
+++ b/tests/integration/mixedFileTests.py
@@ -190,7 +190,7 @@ class MixedFileTests(BaseTestValidator):
                 print('{}: {}'.format(job_type, job_id))
 
             # Load fields and rules
-            FileTypeTests.load_definitions(cls.interfaces, force_tas_load, cls.RULES_TO_APPLY)
+            FileTypeTests.load_definitions(sess, force_tas_load, cls.RULES_TO_APPLY)
 
             cls.jobDict = jobDict
 

--- a/tests/integration/mixedFileTests.py
+++ b/tests/integration/mixedFileTests.py
@@ -4,9 +4,11 @@ import unittest
 
 from dataactcore.aws.s3UrlHandler import s3UrlHandler
 from dataactcore.interfaces.db import GlobalDB
+from dataactcore.interfaces.function_bag import checkNumberOfErrorsByJobId
 from dataactcore.models.jobModels import Job
 from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
 from dataactcore.models.stagingModels import AwardFinancial
+from dataactcore.utils.report import getCrossReportName, getCrossWarningReportName
 from dataactvalidator.app import createApp
 from tests.integration.baseTestValidator import BaseTestValidator
 from tests.integration.fileTypeTests import FileTypeTests
@@ -280,21 +282,24 @@ class MixedFileTests(BaseTestValidator):
         crossFileResponse = self.validateJob(crossId)
         self.assertEqual(crossFileResponse.status_code, 200, msg=str(crossFileResponse.json))
 
-        # Check number of cross file validation errors in DB for this job
-        self.assertEqual(self.interfaces.errorDb.checkNumberOfErrorsByJobId(crossId, self.interfaces.validationDb, "fatal"), 0)
-        self.assertEqual(self.interfaces.errorDb.checkNumberOfErrorsByJobId(crossId, self.interfaces.validationDb, "warning"), 5)
-        self.assertEqual(self.interfaces.jobDb.getJobStatus(crossId), JOB_STATUS_DICT['finished'])
+        with createApp().app_context():
+            sess = GlobalDB.db().session
 
-        # Check that cross file validation report exists and is the right size
-        jobTracker = self.interfaces.jobDb
+            job = sess.query(Job).filter(Job.job_id == crossId).one()
 
-        submissionId = jobTracker.getSubmissionId(crossId)
-        sizePathPairs = [
-            (89, self.interfaces.errorDb.getCrossReportName(submissionId, "appropriations", "program_activity")),
-            (89, self.interfaces.errorDb.getCrossReportName(submissionId, "award_financial", "award")),
-            (2348, self.interfaces.errorDb.getCrossWarningReportName(submissionId, "appropriations", "program_activity")),
-            (424, self.interfaces.errorDb.getCrossWarningReportName(submissionId, "award_financial", "award")),
-        ]
+            # Check number of cross file validation errors in DB for this job
+            self.assertEqual(checkNumberOfErrorsByJobId(crossId, "fatal"), 0)
+            self.assertEqual(checkNumberOfErrorsByJobId(crossId, "warning"), 5)
+            self.assertEqual(job.job_status_id, JOB_STATUS_DICT['finished'])
+
+            # Check that cross file validation report exists and is the right size
+            submissionId = job.submission_id
+            sizePathPairs = [
+                (89, getCrossReportName(submissionId, "appropriations", "program_activity")),
+                (89, getCrossReportName(submissionId, "award_financial", "award")),
+                (2348, getCrossWarningReportName(submissionId, "appropriations", "program_activity")),
+                (424, getCrossWarningReportName(submissionId, "award_financial", "award")),
+            ]
 
         for size, path in sizePathPairs:
             if self.local:

--- a/tests/integration/validatorTests.py
+++ b/tests/integration/validatorTests.py
@@ -122,7 +122,6 @@ class ValidatorTests(BaseTestValidator):
     def test_schema_optional_field(self):
         """Test optional fields."""
         schema = self.schema
-        interfaces = self.interfaces
         record = {
             "test1": "hello",
             "test2": "1.0",
@@ -130,18 +129,15 @@ class ValidatorTests(BaseTestValidator):
             "test4": "1",
             "test5": "1",
          }
-        self.assertTrue(Validator.validate(
-            record, schema, "award_financial", interfaces)[0])
+        self.assertTrue(Validator.validate(record, schema))
         record["test5"] = ""
-        self.assertTrue(Validator.validate(
-            record, schema, "award_financial", interfaces)[0])
+        self.assertTrue(Validator.validate(record, schema))
         record["test5"] = "s"
-        self.assertFalse(Validator.validate(
-            record, schema, "award_financial", interfaces)[0])
+        self.assertTrue(Validator.validate(record, schema))
         record["test5"] = ""
         record["test3"] = ""
-        self.assertFalse(Validator.validate(
-            record, schema, "award_financial", interfaces)[0])
+        self.assertTrue(Validator.validate(record, schema))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/validatorTests.py
+++ b/tests/integration/validatorTests.py
@@ -1,4 +1,5 @@
 import unittest
+
 from dataactcore.models.validationModels import FieldType, FileColumn
 from dataactvalidator.validation_handlers.validator import Validator
 from tests.integration.baseTestValidator import BaseTestValidator
@@ -39,7 +40,6 @@ class ValidatorTests(BaseTestValidator):
         column1.required = True
         column1.field_type = stringType
         column1.file_id = 1
-        cls.interfaces.validationDb.populateFile(column1)
 
         column2 = FileColumn()
         column2.file_column_id = 2
@@ -47,7 +47,6 @@ class ValidatorTests(BaseTestValidator):
         column2.required = True
         column2.field_type = floatType
         column2.file_id = 1
-        cls.interfaces.validationDb.populateFile(column2)
 
         column3 = FileColumn()
         column3.file_column_id = 3
@@ -55,7 +54,6 @@ class ValidatorTests(BaseTestValidator):
         column3.required = True
         column3.field_type = booleanType
         column3.file_id = 1
-        cls.interfaces.validationDb.populateFile(column3)
 
         column4 = FileColumn()
         column4.file_column_id = 3
@@ -63,7 +61,6 @@ class ValidatorTests(BaseTestValidator):
         column4.required = True
         column4.field_type = intType
         column4.file_id = 1
-        cls.interfaces.validationDb.populateFile(column4)
 
         column5 = FileColumn()
         column5.file_column_id = 3
@@ -71,7 +68,6 @@ class ValidatorTests(BaseTestValidator):
         column5.required = False
         column5.field_type = intType
         column5.file_id = 1
-        cls.interfaces.validationDb.populateFile(column5)
 
         column6 = FileColumn()
         column6.file_column_id = 6
@@ -79,7 +75,6 @@ class ValidatorTests(BaseTestValidator):
         column6.required = False
         column6.field_type = stringType
         column6.file_id = 1
-        cls.interfaces.validationDb.populateFile(column6)
 
         column7 = FileColumn()
         column7.file_column_id = 7
@@ -87,7 +82,6 @@ class ValidatorTests(BaseTestValidator):
         column7.required = False
         column7.field_type = longType
         column7.file_id = 1
-        cls.interfaces.validationDb.populateFile(column7)
 
         cls.schema = {
             "test1": column1,


### PR DESCRIPTION
This PR removes the remaining database interfaces from the validator unit tests.