### PR TITLE
Change TAS file format

### DIFF
--- a/dataactvalidator/scripts/loadTas.py
+++ b/dataactvalidator/scripts/loadTas.py
@@ -13,6 +13,36 @@ from dataactvalidator.scripts.loaderUtils import LoaderUtils
 logger = logging.getLogger(__name__)
 
 
+def cleanTas(csvPath):
+    """Read a CSV into a dataframe, then use a configured `cleanData` and
+    return the results"""
+    data = pd.read_csv(csvPath, dtype=str)
+    data = LoaderUtils.cleanData(
+        data,
+        TASLookup,
+        {"ata": "allocation_transfer_agency",
+         "aid": "agency_identifier",
+         "a": "availability_type_code",
+         "bpoa": "beginning_period_of_availability",
+         "epoa": "ending_period_of_availability",
+         "main": "main_account_code",
+         "sub": "sub_account_code",
+         },
+        {"allocation_transfer_agency": {"pad_to_length": 3, "keep_null": True},
+         "agency_identifier": {"pad_to_length": 3},
+         # Account for " " cells
+         "availability_type_code": {"pad_to_length": 0, "keep_null": True},
+         "beginning_period_of_availability": {"pad_to_length": 0,
+                                              "keep_null": True},
+         "ending_period_of_availability": {"pad_to_length": 0,
+                                           "keep_null": True},
+         "main_account_code": {"pad_to_length": 4},
+         "sub_account_code": {"pad_to_length": 3},
+         }
+    )
+    return data.where(pd.notnull(data), None)
+
+
 def loadTas(tasFile=None):
     """Load TAS file into broker database. """
     # read TAS file to dataframe, to make sure all is well
@@ -23,7 +53,6 @@ def loadTas(tasFile=None):
             "dataactvalidator",
             "config",
             "all_tas_betc.csv")
-    data = pd.read_csv(tasFile, dtype=str)
 
     with createApp().app_context():
         sess = GlobalDB.db().session
@@ -33,30 +62,7 @@ def loadTas(tasFile=None):
         # delete existing recs?
         sess.query(TASLookup).delete()
 
-        # clean TAS file
-        data = LoaderUtils.cleanData(
-            data,
-            TASLookup,
-            {"ata": "allocation_transfer_agency",
-             "aid": "agency_identifier",
-             "a": "availability_type_code",
-             "bpoa": "beginning_period_of_availability",
-             "epoa": "ending_period_of_availability",
-             "main": "main_account_code",
-             "sub": "sub_account_code",
-             },
-            {"allocation_transfer_agency": {"pad_to_length": 3,
-                                            "keep_null": True},
-             "agency_identifier": {"pad_to_length": 3},
-             "main_account_code": {"pad_to_length": 4},
-             "sub_account_code": {"pad_to_length": 3},
-             }
-        )
-        # Account for single-character strings
-        for field in ('beginning_period_of_availability',
-                      'ending_period_of_availability'):
-            data[field] = data[field].str.strip()
-        data = data.where(pd.notnull(data), None)
+        data = cleanTas(tasFile)
 
         # instead of using the pandas to_sql dataframe method like
         # some of the other domain load processes, iterate through
@@ -65,7 +71,6 @@ def loadTas(tasFile=None):
         # ultimately decided not to go outside the unit of work
         # for the sake of a performance gain)
         for index, row in data.iterrows():
-            row = {k: v or None for k, v in row.items()}
             sess.add(TASLookup(**row))
 
         sess.commit()

--- a/dataactvalidator/scripts/loadTas.py
+++ b/dataactvalidator/scripts/loadTas.py
@@ -15,8 +15,6 @@ logger = logging.getLogger(__name__)
 
 def loadTas(tasFile=None):
     """Load TAS file into broker database. """
-    model = TASLookup
-
     # read TAS file to dataframe, to make sure all is well
     # with the file before firing up a db transaction
     if not tasFile:
@@ -25,26 +23,20 @@ def loadTas(tasFile=None):
             "dataactvalidator",
             "config",
             "all_tas_betc.csv")
-    data = pd.read_csv(tasFile, dtype=str,
-                       # something in the file format skews the columns/names
-                       # so grab the tas-related columns by index. not going
-                       # to do a deep investigation here, since we're about
-                       # to switch to a new source for the TAS file
-                        usecols=[1, 2, 3, 4, 5, 6, 7])
-    # we only need one row for each unique TAS
-    data.drop_duplicates(inplace=True)
+    data = pd.read_csv(tasFile, dtype=str)
 
     with createApp().app_context():
         sess = GlobalDB.db().session
 
         # delete existing data
-        # TODO: when we swtich to loading TAS from CARS, do we sill want to delete existing recs?
-        sess.query(model).delete()
+        # TODO: when we switch to loading TAS from CARS, do we sill want to
+        # delete existing recs?
+        sess.query(TASLookup).delete()
 
         # clean TAS file
         data = LoaderUtils.cleanData(
             data,
-            model,
+            TASLookup,
             {"ata": "allocation_transfer_agency",
              "aid": "agency_identifier",
              "a": "availability_type_code",
@@ -53,11 +45,12 @@ def loadTas(tasFile=None):
              "main": "main_account_code",
              "sub": "sub_account_code",
              },
-            {"allocation_transfer_agency": {"pad_to_length": 3, "keep_null": True},
-                 "agency_identifier": {"pad_to_length": 3},
-                 "main_account_code": {"pad_to_length": 4},
-                 "sub_account_code": {"pad_to_length": 3},
-            }
+            {"allocation_transfer_agency": {"pad_to_length": 3,
+                                            "keep_null": True},
+             "agency_identifier": {"pad_to_length": 3},
+             "main_account_code": {"pad_to_length": 4},
+             "sub_account_code": {"pad_to_length": 3},
+             }
         )
         data = data.where((pd.notnull(data)), None)
 
@@ -72,8 +65,9 @@ def loadTas(tasFile=None):
 
         sess.commit()
         logger.info('{} records inserted to {}'.format(
-            len(data.index), model.__tablename__))
+            len(data.index), TASLookup.__tablename__))
         return data
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
     loadTas()

--- a/dataactvalidator/scripts/loadTas.py
+++ b/dataactvalidator/scripts/loadTas.py
@@ -52,7 +52,11 @@ def loadTas(tasFile=None):
              "sub_account_code": {"pad_to_length": 3},
              }
         )
-        data = data.where((pd.notnull(data)), None)
+        # Account for single-character strings
+        for field in ('beginning_period_of_availability',
+                      'ending_period_of_availability'):
+            data[field] = data[field].str.strip()
+        data = data.where(pd.notnull(data), None)
 
         # instead of using the pandas to_sql dataframe method like
         # some of the other domain load processes, iterate through
@@ -61,6 +65,7 @@ def loadTas(tasFile=None):
         # ultimately decided not to go outside the unit of work
         # for the sake of a performance gain)
         for index, row in data.iterrows():
+            row = {k: v or None for k, v in row.items()}
             sess.add(TASLookup(**row))
 
         sess.commit()

