### PR TITLE
Global validation error handling

### DIFF
--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -13,7 +13,7 @@ from dataactcore.utils.responseException import ResponseException
 from dataactvalidator.validation_handlers.validationManager import ValidationManager
 
 
-_exception_logger = logging.getLogger('deprecated.exception')
+logger = logging.getLogger(__name__)
 
 
 def createApp():
@@ -38,7 +38,7 @@ def createApp():
     @app.errorhandler(ResponseException)
     def handle_response_exception(error):
         """Handle exceptions explicitly raised during validation."""
-        _exception_logger.exception(str(error))
+        logger.error(str(error))
         return JsonResponse.error(error, error.status)
 
     @app.errorhandler(Exception)
@@ -54,7 +54,7 @@ def createApp():
             sess.commit()
 
         # log failure and return a response
-        _exception_logger.exception(str(error))
+        logger.error(str(error))
         return JsonResponse.error(error, 500)
 
     @app.route("/", methods=["GET"])

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -6,9 +6,10 @@ from dataactcore.config import CONFIG_BROKER, CONFIG_SERVICES
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.interfaces.interfaceHolder import InterfaceHolder
 from dataactcore.logging import configure_logging
+from dataactcore.models.jobModels import Job
+from dataactcore.models.lookups import JOB_STATUS_DICT
 from dataactcore.utils.jsonResponse import JsonResponse
 from dataactcore.utils.responseException import ResponseException
-from dataactcore.utils.statusCode import StatusCode
 from dataactvalidator.validation_handlers.validationManager import ValidationManager
 
 
@@ -17,50 +18,60 @@ _exception_logger = logging.getLogger('deprecated.exception')
 
 def createApp():
     """Create the Flask app."""
-    try:
-        app = Flask(__name__.split('.')[0])
-        app.debug = CONFIG_SERVICES['debug']
-        local = CONFIG_BROKER['local']
-        error_report_path = CONFIG_SERVICES['error_report_path']
-        app.config.from_object(__name__)
+    app = Flask(__name__.split('.')[0])
+    app.debug = CONFIG_SERVICES['debug']
+    local = CONFIG_BROKER['local']
+    error_report_path = CONFIG_SERVICES['error_report_path']
+    app.config.from_object(__name__)
 
-        # Future: Override config w/ environment variable, if set
-        app.config.from_envvar('VALIDATOR_SETTINGS', silent=True)
+    # Future: Override config w/ environment variable, if set
+    app.config.from_envvar('VALIDATOR_SETTINGS', silent=True)
 
-        @app.teardown_appcontext
-        def teardown_appcontext(exception):
-            GlobalDB.close()
+    @app.teardown_appcontext
+    def teardown_appcontext(exception):
+        GlobalDB.close()
 
-        @app.before_request
-        def before_request():
-            GlobalDB.db()
+    @app.before_request
+    def before_request():
+        GlobalDB.db()
 
-        @app.route("/", methods=["GET"])
-        def testApp():
-            """Confirm server running."""
-            return "Validator is running"
+    @app.errorhandler(ResponseException)
+    def handle_response_exception(error):
+        """Handle exceptions explicitly raised during validation."""
+        _exception_logger.exception(str(error))
+        return JsonResponse.error(error, error.status)
 
-        @app.route("/validate/",methods=["POST"])
-        def validate():
-            """Start the validation process on the same threads."""
-            interfaces = InterfaceHolder() # Create sessions for this route
-            try:
-                validationManager = ValidationManager(local, error_report_path)
-                return validationManager.validate_job(request, interfaces)
-            except Exception as e:
-                # Something went wrong getting the flask request
-                open("errorLog","a").write(str(e) + "\n")
-                exc = ResponseException(str(e),StatusCode.INTERNAL_ERROR,type(e))
-                return JsonResponse.error(exc,exc.status)
-            finally:
-                interfaces.close()
+    @app.errorhandler(Exception)
+    def handle_validation_exception(error):
+        """Handle uncaught exceptions in validation process."""
+        job_id = request.json.get('job_id')
 
-        JsonResponse.debugMode = app.debug
+        # if request had a job id, set job to failed status
+        if job_id:
+            sess = GlobalDB.db().session
+            job = sess.query(Job).filter(Job.job_id == job_id).one()
+            job.status_id = JOB_STATUS_DICT['failed']
+            sess.commit()
 
