### PR TITLE
Updating the submission and job models

### DIFF
--- a/dataactcore/migrations/versions/bb33cc8f0a3e_setting_submission_error_numbers_to_.py
+++ b/dataactcore/migrations/versions/bb33cc8f0a3e_setting_submission_error_numbers_to_.py
@@ -31,19 +31,23 @@ def upgrade_data_broker():
     op.execute('UPDATE job SET number_of_errors = 0 WHERE number_of_errors IS NULL')
     op.alter_column('job', 'number_of_errors',
                existing_type=sa.INTEGER(),
-               nullable=False)
+               nullable=False,
+               server_default='0')
     op.execute('UPDATE job SET number_of_warnings = 0 WHERE number_of_warnings IS NULL')
     op.alter_column('job', 'number_of_warnings',
                existing_type=sa.INTEGER(),
-               nullable=False)
+               nullable=False,
+               server_default='0')
     op.execute('UPDATE submission SET number_of_errors = 0 WHERE number_of_errors IS NULL')
     op.alter_column('submission', 'number_of_errors',
                existing_type=sa.INTEGER(),
-               nullable=False)
+               nullable=False,
+               server_default='0')
     op.execute('UPDATE submission SET number_of_warnings = 0 WHERE number_of_warnings IS NULL')
     op.alter_column('submission', 'number_of_warnings',
                existing_type=sa.INTEGER(),
-               nullable=False)
+               nullable=False,
+               server_default='0')
 
 
 def downgrade_data_broker():

--- a/dataactcore/migrations/versions/bb33cc8f0a3e_setting_submission_error_numbers_to_.py
+++ b/dataactcore/migrations/versions/bb33cc8f0a3e_setting_submission_error_numbers_to_.py
@@ -1,0 +1,62 @@
+"""setting submission error numbers to default zero
+
+Revision ID: bb33cc8f0a3e
+Revises: a97dabbd44f4
+Create Date: 2016-11-10 11:08:55.746848
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'bb33cc8f0a3e'
+down_revision = 'a97dabbd44f4'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+
+
+
+def upgrade_data_broker():
+    op.execute('UPDATE job SET number_of_errors = 0 WHERE number_of_errors IS NULL')
+    op.alter_column('job', 'number_of_errors',
+               existing_type=sa.INTEGER(),
+               nullable=False)
+    op.execute('UPDATE job SET number_of_warnings = 0 WHERE number_of_warnings IS NULL')
+    op.alter_column('job', 'number_of_warnings',
+               existing_type=sa.INTEGER(),
+               nullable=False)
+    op.execute('UPDATE submission SET number_of_errors = 0 WHERE number_of_errors IS NULL')
+    op.alter_column('submission', 'number_of_errors',
+               existing_type=sa.INTEGER(),
+               nullable=False)
+    op.execute('UPDATE submission SET number_of_warnings = 0 WHERE number_of_warnings IS NULL')
+    op.alter_column('submission', 'number_of_warnings',
+               existing_type=sa.INTEGER(),
+               nullable=False)
+
+
+def downgrade_data_broker():
+    op.alter_column('submission', 'number_of_warnings',
+               existing_type=sa.INTEGER(),
+               nullable=True)
+    op.alter_column('submission', 'number_of_errors',
+               existing_type=sa.INTEGER(),
+               nullable=True)
+    op.alter_column('job', 'number_of_warnings',
+               existing_type=sa.INTEGER(),
+               nullable=True)
+    op.alter_column('job', 'number_of_errors',
+               existing_type=sa.INTEGER(),
+               nullable=True)
+

--- a/dataactcore/models/jobModels.py
+++ b/dataactcore/models/jobModels.py
@@ -60,8 +60,8 @@ class Submission(Base):
     publishable = Column(Boolean, nullable = False, default = "False", server_default = "False")
     publish_status_id = Column(Integer, ForeignKey("publish_status.publish_status_id", ondelete="SET NULL", name ="fk_publish_status_id"))
     publish_status = relationship("PublishStatus", uselist = False)
-    number_of_errors = Column(Integer)
-    number_of_warnings = Column(Integer)
+    number_of_errors = Column(Integer, nullable=False, default=0, server_default='0')
+    number_of_warnings = Column(Integer, nullable=False, default=0, server_default='0')
 
 class Job(Base):
     __tablename__ = "job"
@@ -80,8 +80,8 @@ class Job(Base):
     file_size = Column(Integer)
     number_of_rows = Column(Integer)
     number_of_rows_valid = Column(Integer)
-    number_of_errors = Column(Integer)
-    number_of_warnings = Column(Integer)
+    number_of_errors = Column(Integer, nullable=False, default=0, server_default='0')
+    number_of_warnings = Column(Integer, nullable=False, default=0, server_default='0')
     error_message = Column(Text)
     start_date = Column(Date)
     end_date = Column(Date)


### PR DESCRIPTION
This pull request upgrades the number_of_errors and number_of_warnings fields in the submission and job models to default to 0 to prevent errors.