--- a/tests/integration/data/all_tas_betc.csv
+++ b/tests/integration/data/all_tas_betc.csv
@@ -1,655 +1,655 @@
-SP,ATA,AID,BPOA,EPOA,A,MAIN,SUB,Admin Bureau,GWA TAS,GWA TAS Name,Agency Name,BETC,BETC Name,Effective Date,Suspend Date,IsCredit,Adj BETC,STAR TAS,STAR Dept Reg,STAR Dept Xfer,STAR Main Acct,Txn Type,Acct Type,Acct Type Description,Fund Type,Fund Type Description
-,,19,2016,2016,,113,0,,19160113,"Diplomatic and Consular Programs, State",Department of State,AP,Regular/Supplemental,10/1/2015,,1,,19160113,19,,113,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AP,Regular/Supplemental,10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APADV,Appropriation -  Advance,10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APBGT,Appropriation -  Budget,10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APCRREF,Appropriation - Credit Reform,10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APIND,Appropriation - Indefinite,10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/1987,,0,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APLIMIND,Appropriation - Limited Indefinite,10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APOTH,Appropriation - Other,10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APROP,Appropriation Warrants,10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERC,"Appropriation Transfer, increase",10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERD,"Appropriation Transfer, Decrease",10/1/1987,,0,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERC,"Balance Transfer , Increase",10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERD,"Balance Transfer , Decrease",10/1/1987,,0,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/1987,,1,COLLAJ,28X0406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/1987,,0,,28X0406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,CXFERD,Transfers to General Fund Receipt Accounts,10/1/1987,,0,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/1987,,0,DISBAJ,28X0406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/1987,,1,,28X0406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRC,Reappropriation,10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRD,Reappropriation,10/1/1987,,0,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RS,Appropriation -  Rescission(s),10/1/1987,,1,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SW,"Surplus, Unavailable for Restoration",10/1/1987,,0,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/1987,,0,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,,,X,406,0,,28X0406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/1987,,0,,28X0406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AP,Regular/Supplemental,10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APADV,Appropriation -  Advance,10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APBGT,Appropriation -  Budget,10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APCRREF,Appropriation - Credit Reform,10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APIND,Appropriation - Indefinite,10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2009,,0,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APLIMIND,Appropriation - Limited Indefinite,10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APOTH,Appropriation - Other,10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APROP,Appropriation Warrants,10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERC,"Appropriation Transfer, increase",10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERD,"Appropriation Transfer, Decrease",10/1/2009,,0,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERC,"Balance Transfer , Increase",10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERD,"Balance Transfer , Decrease",10/1/2009,,0,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/2009,,1,COLLAJ,2810/110406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/2009,,0,,2810/110406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2009,,0,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/2009,,0,DISBAJ,2810/110406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/2009,,1,,2810/110406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRC,Reappropriation,10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRD,Reappropriation,10/1/2009,,0,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RS,Appropriation -  Rescission(s),10/1/2009,,1,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SW,"Surplus, Unavailable for Restoration",10/1/2009,,0,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2009,,0,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2010,2011,,406,0,,2810/110406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2009,,0,,2810/110406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AP,Regular/Supplemental,10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APADV,Appropriation -  Advance,10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APBGT,Appropriation -  Budget,10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APCRREF,Appropriation - Credit Reform,10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APIND,Appropriation - Indefinite,10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2011,,0,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APLIMIND,Appropriation - Limited Indefinite,10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APOTH,Appropriation - Other,10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APROP,Appropriation Warrants,10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERC,"Appropriation Transfer, increase",10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERD,"Appropriation Transfer, Decrease",10/1/2011,,0,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERC,"Balance Transfer , Increase",10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERD,"Balance Transfer , Decrease",10/1/2011,,0,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/2011,,1,COLLAJ,2812/130406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/2011,,0,,2812/130406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2011,,0,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/2011,,0,DISBAJ,2812/130406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/2011,,1,,2812/130406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRC,Reappropriation,10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRD,Reappropriation,10/1/2011,,0,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RS,Appropriation -  Rescission(s),10/1/2011,,1,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SW,"Surplus, Unavailable for Restoration",10/1/2011,,0,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2011,,0,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2012,2013,,406,0,,2812/130406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2011,,0,,2812/130406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AP,Regular/Supplemental,10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APADV,Appropriation -  Advance,10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APBGT,Appropriation -  Budget,10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APCRREF,Appropriation - Credit Reform,10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APIND,Appropriation - Indefinite,10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2012,,0,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APLIMIND,Appropriation - Limited Indefinite,10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APOTH,Appropriation - Other,10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APROP,Appropriation Warrants,10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERC,"Appropriation Transfer, increase",10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERD,"Appropriation Transfer, Decrease",10/1/2012,,0,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERC,"Balance Transfer , Increase",10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERD,"Balance Transfer , Decrease",10/1/2012,,0,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/2012,,1,COLLAJ,2813/140406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/2012,,0,,2813/140406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2012,,0,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/2012,,0,DISBAJ,2813/140406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/2012,,1,,2813/140406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRC,Reappropriation,10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRD,Reappropriation,10/1/2012,,0,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RS,Appropriation -  Rescission(s),10/1/2012,,1,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SW,"Surplus, Unavailable for Restoration",10/1/2012,,0,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2012,,0,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2013,2014,,406,0,,2813/140406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2012,,0,,2813/140406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AP,Regular/Supplemental,10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APADV,Appropriation -  Advance,10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APBGT,Appropriation -  Budget,10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APCRREF,Appropriation - Credit Reform,10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APIND,Appropriation - Indefinite,10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2013,,0,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APLIMIND,Appropriation - Limited Indefinite,10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APOTH,Appropriation - Other,10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APROP,Appropriation Warrants,10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERC,"Appropriation Transfer, increase",10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERD,"Appropriation Transfer, Decrease",10/1/2013,,0,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERC,"Balance Transfer , Increase",10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERD,"Balance Transfer , Decrease",10/1/2013,,0,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/2013,,1,COLLAJ,2814/150406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/2013,,0,,2814/150406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2013,,0,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/2013,,0,DISBAJ,2814/150406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/2013,,1,,2814/150406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRC,Reappropriation,10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRD,Reappropriation,10/1/2013,,0,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RS,Appropriation -  Rescission(s),10/1/2013,,1,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SW,"Surplus, Unavailable for Restoration",10/1/2013,,0,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2013,,0,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2014,2015,,406,0,,2814/150406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2013,,0,,2814/150406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AP,Regular/Supplemental,10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APADV,Appropriation -  Advance,10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APBGT,Appropriation -  Budget,10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APCRREF,Appropriation - Credit Reform,10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APIND,Appropriation - Indefinite,10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2014,,0,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APLIMIND,Appropriation - Limited Indefinite,10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APOTH,Appropriation - Other,10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APROP,Appropriation Warrants,10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERC,"Appropriation Transfer, increase",10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERD,"Appropriation Transfer, Decrease",10/1/2014,,0,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERC,"Balance Transfer , Increase",10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERD,"Balance Transfer , Decrease",10/1/2014,,0,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/2014,,1,COLLAJ,2815/160406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/2014,,0,,2815/160406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2014,,0,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/2014,,0,DISBAJ,2815/160406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/2014,,1,,2815/160406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRC,Reappropriation,10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRD,Reappropriation,10/1/2014,,0,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RS,Appropriation -  Rescission(s),10/1/2014,,1,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SW,"Surplus, Unavailable for Restoration",10/1/2014,,0,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2014,,0,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2016,,406,0,,2815/160406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2014,,0,,2815/160406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AP,Regular/Supplemental,10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APADV,Appropriation -  Advance,10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APBGT,Appropriation -  Budget,10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APCRREF,Appropriation - Credit Reform,10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APIND,Appropriation - Indefinite,10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2014,,0,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APLIMIND,Appropriation - Limited Indefinite,10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APOTH,Appropriation - Other,10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APROP,Appropriation Warrants,10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERC,"Appropriation Transfer, increase",10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERD,"Appropriation Transfer, Decrease",10/1/2014,,0,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERC,"Balance Transfer , Increase",10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERD,"Balance Transfer , Decrease",10/1/2014,,0,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/2014,,1,COLLAJ,2815/170406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/2014,,0,,2815/170406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2014,,0,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/2014,,0,DISBAJ,2815/170406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/2014,,1,,2815/170406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRC,Reappropriation,10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRD,Reappropriation,10/1/2014,,0,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RS,Appropriation -  Rescission(s),10/1/2014,,1,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SW,"Surplus, Unavailable for Restoration",10/1/2014,,0,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2014,,0,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2015,2017,,406,0,,2815/170406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2014,,0,,2815/170406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AP,Regular/Supplemental,10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APADV,Appropriation -  Advance,10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APBGT,Appropriation -  Budget,10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APCRREF,Appropriation - Credit Reform,10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APIND,Appropriation - Indefinite,10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2015,,0,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APLIMIND,Appropriation - Limited Indefinite,10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APOTH,Appropriation - Other,10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,APROP,Appropriation Warrants,10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERC,"Appropriation Transfer, increase",10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,AXFERD,"Appropriation Transfer, Decrease",10/1/2015,,0,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERC,"Balance Transfer , Increase",10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,BXFERD,"Balance Transfer , Decrease",10/1/2015,,0,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/2015,,1,COLLAJ,2816/180406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/2015,,0,,2816/180406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2015,,0,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/2015,,0,DISBAJ,2816/180406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/2015,,1,,2816/180406,28,,406,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRC,Reappropriation,10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RAPPRD,Reappropriation,10/1/2015,,0,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,RS,Appropriation -  Rescission(s),10/1/2015,,1,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SW,"Surplus, Unavailable for Restoration",10/1/2015,,0,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2015,,0,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,,28,2016,2018,,406,0,,2816/180406,"Supplemental Security Income Program, Social Security Administration",Social Security Administration,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2015,,0,,2816/180406,28,,406,,EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,APCRREF,Appropriation - Credit Reform,5/15/2002,,1,,69-13X2050.5,69,13,2050,,EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",5/15/2002,,1,,69-13X2050.5,69,13,2050,,EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",5/15/2002,,0,,69-13X2050.5,69,13,2050,,EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,APLIMIND,Appropriation - Limited Indefinite,5/15/2002,,1,,69-13X2050.5,69,13,2050,,EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,AXFERC,"Appropriation Transfer, increase",5/15/2002,,1,,69-13X2050.5,69,13,2050,,EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,AXFERD,"Appropriation Transfer, Decrease",5/15/2002,,0,,69-13X2050.5,69,13,2050,,EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,BXFERC,"Balance Transfer , Increase",5/15/2002,,1,,69-13X2050.5,69,13,2050,,EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,BXFERD,"Balance Transfer , Decrease",5/15/2002,,0,,69-13X2050.5,69,13,2050,,EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,COLL,Offsetting Collection,5/15/2002,,1,COLLAJ,69-13X2050.5,69,13,2050,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,COLLAJ,Adjustment to Offsetting Collections,5/15/2002,,0,,69-13X2050.5,69,13,2050,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,DISB,Gross Disbursement,5/15/2002,,0,DISBAJ,69-13X2050.5,69,13,2050,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,DISBAJ,Adjustment to Gross Disbursements,5/15/2002,,1,,69-13X2050.5,69,13,2050,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",5/15/2002,,0,,69-13X2050.5,69,13,2050,,EXPND,Expenditure,GF,General Fund
-,69,13,,,X,2050,5,5,69-13X2050.5,Federal Highway Administration,Department of Transportation,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",5/15/2002,,0,,69-13X2050.5,69,13,2050,,EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,APCRREF,Appropriation - Credit Reform,8/15/2002,,1,,69-21X2065.5,69,21,2065,,EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",8/15/2002,,1,,69-21X2065.5,69,21,2065,,EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",8/15/2002,,0,,69-21X2065.5,69,21,2065,,EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,APLIMIND,Appropriation - Limited Indefinite,8/15/2002,,1,,69-21X2065.5,69,21,2065,,EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,AXFERC,"Appropriation Transfer, increase",8/15/2002,,1,,69-21X2065.5,69,21,2065,,EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,AXFERD,"Appropriation Transfer, Decrease",8/15/2002,,0,,69-21X2065.5,69,21,2065,,EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,BXFERC,"Balance Transfer , Increase",8/15/2002,,1,,69-21X2065.5,69,21,2065,,EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,BXFERD,"Balance Transfer , Decrease",8/15/2002,,0,,69-21X2065.5,69,21,2065,,EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,COLL,Offsetting Collection,8/15/2002,,1,COLLAJ,69-21X2065.5,69,21,2065,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,COLLAJ,Adjustment to Offsetting Collections,8/15/2002,,0,,69-21X2065.5,69,21,2065,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,DISB,Gross Disbursement,8/15/2002,,0,DISBAJ,69-21X2065.5,69,21,2065,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,DISBAJ,Adjustment to Gross Disbursements,8/15/2002,,1,,69-21X2065.5,69,21,2065,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",8/15/2002,,0,,69-21X2065.5,69,21,2065,,EXPND,Expenditure,GF,General Fund
-,69,21,,,X,2065,5,5,69-21X2065.5,Federal Highway Administration,Department of Transportation,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",8/15/2002,,0,,69-21X2065.5,69,21,2065,,EXPND,Expenditure,GF,General Fund
-,28,28,,,X,8007,0,,28-28X8007,Social Security Administration,Social Security Administration,AXFERC,"Appropriation Transfer, increase",10/1/1987,,1,,28-28X8007,28,28,8007,,EXPND,Expenditure,TF,Trust Funds
-,28,28,,,X,8007,0,,28-28X8007,Social Security Administration,Social Security Administration,AXFERD,"Appropriation Transfer, Decrease",10/1/1987,,0,,28-28X8007,28,28,8007,,EXPND,Expenditure,TF,Trust Funds
-,28,28,,,X,8007,0,,28-28X8007,Social Security Administration,Social Security Administration,BXFERC,"Balance Transfer , Increase",10/1/1987,,1,,28-28X8007,28,28,8007,,EXPND,Expenditure,TF,Trust Funds
-,28,28,,,X,8007,0,,28-28X8007,Social Security Administration,Social Security Administration,BXFERD,"Balance Transfer , Decrease",10/1/1987,,0,,28-28X8007,28,28,8007,,EXPND,Expenditure,TF,Trust Funds
-,28,28,,,X,8007,0,,28-28X8007,Social Security Administration,Social Security Administration,COLL,Offsetting Collection,10/1/1987,,1,COLLAJ,28-28X8007,28,28,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-,28,28,,,X,8007,0,,28-28X8007,Social Security Administration,Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/1987,,0,,28-28X8007,28,28,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-,28,28,,,X,8007,0,,28-28X8007,Social Security Administration,Social Security Administration,DISB,Gross Disbursement,10/1/1987,,0,DISBAJ,28-28X8007,28,28,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-,28,28,,,X,8007,0,,28-28X8007,Social Security Administration,Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/1987,,1,,28-28X8007,28,28,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-,28,28,,,X,8007,0,,28-28X8007,Social Security Administration,Social Security Administration,SRRTYEDR,"Surplus, YR End Closing Cancellation Special and Non-Revolving Trust fund (Unavail Receipts), Debit",10/1/1987,,0,,28-28X8007,28,28,8007,,EXPND,Expenditure,TF,Trust Funds
-15,,28,,,X,8007,0,,(15)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,REFTAXC,"Refund of Taxes, Credit",10/1/1987,,1,REFTXCAJ,(15)28X8007,28,,8007,"Collection, IPC, NTDOPMT",EXPND,Expenditure,TF,Trust Funds
-15,,28,,,X,8007,0,,(15)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,REFTAXD,"Refund of Taxes, Debit",10/1/1987,,0,REFTXDAJ,(15)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-15,,28,,,X,8007,0,,(15)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,REFTXCAJ,Adjustment To Refund of Taxes,10/1/1987,,0,,(15)28X8007,28,,8007,"Collection, IPC, NTDOPMT",EXPND,Expenditure,TF,Trust Funds
-15,,28,,,X,8007,0,,(15)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,REFTXDAJ,Adjustment To Refund of Taxes,10/1/1987,,1,,(15)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-16,,28,,,X,8007,0,,(16)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/1987,,1,COLLAJ,(16)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-16,,28,,,X,8007,0,,(16)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/1987,,0,,(16)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-16,,28,,,X,8007,0,,(16)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/1987,,0,DISBAJ,(16)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-16,,28,,,X,8007,0,,(16)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/1987,,1,,(16)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-30,,28,,,X,8007,0,,(30)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/1987,,1,COLLAJ,(30)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-30,,28,,,X,8007,0,,(30)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/1987,,0,,(30)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-30,,28,,,X,8007,0,,(30)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/1987,,0,DISBAJ,(30)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-30,,28,,,X,8007,0,,(30)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/1987,,1,,(30)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-31,,28,,,X,8007,0,,(31)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/1987,,1,COLLAJ,(31)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-31,,28,,,X,8007,0,,(31)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/1987,,0,,(31)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-31,,28,,,X,8007,0,,(31)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/1987,,0,DISBAJ,(31)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-31,,28,,,X,8007,0,,(31)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/1987,,1,,(31)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-32,,28,,,X,8007,0,,(32)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/1987,,1,COLLAJ,(32)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-32,,28,,,X,8007,0,,(32)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/1987,,0,,(32)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-32,,28,,,X,8007,0,,(32)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/1987,,0,DISBAJ,(32)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-32,,28,,,X,8007,0,,(32)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/1987,,1,,(32)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-33,,28,,,X,8007,0,,(33)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/1987,,1,COLLAJ,(33)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-33,,28,,,X,8007,0,,(33)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/1987,,0,,(33)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-33,,28,,,X,8007,0,,(33)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/1987,,0,DISBAJ,(33)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-33,,28,,,X,8007,0,,(33)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/1987,,1,,(33)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-34,,28,,,X,8007,0,,(34)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLL,Offsetting Collection,10/1/1987,,1,COLLAJ,(34)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-34,,28,,,X,8007,0,,(34)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,COLLAJ,Adjustment to Offsetting Collections,10/1/1987,,0,,(34)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-34,,28,,,X,8007,0,,(34)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/1987,,0,DISBAJ,(34)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-34,,28,,,X,8007,0,,(34)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/1987,,1,,(34)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-61,,28,,,X,8007,0,,(61)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/1/1987,,0,DISBAJ,(61)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-61,,28,,,X,8007,0,,(61)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/1/1987,,1,,(61)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-63,,28,,,X,8007,0,,(63)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,2/15/1995,,0,DISBAJ,(63)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-63,,28,,,X,8007,0,,(63)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,2/15/1995,,1,,(63)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-66,,28,,,X,8007,0,,(66)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISB,Gross Disbursement,10/15/1987,,0,DISBAJ,(66)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-66,,28,,,X,8007,0,,(66)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,DISBAJ,Adjustment to Gross Disbursements,10/15/1987,,1,,(66)28X8007,28,,8007,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,APOTH,Appropriation - Other,10/1/1987,,1,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,APROP,Appropriation Warrants,10/1/1987,,1,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,APSPCEXP,Special and Trust Fund Unappropriated,10/1/1987,,1,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,AXFERC,"Appropriation Transfer, increase",10/1/1987,,1,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,AXFERD,"Appropriation Transfer, Decrease",10/1/1987,,0,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,BXFERC,"Balance Transfer , Increase",10/1/1987,,1,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,BXFERD,"Balance Transfer , Decrease",10/1/1987,,0,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,CXFERD,Transfers to General Fund Receipt Accounts,10/1/1987,,0,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,INVINFAJ,Debit Adjustment of Investment In US Treasury Securities,10/1/1987,,0,,(88)28X8007,28,,8007,IPC,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,INVTSAJ,Credit Adjustment of Investment In US Treasury Securities,10/1/1987,,1,,(88)28X8007,28,,8007,IPC,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,INVTSEC,"Investment In US Treasury Securities, Debit",10/1/1987,,0,INVTSAJ,(88)28X8007,28,,8007,IPC,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,INVTSINF,"Investment In US Treasury Securities, Credit",10/1/1987,,1,INVINFAJ,(88)28X8007,28,,8007,IPC,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,RAPPRC,Reappropriation,10/1/1987,,1,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,RAPPRD,Reappropriation,10/1/1987,,0,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,REDTSAJ,Debit Adjustment of Redemption (Sale) Of US Treasury Securities,10/1/1987,,0,,(98)28X8007,28,,8007,IPC,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,REDTSD,"Redemption (Sale) Of US Treasury Securities, Debit",10/1/1987,,0,REDTSDAJ,(98)28X8007,28,,8007,IPC,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,REDTSDAJ,Credit Adjustment of Redemption (Sale) Of US Treasury Securities,10/1/1987,,1,,(98)28X8007,28,,8007,IPC,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,REDTSEC,"Redemption (Sale) Of US Treasury Securities, Credit",10/1/1987,,1,REDTSAJ,(98)28X8007,28,,8007,IPC,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,RS,Appropriation -  Rescission(s),10/1/1987,,1,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,SRRCTEXP,"Surplus, Special or Trust Available for Restoration",10/1/1987,,0,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,SRRTYEDR,"Surplus, YR End Closing Cancellation Special and Non-Revolving Trust fund (Unavail Receipts), Debit",10/1/1987,,0,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,SW,"Surplus, Unavailable for Restoration",10/1/1987,,0,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/1987,,0,,28X8007,28,,8007,,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,UNRLDIAJ,"Unrealized Discount, Debit",10/15/1987,,0,,(75)28X8007,28,,8007,IPC,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,0,,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",Social Security Administration,UNRLDISC,"Unrealized Discount, Credit",10/15/1987,,1,UNRLDIAJ,(75)28X8007,28,,8007,IPC,EXPND,Expenditure,TF,Trust Funds
-,,28,,,X,8007,1,,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.1,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,1,,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.1,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,1,,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.1,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,1,,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.1,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,1,,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,FTAD,"FICA Tax Adjustment, Decrease",10/1/1987,,0,,28X8007.1,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,1,,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.1,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,1,,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.1,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,2,,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.2,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,2,,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.2,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,2,,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.2,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,2,,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.2,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,2,,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.2,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,2,,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.2,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,3,,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.3,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,3,,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.3,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,3,,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.3,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,3,,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.3,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,3,,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.3,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,3,,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.3,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,5,,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.5,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,5,,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.5,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,5,,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.5,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,5,,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.5,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,5,,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.5,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,5,,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.5,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,6,,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.6,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,6,,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.6,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,6,,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.6,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,6,,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.6,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,6,,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.6,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,6,,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.6,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,9,,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/15/1993,,0,COLAVINC,28X8007.9,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,9,,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/15/1993,,1,,28X8007.9,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,9,,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/15/1993,,0,,28X8007.9,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,9,,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/15/1993,,1,COLAVRAJ,28X8007.9,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,9,,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/15/1993,,0,,28X8007.9,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,9,,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/15/1993,,1,,28X8007.9,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,10,,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.10,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,10,,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.10,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,10,,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.10,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,10,,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.10,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,10,,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.10,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,10,,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.10,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,11,,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.11,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,11,,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.11,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,11,,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.11,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,11,,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.11,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,11,,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.11,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,11,,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.11,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,12,,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.12,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,12,,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.12,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,12,,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.12,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,12,,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.12,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,12,,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",Social Security Administration,FTAC,"FICA Tax Adjustment, Increase",10/1/1987,,1,,28X8007.12,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,12,,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.12,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,12,,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.12,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,14,,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",2/15/1995,,0,COLAVINC,28X8007.14,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,14,,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,2/15/1995,,1,,28X8007.14,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,14,,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),2/15/1995,,0,,28X8007.14,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,14,,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",2/15/1995,,1,COLAVRAJ,28X8007.14,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,14,,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,2/15/1995,,0,,28X8007.14,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,14,,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,2/15/1995,,1,,28X8007.14,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,16,,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.16,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,16,,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.16,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,16,,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.16,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,16,,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.16,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,16,,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.16,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,16,,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.16,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,18,,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/2010,,0,COLAVINC,28X8007.18,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,18,,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/2010,,1,,28X8007.18,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,18,,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/2010,,0,,28X8007.18,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,18,,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/2010,,1,COLAVRAJ,28X8007.18,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,18,,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/2010,,0,,28X8007.18,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,18,,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/2010,,1,,28X8007.18,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,22,,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.22,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,22,,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.22,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,22,,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.22,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,22,,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.22,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,22,,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.22,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,22,,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.22,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,24,,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",8/15/2006,,0,COLAVINC,28X8007.24,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,24,,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,8/15/2006,,1,,28X8007.24,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,24,,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),8/15/2006,,0,,28X8007.24,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,24,,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",8/15/2006,,1,COLAVRAJ,28X8007.24,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,24,,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,8/15/2006,,0,,28X8007.24,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,24,,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,8/15/2006,,1,,28X8007.24,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,25,,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",8/15/2006,,0,COLAVINC,28X8007.25,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,25,,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,8/15/2006,,1,,28X8007.25,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,25,,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),8/15/2006,,0,,28X8007.25,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,25,,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",8/15/2006,,1,COLAVRAJ,28X8007.25,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,25,,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,8/15/2006,,0,,28X8007.25,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,25,,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,8/15/2006,,1,,28X8007.25,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,27,,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.27,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,27,,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.27,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,27,,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.27,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,27,,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.27,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,27,,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.27,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,27,,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.27,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,28,,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",4/15/2005,,0,COLAVINC,28X8007.28,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,28,,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,4/15/2005,,1,,28X8007.28,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,28,,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),4/15/2005,,0,,28X8007.28,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,28,,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",4/15/2005,,1,COLAVRAJ,28X8007.28,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,28,,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,4/15/2005,,0,,28X8007.28,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,28,,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,4/15/2005,,1,,28X8007.28,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,29,,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.29,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,29,,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.29,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,29,,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.29,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,29,,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.29,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,29,,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.29,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,29,,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.29,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,31,,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",2/15/2000,,0,COLAVINC,28X8007.31,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,31,,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,2/15/2000,,1,,28X8007.31,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,31,,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),2/15/2000,,0,,28X8007.31,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,31,,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",2/15/2000,,1,COLAVRAJ,28X8007.31,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,31,,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,2/15/2000,,0,,28X8007.31,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,31,,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,2/15/2000,,1,,28X8007.31,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,42,,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",10/1/1987,,0,COLAVINC,28X8007.42,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,42,,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,10/1/1987,,1,,28X8007.42,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,42,,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),10/1/1987,,0,,28X8007.42,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,42,,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",10/1/1987,,1,COLAVRAJ,28X8007.42,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,42,,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,10/1/1987,,0,,28X8007.42,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,42,,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,10/1/1987,,1,,28X8007.42,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,65,,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVDEC,"Collection to an Available Receipt Account, Debit",5/1/1989,,0,COLAVINC,28X8007.65,28,,8007,IPC,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,65,,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVINC,Credit Adjustment of Collection to an Available Receipt Account,5/1/1989,,1,,28X8007.65,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,65,,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRAJ,Debit Adjustment of Collection for an Available Receipt Account (current fiscal year),5/1/1989,,0,,28X8007.65,28,,8007,"Collection, IPC, NTDOPMT, Payment",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,65,,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",Social Security Administration,COLAVRCT,"Collection To An Available Receipt Account, Credit (current fiscal year)",5/1/1989,,1,COLAVRAJ,28X8007.65,28,,8007,"Collection, IPC, NTDOPMT",AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,65,,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",Social Security Administration,WJVFFAR,Warrant Journal Voucher - Transfer From Trust Fund,5/1/1989,,0,,28X8007.65,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,28,,,X,8007,65,,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",Social Security Administration,WJVTTAR,Warrant Journal Voucher - Transfer To Trust Fund,5/1/1989,,1,,28X8007.65,28,,8007,,AVAIL,Available Receipt,TF,Trust Funds
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,AP,Regular/Supplemental,10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,APADV,Appropriation -  Advance,10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,APBGT,Appropriation -  Budget,10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,APCRREF,Appropriation - Credit Reform,10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,APIND,Appropriation - Indefinite,10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/1987,,0,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,APLIMIND,Appropriation - Limited Indefinite,10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,APOTH,Appropriation - Other,10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,APROP,Appropriation Warrants,10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERC,"Appropriation Transfer, increase",10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERD,"Appropriation Transfer, Decrease",10/1/1987,,0,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERC,"Balance Transfer , Increase",10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERD,"Balance Transfer , Decrease",10/1/1987,,0,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLL,Offsetting Collection,10/1/1987,,1,COLLAJ,49X0100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLLAJ,Adjustment to Offsetting Collections,10/1/1987,,0,,49X0100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,CXFERD,Transfers to General Fund Receipt Accounts,10/1/1987,,0,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISB,Gross Disbursement,10/1/1987,,0,DISBAJ,49X0100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISBAJ,Adjustment to Gross Disbursements,10/1/1987,,1,,49X0100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,FHOTXC,"Funds Held Outside The Treasury, Credit",10/1/1987,,1,FHOTXCAJ,(41)49X0100,49,,100,"Collection, IPC, NTDOPMT",EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,FHOTXCAJ,"Adjustment to Funds Held Outside The Treasury, Credit",10/1/1987,,0,,(41)49X0100,49,,100,"Collection, IPC, NTDOPMT",EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,FHOTXD,"Funds Held Outside The Treasury, Debit",10/1/1987,,0,FHOTXDAJ,(41)49X0100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,FHOTXDAJ,"Adjustment to Funds Held Outside The Treasury, Debit",10/1/1987,,1,,(41)49X0100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRC,Reappropriation,10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRD,Reappropriation,10/1/1987,,0,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,RS,Appropriation -  Rescission(s),10/1/1987,,1,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,SW,"Surplus, Unavailable for Restoration",10/1/1987,,0,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/1987,,0,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,,,X,100,0,0,49X0100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/1987,,0,,49X0100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,AP,Regular/Supplemental,10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,APADV,Appropriation -  Advance,10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,APBGT,Appropriation -  Budget,10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,APCRREF,Appropriation - Credit Reform,10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,APIND,Appropriation - Indefinite,10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2009,,0,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,APLIMIND,Appropriation - Limited Indefinite,10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,APOTH,Appropriation - Other,10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,APROP,Appropriation Warrants,10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERC,"Appropriation Transfer, increase",10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERD,"Appropriation Transfer, Decrease",10/1/2009,,0,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERC,"Balance Transfer , Increase",10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERD,"Balance Transfer , Decrease",10/1/2009,,0,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLL,Offsetting Collection,10/1/2009,,1,COLLAJ,4910/110100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLLAJ,Adjustment to Offsetting Collections,10/1/2009,,0,,4910/110100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2009,,0,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISB,Gross Disbursement,10/1/2009,,0,DISBAJ,4910/110100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISBAJ,Adjustment to Gross Disbursements,10/1/2009,,1,,4910/110100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRC,Reappropriation,10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRD,Reappropriation,10/1/2009,,0,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,RS,Appropriation -  Rescission(s),10/1/2009,,1,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,SW,"Surplus, Unavailable for Restoration",10/1/2009,,0,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2009,,0,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2010,2011,,100,0,0,4910/110100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2009,,0,,4910/110100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,AP,Regular/Supplemental,10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,APADV,Appropriation -  Advance,10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,APBGT,Appropriation -  Budget,10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,APCRREF,Appropriation - Credit Reform,10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,APIND,Appropriation - Indefinite,10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2010,,0,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,APLIMIND,Appropriation - Limited Indefinite,10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,APOTH,Appropriation - Other,10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,APROP,Appropriation Warrants,10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERC,"Appropriation Transfer, increase",10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERD,"Appropriation Transfer, Decrease",10/1/2010,,0,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERC,"Balance Transfer , Increase",10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERD,"Balance Transfer , Decrease",10/1/2010,,0,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLL,Offsetting Collection,10/1/2010,,1,COLLAJ,4911/120100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLLAJ,Adjustment to Offsetting Collections,10/1/2010,,0,,4911/120100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2010,,0,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISB,Gross Disbursement,10/1/2010,,0,DISBAJ,4911/120100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISBAJ,Adjustment to Gross Disbursements,10/1/2010,,1,,4911/120100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRC,Reappropriation,10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRD,Reappropriation,10/1/2010,,0,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,RS,Appropriation -  Rescission(s),10/1/2010,,1,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,SW,"Surplus, Unavailable for Restoration",10/1/2010,,0,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2010,,0,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2011,2012,,100,0,0,4911/120100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2010,,0,,4911/120100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,AP,Regular/Supplemental,10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,APADV,Appropriation -  Advance,10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,APBGT,Appropriation -  Budget,10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,APCRREF,Appropriation - Credit Reform,10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,APIND,Appropriation - Indefinite,10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2011,,0,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,APLIMIND,Appropriation - Limited Indefinite,10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,APOTH,Appropriation - Other,10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,APROP,Appropriation Warrants,10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERC,"Appropriation Transfer, increase",10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERD,"Appropriation Transfer, Decrease",10/1/2011,,0,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERC,"Balance Transfer , Increase",10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERD,"Balance Transfer , Decrease",10/1/2011,,0,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLL,Offsetting Collection,10/1/2011,,1,COLLAJ,4912/130100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLLAJ,Adjustment to Offsetting Collections,10/1/2011,,0,,4912/130100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2011,,0,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISB,Gross Disbursement,10/1/2011,,0,DISBAJ,4912/130100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISBAJ,Adjustment to Gross Disbursements,10/1/2011,,1,,4912/130100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRC,Reappropriation,10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRD,Reappropriation,10/1/2011,,0,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,RS,Appropriation -  Rescission(s),10/1/2011,,1,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,SW,"Surplus, Unavailable for Restoration",10/1/2011,,0,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2011,,0,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2012,2013,,100,0,0,4912/130100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2011,,0,,4912/130100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,AP,Regular/Supplemental,10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,APADV,Appropriation -  Advance,10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,APBGT,Appropriation -  Budget,10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,APCRREF,Appropriation - Credit Reform,10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,APIND,Appropriation - Indefinite,10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2012,,0,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,APLIMIND,Appropriation - Limited Indefinite,10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,APOTH,Appropriation - Other,10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,APROP,Appropriation Warrants,10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERC,"Appropriation Transfer, increase",10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERD,"Appropriation Transfer, Decrease",10/1/2012,,0,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERC,"Balance Transfer , Increase",10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERD,"Balance Transfer , Decrease",10/1/2012,,0,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLL,Offsetting Collection,10/1/2012,,1,COLLAJ,4913/140100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLLAJ,Adjustment to Offsetting Collections,10/1/2012,,0,,4913/140100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2012,,0,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISB,Gross Disbursement,10/1/2012,,0,DISBAJ,4913/140100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISBAJ,Adjustment to Gross Disbursements,10/1/2012,,1,,4913/140100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRC,Reappropriation,10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRD,Reappropriation,10/1/2012,,0,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,RS,Appropriation -  Rescission(s),10/1/2012,,1,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,SW,"Surplus, Unavailable for Restoration",10/1/2012,,0,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2012,,0,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2013,2014,,100,0,0,4913/140100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2012,,0,,4913/140100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,AP,Regular/Supplemental,10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,APADV,Appropriation -  Advance,10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,APBGT,Appropriation -  Budget,10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,APCRREF,Appropriation - Credit Reform,10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,APIND,Appropriation - Indefinite,10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2013,,0,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,APLIMIND,Appropriation - Limited Indefinite,10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,APOTH,Appropriation - Other,10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,APROP,Appropriation Warrants,10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERC,"Appropriation Transfer, increase",10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERD,"Appropriation Transfer, Decrease",10/1/2013,,0,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERC,"Balance Transfer , Increase",10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERD,"Balance Transfer , Decrease",10/1/2013,,0,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLL,Offsetting Collection,10/1/2013,,1,COLLAJ,4914/150100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLLAJ,Adjustment to Offsetting Collections,10/1/2013,,0,,4914/150100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2013,,0,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISB,Gross Disbursement,10/1/2013,,0,DISBAJ,4914/150100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISBAJ,Adjustment to Gross Disbursements,10/1/2013,,1,,4914/150100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRC,Reappropriation,10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRD,Reappropriation,10/1/2013,,0,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,RS,Appropriation -  Rescission(s),10/1/2013,,1,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,SW,"Surplus, Unavailable for Restoration",10/1/2013,,0,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2013,,0,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2014,2015,,100,0,0,4914/150100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2013,,0,,4914/150100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,AP,Regular/Supplemental,10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,APADV,Appropriation -  Advance,10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,APBGT,Appropriation -  Budget,10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,APCRREF,Appropriation - Credit Reform,10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,APIND,Appropriation - Indefinite,10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2014,,0,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,APLIMIND,Appropriation - Limited Indefinite,10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,APOTH,Appropriation - Other,10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,APROP,Appropriation Warrants,10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERC,"Appropriation Transfer, increase",10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERD,"Appropriation Transfer, Decrease",10/1/2014,,0,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERC,"Balance Transfer , Increase",10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERD,"Balance Transfer , Decrease",10/1/2014,,0,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLL,Offsetting Collection,10/1/2014,,1,COLLAJ,4915/160100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLLAJ,Adjustment to Offsetting Collections,10/1/2014,,0,,4915/160100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2014,,0,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISB,Gross Disbursement,10/1/2014,,0,DISBAJ,4915/160100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISBAJ,Adjustment to Gross Disbursements,10/1/2014,,1,,4915/160100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRC,Reappropriation,10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRD,Reappropriation,10/1/2014,,0,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,RS,Appropriation -  Rescission(s),10/1/2014,,1,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,SW,"Surplus, Unavailable for Restoration",10/1/2014,,0,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2014,,0,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2015,2016,,100,0,0,4915/160100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2014,,0,,4915/160100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,AP,Regular/Supplemental,10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,APADV,Appropriation -  Advance,10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,APBGT,Appropriation -  Budget,10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,APCRREF,Appropriation - Credit Reform,10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,APIND,Appropriation - Indefinite,10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYEC,"Indefinite, Year End Closing Adjustment, Credit",10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,APINDYED,"Indefinite, Year End Closing Adjustment, Debit",10/1/2015,,0,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,APLIMIND,Appropriation - Limited Indefinite,10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,APOTH,Appropriation - Other,10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,APROP,Appropriation Warrants,10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERC,"Appropriation Transfer, increase",10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,AXFERD,"Appropriation Transfer, Decrease",10/1/2015,,0,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERC,"Balance Transfer , Increase",10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,BXFERD,"Balance Transfer , Decrease",10/1/2015,,0,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLL,Offsetting Collection,10/1/2015,,1,COLLAJ,4916/170100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,COLLAJ,Adjustment to Offsetting Collections,10/1/2015,,0,,4916/170100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,CXFERD,Transfers to General Fund Receipt Accounts,10/1/2015,,0,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISB,Gross Disbursement,10/1/2015,,0,DISBAJ,4916/170100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,DISBAJ,Adjustment to Gross Disbursements,10/1/2015,,1,,4916/170100,49,,100,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,JRCR,Appropriation - Joint Resolution/Continuing Resolution,10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRC,Reappropriation,10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,RAPPRD,Reappropriation,10/1/2015,,0,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,RS,Appropriation -  Rescission(s),10/1/2015,,1,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,SW,"Surplus, Unavailable for Restoration",10/1/2015,,0,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYE,"Surplus, Year End Closing Cancellation of Expired Account Balances",10/1/2015,,0,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,,49,2016,2017,,100,0,0,4916/170100,"Research and Related Activities, National Science Foundation",National Science Foundation,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2015,,0,,4916/170100,49,,100,,EXPND,Expenditure,GF,General Fund
-,19,72,,,X,306,0,0,19-72X0306,State,Department of State,AXFERC,"Appropriation Transfer, increase",10/1/2010,,1,,19-72X0306,19,72,306,,EXPND,Expenditure,GF,General Fund
-,19,72,,,X,306,0,0,19-72X0306,State,Department of State,AXFERD,"Appropriation Transfer, Decrease",10/1/2010,,0,,19-72X0306,19,72,306,,EXPND,Expenditure,GF,General Fund
-,19,72,,,X,306,0,0,19-72X0306,State,Department of State,BXFERC,"Balance Transfer , Increase",10/1/2010,,1,,19-72X0306,19,72,306,,EXPND,Expenditure,GF,General Fund
-,19,72,,,X,306,0,0,19-72X0306,State,Department of State,BXFERD,"Balance Transfer , Decrease",10/1/2010,,0,,19-72X0306,19,72,306,,EXPND,Expenditure,GF,General Fund
-,19,72,,,X,306,0,0,19-72X0306,State,Department of State,COLL,Offsetting Collection,10/1/2010,,1,COLLAJ,19-72X0306,19,72,306,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,19,72,,,X,306,0,0,19-72X0306,State,Department of State,COLLAJ,Adjustment to Offsetting Collections,10/1/2010,,0,,19-72X0306,19,72,306,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,19,72,,,X,306,0,0,19-72X0306,State,Department of State,DISB,Gross Disbursement,10/1/2010,,0,DISBAJ,19-72X0306,19,72,306,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,19,72,,,X,306,0,0,19-72X0306,State,Department of State,DISBAJ,Adjustment to Gross Disbursements,10/1/2010,,1,,19-72X0306,19,72,306,"Collection, IPC, NTDOPMT, Payment",EXPND,Expenditure,GF,General Fund
-,19,72,,,X,306,0,0,19-72X0306,State,Department of State,SWYEAR,"Surplus, YR End Closing Cancellation Revolving, Special and Non-Revolving Trust fund (Avail Rec)",10/1/2010,,0,,19-72X0306,19,72,306,,EXPND,Expenditure,GF,General Fund
+ACCT_NUM,ATA,AID,BPOA,EPOA,A,MAIN,SUB,GWA_TAS,GWA_TAS NAME,Agency AID,Agency Name,ADMIN_ORG, Admin Org Name,FR Entity Type Code,FR Entity Description,FIN Type 2,FIN Type 2 Description
+0,,19,2016,2016,,113,0,19160113,"Diplomatic and Consular Programs, State",,Department of State,,,,,,
+1,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+2,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+3,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+4,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+5,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+6,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+7,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+8,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+9,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+10,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+11,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+12,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+13,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+14,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+15,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+16,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+17,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+18,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+19,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+20,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+21,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+22,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+23,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+24,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+25,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+26,,28,,,X,406,0,28X0406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+27,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+28,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+29,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+30,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+31,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+32,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+33,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+34,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+35,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+36,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+37,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+38,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+39,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+40,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+41,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+42,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+43,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+44,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+45,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+46,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+47,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+48,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+49,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+50,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+51,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+52,,28,2010,2011,,406,0,2810/110406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+53,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+54,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+55,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+56,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+57,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+58,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+59,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+60,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+61,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+62,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+63,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+64,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+65,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+66,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+67,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+68,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+69,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+70,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+71,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+72,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+73,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+74,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+75,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+76,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+77,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+78,,28,2012,2013,,406,0,2812/130406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+79,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+80,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+81,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+82,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+83,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+84,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+85,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+86,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+87,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+88,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+89,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+90,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+91,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+92,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+93,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+94,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+95,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+96,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+97,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+98,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+99,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+100,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+101,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+102,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+103,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+104,,28,2013,2014,,406,0,2813/140406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+105,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+106,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+107,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+108,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+109,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+110,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+111,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+112,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+113,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+114,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+115,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+116,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+117,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+118,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+119,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+120,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+121,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+122,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+123,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+124,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+125,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+126,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+127,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+128,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+129,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+130,,28,2014,2015,,406,0,2814/150406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+131,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+132,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+133,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+134,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+135,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+136,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+137,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+138,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+139,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+140,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+141,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+142,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+143,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+144,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+145,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+146,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+147,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+148,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+149,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+150,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+151,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+152,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+153,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+154,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+155,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+156,,28,2015,2016,,406,0,2815/160406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+157,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+158,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+159,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+160,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+161,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+162,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+163,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+164,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+165,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+166,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+167,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+168,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+169,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+170,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+171,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+172,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+173,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+174,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+175,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+176,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+177,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+178,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+179,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+180,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+181,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+182,,28,2015,2017,,406,0,2815/170406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+183,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+184,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+185,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+186,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+187,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+188,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+189,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+190,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+191,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+192,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+193,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+194,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+195,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+196,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+197,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+198,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+199,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+200,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+201,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+202,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+203,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+204,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+205,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+206,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+207,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+208,,28,2016,2018,,406,0,2816/180406,"Supplemental Security Income Program, Social Security Administration",,Social Security Administration,,,,,,
+209,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+210,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+211,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+212,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+213,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+214,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+215,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+216,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+217,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+218,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+219,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+220,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+221,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+222,69,13,,,X,2050,5,69-13X2050.5,Federal Highway Administration,,Department of Transportation,,,,,,
+223,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+224,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+225,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+226,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+227,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+228,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+229,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+230,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+231,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+232,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+233,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+234,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+235,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+236,69,21,,,X,2065,5,69-21X2065.5,Federal Highway Administration,,Department of Transportation,,,,,,
+237,28,28,,,X,8007,0,28-28X8007,Social Security Administration,,Social Security Administration,,,,,,
+238,28,28,,,X,8007,0,28-28X8007,Social Security Administration,,Social Security Administration,,,,,,
+239,28,28,,,X,8007,0,28-28X8007,Social Security Administration,,Social Security Administration,,,,,,
+240,28,28,,,X,8007,0,28-28X8007,Social Security Administration,,Social Security Administration,,,,,,
+241,28,28,,,X,8007,0,28-28X8007,Social Security Administration,,Social Security Administration,,,,,,
+242,28,28,,,X,8007,0,28-28X8007,Social Security Administration,,Social Security Administration,,,,,,
+243,28,28,,,X,8007,0,28-28X8007,Social Security Administration,,Social Security Administration,,,,,,
+244,28,28,,,X,8007,0,28-28X8007,Social Security Administration,,Social Security Administration,,,,,,
+245,28,28,,,X,8007,0,28-28X8007,Social Security Administration,,Social Security Administration,,,,,,
+246,,28,,,X,8007,0,(15)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+247,,28,,,X,8007,0,(15)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+248,,28,,,X,8007,0,(15)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+249,,28,,,X,8007,0,(15)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+250,,28,,,X,8007,0,(16)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+251,,28,,,X,8007,0,(16)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+252,,28,,,X,8007,0,(16)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+253,,28,,,X,8007,0,(16)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+254,,28,,,X,8007,0,(30)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+255,,28,,,X,8007,0,(30)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+256,,28,,,X,8007,0,(30)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+257,,28,,,X,8007,0,(30)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+258,,28,,,X,8007,0,(31)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+259,,28,,,X,8007,0,(31)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+260,,28,,,X,8007,0,(31)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+261,,28,,,X,8007,0,(31)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+262,,28,,,X,8007,0,(32)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+263,,28,,,X,8007,0,(32)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+264,,28,,,X,8007,0,(32)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+265,,28,,,X,8007,0,(32)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+266,,28,,,X,8007,0,(33)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+267,,28,,,X,8007,0,(33)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+268,,28,,,X,8007,0,(33)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+269,,28,,,X,8007,0,(33)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+270,,28,,,X,8007,0,(34)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+271,,28,,,X,8007,0,(34)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+272,,28,,,X,8007,0,(34)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+273,,28,,,X,8007,0,(34)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+274,,28,,,X,8007,0,(61)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+275,,28,,,X,8007,0,(61)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+276,,28,,,X,8007,0,(63)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+277,,28,,,X,8007,0,(63)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+278,,28,,,X,8007,0,(66)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+279,,28,,,X,8007,0,(66)28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+280,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+281,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+282,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+283,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+284,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+285,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+286,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+287,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+288,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+289,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+290,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+291,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+292,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+293,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+294,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+295,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+296,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+297,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+298,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+299,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+300,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+301,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+302,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+303,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+304,,28,,,X,8007,0,28X8007,"Federal Disability Insurance Trust Fund - Treasury Managed, Social Security Administration",,Social Security Administration,,,,,,
+305,,28,,,X,8007,1,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+306,,28,,,X,8007,1,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+307,,28,,,X,8007,1,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+308,,28,,,X,8007,1,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+309,,28,,,X,8007,1,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+310,,28,,,X,8007,1,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+311,,28,,,X,8007,1,28X8007.1,"Transfers from General Fund of Amounts Equal to FICA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+312,,28,,,X,8007,2,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+313,,28,,,X,8007,2,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+314,,28,,,X,8007,2,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+315,,28,,,X,8007,2,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+316,,28,,,X,8007,2,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+317,,28,,,X,8007,2,28X8007.2,"Earnings on Investments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+318,,28,,,X,8007,3,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+319,,28,,,X,8007,3,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+320,,28,,,X,8007,3,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+321,,28,,,X,8007,3,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+322,,28,,,X,8007,3,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+323,,28,,,X,8007,3,28X8007.3,"Deposits by States, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+324,,28,,,X,8007,5,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+325,,28,,,X,8007,5,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+326,,28,,,X,8007,5,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+327,,28,,,X,8007,5,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+328,,28,,,X,8007,5,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+329,,28,,,X,8007,5,28X8007.5,"Interest Payments by Railroad Retirement Board, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+330,,28,,,X,8007,6,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+331,,28,,,X,8007,6,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+332,,28,,,X,8007,6,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+333,,28,,,X,8007,6,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+334,,28,,,X,8007,6,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+335,,28,,,X,8007,6,28X8007.6,"Miscellaneous Federal Payments, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+336,,28,,,X,8007,9,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+337,,28,,,X,8007,9,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+338,,28,,,X,8007,9,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+339,,28,,,X,8007,9,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+340,,28,,,X,8007,9,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+341,,28,,,X,8007,9,28X8007.9,"Tax Refund, Offset Collections, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+342,,28,,,X,8007,10,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+343,,28,,,X,8007,10,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+344,,28,,,X,8007,10,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+345,,28,,,X,8007,10,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+346,,28,,,X,8007,10,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+347,,28,,,X,8007,10,28X8007.10,"Receipts from Railroad Retirement Account, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+348,,28,,,X,8007,11,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+349,,28,,,X,8007,11,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+350,,28,,,X,8007,11,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+351,,28,,,X,8007,11,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+352,,28,,,X,8007,11,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+353,,28,,,X,8007,11,28X8007.11,"Transfers from General Fund of Amounts Equal to SECA Taxes, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+354,,28,,,X,8007,12,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",,Social Security Administration,,,,,,
+355,,28,,,X,8007,12,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",,Social Security Administration,,,,,,
+356,,28,,,X,8007,12,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",,Social Security Administration,,,,,,
+357,,28,,,X,8007,12,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",,Social Security Administration,,,,,,
+358,,28,,,X,8007,12,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",,Social Security Administration,,,,,,
+359,,28,,,X,8007,12,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",,Social Security Administration,,,,,,
+360,,28,,,X,8007,12,28X8007.12,"Transfers from General Fund of Amounts Equal to Federal Employer Contributions for FICA Taxes, Federal Disability Insurance Trust",,Social Security Administration,,,,,,
+361,,28,,,X,8007,14,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",,Social Security Administration,,,,,,
+362,,28,,,X,8007,14,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",,Social Security Administration,,,,,,
+363,,28,,,X,8007,14,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",,Social Security Administration,,,,,,
+364,,28,,,X,8007,14,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",,Social Security Administration,,,,,,
+365,,28,,,X,8007,14,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",,Social Security Administration,,,,,,
+366,,28,,,X,8007,14,28X8007.14,"Interest Income, Cash Management Improvement Act, Federal Disability Trust Fund",,Social Security Administration,,,,,,
+367,,28,,,X,8007,16,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+368,,28,,,X,8007,16,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+369,,28,,,X,8007,16,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+370,,28,,,X,8007,16,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+371,,28,,,X,8007,16,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+372,,28,,,X,8007,16,28X8007.16,"Taxes on Benefits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+373,,28,,,X,8007,18,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",,Social Security Administration,,,,,,
+374,,28,,,X,8007,18,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",,Social Security Administration,,,,,,
+375,,28,,,X,8007,18,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",,Social Security Administration,,,,,,
+376,,28,,,X,8007,18,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",,Social Security Administration,,,,,,
+377,,28,,,X,8007,18,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",,Social Security Administration,,,,,,
+378,,28,,,X,8007,18,28X8007.18,"FDI, General Fund Payments for Payroll Tax Holiday, SSA",,Social Security Administration,,,,,,
+379,,28,,,X,8007,22,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+380,,28,,,X,8007,22,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+381,,28,,,X,8007,22,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+382,,28,,,X,8007,22,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+383,,28,,,X,8007,22,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+384,,28,,,X,8007,22,28X8007.22,"Interest and Profits on Investments in Participation Certificates, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+385,,28,,,X,8007,24,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+386,,28,,,X,8007,24,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+387,,28,,,X,8007,24,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+388,,28,,,X,8007,24,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+389,,28,,,X,8007,24,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+390,,28,,,X,8007,24,28X8007.24,"Refunds for Voluntary Income Tax Withholding, Principal, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+391,,28,,,X,8007,25,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+392,,28,,,X,8007,25,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+393,,28,,,X,8007,25,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+394,,28,,,X,8007,25,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+395,,28,,,X,8007,25,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+396,,28,,,X,8007,25,28X8007.25,"Refunds for Voluntary Tax Withholding, Interest, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+397,,28,,,X,8007,27,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+398,,28,,,X,8007,27,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+399,,28,,,X,8007,27,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+400,,28,,,X,8007,27,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+401,,28,,,X,8007,27,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+402,,28,,,X,8007,27,28X8007.27,"Interest on Interfund Borrowings, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+403,,28,,,X,8007,28,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+404,,28,,,X,8007,28,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+405,,28,,,X,8007,28,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+406,,28,,,X,8007,28,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+407,,28,,,X,8007,28,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+408,,28,,,X,8007,28,28X8007.28,"Non-Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+409,,28,,,X,8007,29,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+410,,28,,,X,8007,29,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+411,,28,,,X,8007,29,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+412,,28,,,X,8007,29,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+413,,28,,,X,8007,29,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+414,,28,,,X,8007,29,28X8007.29,"Other Proprietary Receipts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+415,,28,,,X,8007,31,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+416,,28,,,X,8007,31,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+417,,28,,,X,8007,31,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+418,,28,,,X,8007,31,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+419,,28,,,X,8007,31,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+420,,28,,,X,8007,31,28X8007.31,"Attorney Fees, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+421,,28,,,X,8007,42,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+422,,28,,,X,8007,42,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+423,,28,,,X,8007,42,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+424,,28,,,X,8007,42,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+425,,28,,,X,8007,42,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+426,,28,,,X,8007,42,28X8007.42,"Gifts, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+427,,28,,,X,8007,65,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+428,,28,,,X,8007,65,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+429,,28,,,X,8007,65,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+430,,28,,,X,8007,65,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+431,,28,,,X,8007,65,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+432,,28,,,X,8007,65,28X8007.65,"Military Service Credits, Federal Disability Insurance Trust Fund",,Social Security Administration,,,,,,
+433,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+434,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+435,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+436,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+437,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+438,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+439,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+440,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+441,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+442,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+443,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+444,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+445,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+446,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+447,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+448,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+449,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+450,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+451,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+452,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+453,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+454,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+455,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+456,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+457,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+458,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+459,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+460,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+461,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+462,,49,,,X,100,0,49X0100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+463,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+464,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+465,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+466,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+467,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+468,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+469,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+470,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+471,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+472,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+473,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+474,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+475,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+476,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+477,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+478,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+479,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+480,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+481,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+482,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+483,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+484,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+485,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+486,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+487,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+488,,49,2010,2011,,100,0,4910/110100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+489,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+490,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+491,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+492,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+493,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+494,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+495,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+496,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+497,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+498,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+499,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+500,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+501,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+502,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+503,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+504,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+505,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+506,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+507,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+508,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+509,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+510,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+511,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+512,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+513,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+514,,49,2011,2012,,100,0,4911/120100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+515,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+516,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+517,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+518,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+519,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+520,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+521,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+522,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+523,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+524,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+525,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+526,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+527,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+528,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+529,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+530,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+531,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+532,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+533,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+534,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+535,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+536,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+537,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+538,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+539,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+540,,49,2012,2013,,100,0,4912/130100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+541,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+542,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+543,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+544,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+545,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+546,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+547,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+548,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+549,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+550,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+551,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+552,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+553,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+554,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+555,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+556,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+557,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+558,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+559,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+560,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+561,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+562,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+563,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+564,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+565,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+566,,49,2013,2014,,100,0,4913/140100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+567,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+568,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+569,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+570,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+571,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+572,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+573,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+574,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+575,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+576,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+577,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+578,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+579,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+580,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+581,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+582,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+583,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+584,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+585,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+586,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+587,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+588,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+589,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+590,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+591,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+592,,49,2014,2015,,100,0,4914/150100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+593,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+594,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+595,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+596,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+597,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+598,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+599,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+600,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+601,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+602,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+603,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+604,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+605,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+606,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+607,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+608,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+609,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+610,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+611,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+612,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+613,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+614,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+615,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+616,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+617,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+618,,49,2015,2016,,100,0,4915/160100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+619,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+620,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+621,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+622,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+623,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+624,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+625,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+626,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+627,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+628,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+629,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+630,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+631,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+632,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+633,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+634,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+635,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+636,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+637,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+638,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+639,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+640,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+641,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+642,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+643,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+644,,49,2016,2017,,100,0,4916/170100,"Research and Related Activities, National Science Foundation",,National Science Foundation,,,,,,
+645,19,72,,,X,306,0,19-72X0306,State,,Department of State,,,,,,
+646,19,72,,,X,306,0,19-72X0306,State,,Department of State,,,,,,
+647,19,72,,,X,306,0,19-72X0306,State,,Department of State,,,,,,
+648,19,72,,,X,306,0,19-72X0306,State,,Department of State,,,,,,
+649,19,72,,,X,306,0,19-72X0306,State,,Department of State,,,,,,
+650,19,72,,,X,306,0,19-72X0306,State,,Department of State,,,,,,
+651,19,72,,,X,306,0,19-72X0306,State,,Department of State,,,,,,
+652,19,72,,,X,306,0,19-72X0306,State,,Department of State,,,,,,
+653,19,72,,,X,306,0,19-72X0306,State,,Department of State,,,,,,