-        return app
-    except:
-        _exception_logger.exception('Validator App Level Error: ')
-        raise
+        # log failure and return a response
+        _exception_logger.exception(str(error))
+        return JsonResponse.error(error, 500)
+
+    @app.route("/", methods=["GET"])
+    def testApp():
+        """Confirm server running."""
+        return "Validator is running"
+
+    @app.route("/validate/",methods=["POST"])
+    def validate():
+        """Start the validation process."""
+        interfaces = InterfaceHolder() # Create sessions for this route
+        validation_manager = ValidationManager(local, error_report_path)
+        return validation_manager.validate_job(request,interfaces)
+
+    JsonResponse.debugMode = app.debug
+
+    return app
 
 def runApp():
     """Run the application."""

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -524,49 +524,49 @@ class ValidationManager:
         Returns:
         Http response object
         """
-        sess = GlobalDB.db().session
         # Create connection to job tracker database
         self.filename = None
-        job_id = None
-        jobTracker = None
+        sess = GlobalDB.db().session
 
-        try:
-            jobTracker = interfaces.jobDb
-            requestDict = RequestDictionary(request)
-            if requestDict.exists("job_id"):
-                job_id = requestDict.getValue("job_id")
-            else:
-                # Request does not have a job ID, can't validate
-                raise ResponseException("No job ID specified in request",
-                                        StatusCode.CLIENT_ERROR)
+        jobTracker = interfaces.jobDb
+        requestDict = RequestDictionary(request)
+        if requestDict.exists('job_id'):
+            job_id = requestDict.getValue('job_id')
+        else:
+            # Request does not have a job ID, can't validate
+            validation_error_type = ValidationError.jobError
+            raise ResponseException('No job ID specified in request',
+                                    StatusCode.CLIENT_ERROR, None,
+                                    validation_error_type)
 
-            # Get the job
-            job = sess.query(Job).filter_by(job_id=job_id).one()
+        # Get the job
+        job = sess.query(Job).filter_by(job_id=job_id).one_or_none()
+        if job is None:
+            validation_error_type = ValidationError.jobError
+            writeFileError(job_id, self.filename, validation_error_type)
+            raise ResponseException('Checks failed on Job ID',
+                                    StatusCode.CLIENT_ERROR, None,
+                                    validation_error_type)
 
-            # Make sure job's prerequisites are complete
-            if not run_job_checks(job_id):
-                raise ResponseException("Checks failed on Job ID",
-                                        StatusCode.CLIENT_ERROR)
+        # Make sure job's prerequisites are complete
+        if not run_job_checks(job_id):
+            validation_error_type = ValidationError.jobError
+            writeFileError(job_id, self.filename, validation_error_type)
+            raise ResponseException('Checks failed on Job ID',
+                                    StatusCode.CLIENT_ERROR, None,
+                                    validation_error_type)
 
-            # Make sure this is a validation job
-            if job.job_type.name in ('csv_record_validation', 'validation'):
-                job_type_name = job.job_type.name
-            else:
-                raise ResponseException("Wrong type of job for this service", StatusCode.CLIENT_ERROR, None,
-                                    ValidationError.jobError)
+        # Make sure this is a validation job
+        if job.job_type.name in ('csv_record_validation', 'validation'):
+            job_type_name = job.job_type.name
+        else:
+            validation_error_type = ValidationError.jobError
+            writeFileError(job_id, self.filename, validation_error_type)
+            raise ResponseException('Wrong type of job for this service',
+                                    StatusCode.CLIENT_ERROR, None,
+                                    validation_error_type)
 
-        except ResponseException as e:
-            _exception_logger.exception(str(e))
-            if e.errorType == None:
-                # Error occurred while trying to get and check job ID
-                e.errorType = ValidationError.jobError
-            writeFileError(job_id, self.filename, e.errorType, e.extraInfo)
-            return JsonResponse.error(e, e.status)
-        except Exception as e:
-            _exception_logger.exception(str(e))
-            self.markJob(job_id, jobTracker, "failed", self.filename, ValidationError.unknownError)
-            return JsonResponse.error(e, StatusCode.INTERNAL_ERROR)
-
+        # todo: remove the following try/catch once 1st batch of changes are merged
         try:
             jobTracker.markJobStatus(job_id, "running")
             if job_type_name == 'csv_record_validation':

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -544,7 +544,7 @@ class ValidationManager:
         if job is None:
             validation_error_type = ValidationError.jobError
             writeFileError(job_id, self.filename, validation_error_type)
-            raise ResponseException('Checks failed on Job ID',
+            raise ResponseException('Job ID {} not found in database'.format(job_id),
                                     StatusCode.CLIENT_ERROR, None,
                                     validation_error_type)
 
@@ -552,7 +552,7 @@ class ValidationManager:
         if not run_job_checks(job_id):
             validation_error_type = ValidationError.jobError
             writeFileError(job_id, self.filename, validation_error_type)
-            raise ResponseException('Checks failed on Job ID',
+            raise ResponseException('Prerequisites for Job ID {} are not complete'.format(job_id),
                                     StatusCode.CLIENT_ERROR, None,
                                     validation_error_type)
 
@@ -562,9 +562,10 @@ class ValidationManager:
         else:
             validation_error_type = ValidationError.jobError
             writeFileError(job_id, self.filename, validation_error_type)
-            raise ResponseException('Wrong type of job for this service',
-                                    StatusCode.CLIENT_ERROR, None,
-                                    validation_error_type)
+            raise ResponseException(
+                'Job ID {} is not a validation job (job type is {})'.format(job_id, job.job_type.name),
+                StatusCode.CLIENT_ERROR, None,
+                validation_error_type)
 
         # todo: remove the following try/catch once 1st batch of changes are merged
         try:

--- a/tests/integration/jobTests.py
+++ b/tests/integration/jobTests.py
@@ -123,16 +123,9 @@ class JobTests(BaseTestValidator):
 
     def test_bad_id_job(self):
         """Test job ID not found in job table."""
-        # This test is in an in-between place as we refactor database access.
-        # Because run_test now retrieves a job directly from the db instead of
-        # using getJobById from the job interface, sending a bad job id now
-        # results in a SQLAlchemy exception rather than a 400. So for now, the
-        # test is testing the test code. Arguably, we could remove this entirely
-        # and replace it with a unit test as the logging and umbrella exeception
-        # handling is refactored.
         jobId = -1
         with self.assertRaises(NoResultFound):
-            self.run_test(jobId, 500, False, False, False, False, 0)
+            self.run_test(jobId, 400, False, False, False, False, 0)
 
     def test_bad_prereq_job(self):
         """Test job with unfinished prerequisites."""


### PR DESCRIPTION
I went through a lot of iterations on this and finally came back to @cmc333333's advice of keeping
things simple for the first go-round.

This PR tries to reduce the layers of try/except that wrap the validation application and process. Ultimately, I needed to untangle these layers to best proceed with the JobTracker database refactor.

Best to step through the commits--I tried to explain everything in the messages.

Once this is reviewed and merged, the next step is to remove the second try/except block in `validation_job`