### PR TITLE
Use new, consolidated debug flag when creating Flask apps

### DIFF
--- a/dataactbroker/app.py
+++ b/dataactbroker/app.py
@@ -20,8 +20,7 @@ def createApp():
     local = CONFIG_BROKER['local']
     app.config.from_object(__name__)
     app.config['LOCAL'] = local
-    app.debug = CONFIG_SERVICES['server_debug']
-    app.config['REST_TRACE'] = CONFIG_SERVICES['rest_trace']
+    app.debug = CONFIG_SERVICES['debug']
     app.config['SYSTEM_EMAIL'] = CONFIG_BROKER['reply_to_email']
 
     # Future: Override config w/ environment variable, if set
@@ -38,7 +37,7 @@ def createApp():
     if local and not os.path.exists(broker_file_path):
         os.makedirs(broker_file_path)
 
-    JsonResponse.debugMode = app.config['REST_TRACE']
+    JsonResponse.debugMode = app.debug
 
     if CONFIG_SERVICES['cross_origin_url'] ==  "*":
         cors = CORS(app, supports_credentials=False, allow_headers = "*", expose_headers = "X-Session-Id")

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -62,10 +62,11 @@ broker:
 
 services:
     # Set to true to turn on tracing rest errors.
-    rest_trace: true
+    rest_trace: false #deprecated
 
     # Set to true to turn on server debugging.
-    server_debug: true
+    server_debug: false #deprecated
+    debug: false
 
     # URL/IP address that hosts the broker API
     broker_api_host: http://dataactbroker-api.domain.com

--- a/dataactcore/local_config_example.yml
+++ b/dataactcore/local_config_example.yml
@@ -13,6 +13,7 @@ broker:
 
 services:
 
+    debug: true
     broker_api_host: 127.0.0.1
     broker_api_port: 3333
     validator_host: 127.0.0.1

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -15,7 +15,7 @@ def createApp():
     """Create the Flask app."""
     try:
         app = Flask(__name__.split('.')[0])
-        app.debug = CONFIG_SERVICES['server_debug']
+        app.debug = CONFIG_SERVICES['debug']
         local = CONFIG_BROKER['local']
         error_report_path = CONFIG_SERVICES['error_report_path']
         app.config.from_object(__name__)
@@ -51,7 +51,7 @@ def createApp():
             finally:
                 interfaces.close()
 
-        JsonResponse.debugMode = CONFIG_SERVICES['rest_trace']
+        JsonResponse.debugMode = app.debug
 
         return app
 


### PR DESCRIPTION
This commit uses the new debug flag for all debug-related settings.
Going forward, code that needs to know the debug status of the app
can either get it from app.debug, if the Flask app is handy, or
from CONFIG_SERVICES['debug'].

The new flag has already been merged into the config repo: https://github.com/fedspendingtransparency/data-act-broker-config/pull/25

Folks will have to add debug to their local configs once this is merged.