--- a/tests/unit/dataactvalidator/test_scripts_loadTas.py
+++ b/tests/unit/dataactvalidator/test_scripts_loadTas.py
@@ -1,0 +1,47 @@
+from csv import DictWriter
+
+from dataactvalidator.scripts import loadTas
+
+
+def import_tas(session, tmpdir, *rows):
+    """Write the provided rows to a CSV, then read them in via pandas and
+    clean them"""
+    csv_file = tmpdir.join("all_tas_betc.csv")
+    with open(str(csv_file), 'w') as f:
+        writer = DictWriter(
+            f, ['ATA', 'AID', 'A', 'BPOA', 'EPOA', 'MAIN', 'SUB']
+        )
+        writer.writeheader()
+        for row in rows:
+            data = {key: '' for key in writer.fieldnames}
+            data.update(row)
+            writer.writerow(data)
+
+    return loadTas.cleanTas(str(csv_file))
+
+
+def test_loadTas_multiple(database, tmpdir):
+    """If we have two rows in the CSV, we should have two TASLookups"""
+    results = import_tas(
+        database.session, tmpdir,
+        {'ATA': 'aaa', 'AID': 'bbb', 'A': 'ccc', 'BPOA': 'ddd', 'EPOA': 'eee',
+         'MAIN': 'ffff', 'SUB': 'ggg'},
+        {'ATA': '111', 'AID': '222', 'A': '333', 'BPOA': '444', 'EPOA': '555',
+         'MAIN': '6666', 'SUB': '777'}
+    )
+    assert results['allocation_transfer_agency'].tolist() == ['aaa', '111']
+    assert results['agency_identifier'].tolist() == ['bbb', '222']
+    assert results['availability_type_code'].tolist() == ['ccc', '333']
+    assert results['beginning_period_of_availability'].tolist() == [
+        'ddd', '444']
+    assert results['ending_period_of_availability'].tolist() == ['eee', '555']
+    assert results['main_account_code'].tolist() == ['ffff', '6666']
+    assert results['sub_account_code'].tolist() == ['ggg', '777']
+
+
+def test_loadTas_space_nulls(database, tmpdir):
+    results = import_tas(
+        database.session, tmpdir, {'BPOA': '', 'EPOA': ' ', 'A': '   '})
+    assert results['beginning_period_of_availability'][0] is None
+    assert results['ending_period_of_availability'][0] is None
+    assert results['availability_type_code'][0] is None


### PR DESCRIPTION
We're getting our TAS files from a different source now, which has a slightly
different set of columns. Modify the import script to accommodate and replace
the CSVs included in the app. The logic is simplified as our data source is
now more accurate (not including duplicate rows, for example).

This is a first step towards replacing the `tas` field in our models with the new `ACCT_NUM`-based approach.