### PR TITLE
Remove validate_threaded route

### DIFF
--- a/dataactvalidator/README.md
+++ b/dataactvalidator/README.md
@@ -24,11 +24,6 @@ Called to apply validation rules to a specified job ID.  Expects a JSON with key
 Example input: `{"job_id":3664}`
 Example output: None (status 200 if successful)
 
-##### POST `/validate_threaded/`
-Same as validate route, but launches validation in a separate thread and immediately returns 200.  Success or failure of the validation should then be determined from the job tracker database.
-
-Example input: `{"job_id":3664}`
-Example output: None
 
 ## Process Overview
 The validation process begins with a call to one of the above routes from either the job manager or the broker API, specifying the job ID for the validation job.  First, the validator checks the job tracker to ensure that the job is of the correct type, and that all prerequisites are completed.

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -40,68 +40,6 @@ def createApp():
             """Confirm server running."""
             return "Validator is running"
 
-        @app.route("/validate_threaded/", methods=["POST"])
-        def validate_threaded():
-            """Start the validation process on a new thread."""
-            @copy_current_request_context
-            def ThreadedFunction(arg):
-                """The new thread."""
-                threadedManager = ValidationManager(local, error_report_path)
-                threadedManager.threadedValidateJob(arg)
-
-            try:
-                interfaces = InterfaceHolder()
-                jobTracker = interfaces.jobDb
-            except ResponseException as e:
-                open("errorLog","a").write(str(e) + "\n")
-                return JsonResponse.error(e,e.status)
-            except Exception as e:
-                open("errorLog","a").write(str(e) + "\n")
-                exc = ResponseException(str(e),StatusCode.INTERNAL_ERROR,type(e))
-                return JsonResponse.error(exc,exc.status)
-
-            jobId = None
-            manager = ValidationManager(local, error_report_path)
-
-            try:
-                jobId = manager.getJobID(request)
-            except ResponseException as e:
-                manager.markJob(jobId,jobTracker,"invalid",interfaces.errorDb,manager.filename)
-                CloudLogger.logError(str(e),e,traceback.extract_tb(sys.exc_info()[2]))
-                return JsonResponse.error(e,e.status)
-            except Exception as e:
-                exc = ResponseException(str(e),StatusCode.CLIENT_ERROR,type(e))
-                manager.markJob(jobId,jobTracker,"invalid",interfaces.errorDb,manager.filename)
-                CloudLogger.logError(str(e),exc,traceback.extract_tb(sys.exc_info()[2]))
-                return JsonResponse.error(exc,exc.status)
-
-            try:
-                manager.testJobID(jobId,interfaces)
-            except ResponseException as e:
-                open("errorLog","a").write(str(e) + "\n")
-                # Job is not ready to run according to job tracker, do not change status of job in job tracker
-                interfaces.errorDb.writeFileError(jobId,manager.filename,ValidationError.jobError)
-                return JsonResponse.error(e,e.status)
-            except Exception as e:
-                open("errorLog","a").write(str(e) + "\n")
-                exc = ResponseException(str(e),StatusCode.CLIENT_ERROR,type(e))
-                interfaces.errorDb.writeFileError(jobId,manager.filename,ValidationError.jobError)
-                return JsonResponse.error(exc,exc.status)
-
-            thread = Thread(target=ThreadedFunction, args= (jobId,))
-
-            try :
-                jobTracker.markJobStatus(jobId,"running")
-            except Exception as e:
-                open("errorLog","a").write(str(e) + "\n")
-                exc = ResponseException(str(e),StatusCode.INTERNAL_ERROR,type(e))
-                return JsonResponse.error(exc,exc.status)
-
-            interfaces.close()
-            thread.start()
-
-            return JsonResponse.create(StatusCode.OK, {"message":"Validation complete"})
-
         @app.route("/validate/",methods=["POST"])
         def validate():
             """Start the validation process on the same threads."""


### PR DESCRIPTION
This is something we'd discussed a while back. The validate_threaded
route is not currently in use. If we ever need this in the future,
we'd likely want to revist the approach because so much has changed
since the route was originally implemented (e.g., single code
base, migration to Python 3). In the meantime, though, this commit
removes the route entirely so we don't need to update it as part
of the ongoing database refactor.