### PR TITLE
Remove nonpytest runner

### DIFF
--- a/dataactbroker/handlers/jobHandler.py
+++ b/dataactbroker/handlers/jobHandler.py
@@ -253,7 +253,7 @@ class JobHandler(JobTrackerInterface):
         jobId -- job_id to mark as finished
 
         """
-        JobTrackerInterface.markJobStatus(self, jobId, 'finished')
+        self.markJobStatus(jobId, 'finished')
 
     def getSubmissionForJob(self,job):
         """ Takes a job object and returns the associated submission object """

--- a/tests/integration/baseTestAPI.py
+++ b/tests/integration/baseTestAPI.py
@@ -184,6 +184,7 @@ class BaseTestAPI(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """Tear down class-level resources."""
+        GlobalDB.close()
         dropDatabase(CONFIG_DB['db_name'])
 
     def tearDown(self):

--- a/tests/integration/runTests.py
+++ b/tests/integration/runTests.py
@@ -1,67 +1,19 @@
-import unittest
-from unittest.mock import patch
-from tests.integration.loginTests import LoginTests
-from tests.integration.fileTests import FileTests
-from tests.integration.userTests import UserTests
-from tests.integration.jobTests import JobTests
-from tests.integration.validatorTests import ValidatorTests
-from tests.integration.fileTypeTests import FileTypeTests
-from tests.integration.mixedFileTests import MixedFileTests
-import cProfile
-import pstats
-import xmlrunner
-import sys, getopt
+"""Transition module. We need to update our CI to use
+py.test tests/integration
 
-def runTests(argv=''):
-    PROFILE = False
-    XMLresults = False
+rather than
 
-    # Get command line arg to determine output
-    try:
-        opts, args = getopt.getopt(argv,"o:")
-    except getopt.GetoptError:
-        XMLresults = False
-    for opt, arg in opts:
-      if opt == '-o' and arg == "XML":
-        XMLresults = True
-      else: 
-        XMLresults = False
+py.test tests/integration/runTests.py
+"""
+from tests.integration.loginTests import LoginTests             # noqa
+from tests.integration.fileTests import FileTests               # noqa
+from tests.integration.userTests import UserTests               # noqa
+from tests.integration.jobTests import JobTests                 # noqa
+from tests.integration.validatorTests import ValidatorTests     # noqa
+from tests.integration.fileTypeTests import FileTypeTests       # noqa
+from tests.integration.mixedFileTests import MixedFileTests     # noqa
 
-    # Create test suite
-    suite = unittest.TestSuite()
-
-    suite.addTests(unittest.makeSuite(LoginTests))
-    suite.addTests(unittest.makeSuite(FileTests))
-    suite.addTests(unittest.makeSuite(UserTests))
-    suite.addTests(unittest.makeSuite(ValidatorTests))
-    suite.addTests(unittest.makeSuite(JobTests))
-    suite.addTests(unittest.makeSuite(FileTypeTests))
-    suite.addTests(unittest.makeSuite(MixedFileTests))
-
-    # to run a single test:
-    #suite.addTest(FileTests('test_file_generation'))
-    #suite.addTest(MixedFileTests('test_award_mixed'))
-
-    print("{} tests in suite".format(suite.countTestCases()))
-
-    # Run tests and store results
-    if XMLresults:
-        runner = xmlrunner.XMLTestRunner(output='test-reports')
-    else:
-        runner = unittest.TextTestRunner(verbosity=2)
-
-    with patch('dataactbroker.handlers.accountHandler.sesEmail.send'):
-        if PROFILE:
-            # Creating globals to be accessible to cProfile
-            global profileRunner
-            global profileSuite
-            profileRunner = runner
-            profileSuite = suite
-            cProfile.run("profileRunner.run(profileSuite)", "stats")
-            stats = pstats.Stats("stats")
-            stats.sort_stats("tottime").print_stats(100)
-        else:
-            runner.run(suite)
 
 if __name__ == '__main__':
-    runTests(sys.argv[1:])
+    print("Did you mean to run")
+    print("py.test tests/integration/runTests.py")


### PR DESCRIPTION
This also makes it possible to just run `py.test` from the root of the project without errors.
