### PR TITLE
Exclude migrations from flake8

### DIFF
--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from dataactcore.models.errorModels import ErrorMetadata, File
 from dataactcore.models.jobModels import Job, Submission, JobDependency
 from dataactcore.models.stagingModels import AwardFinancial
-from dataactcore.models.userModel import User, UserStatus, EmailTemplateType, EmailTemplate, PermissionType
+from dataactcore.models.userModel import User, UserStatus, EmailTemplateType, EmailTemplate
 from dataactcore.models.validationModels import RuleSeverity
 from dataactcore.models.lookups import (FILE_TYPE_DICT, FILE_STATUS_DICT, JOB_TYPE_DICT,
                                         JOB_STATUS_DICT, FILE_TYPE_DICT_ID, PERMISSION_TYPE_DICT)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ python_files=test_*.py *_test.py *_tests.py *Tests.py
 [flake8]
 # Ideally, we won't be ignoring any of these
 ignore=E101,E111,E114,E115,E116,E121,E122,E124,E125,E126,E127,E128,E129,E201,E202,E203,E211,E221,E222,E225,E226,E231,E241,E251,E261,E262,E265,E266,E271,E301,E302,E303,E401,E402,E501,E711,E712,E713,E721,E731,F403,F405,F841,W191,W291,W292,W293,W391,W503
+exclude=dataactcore/migrations/versions


### PR DESCRIPTION
These are auto-generated files, so we don't really need to lint them. Also fixes a linting bug. We should be able to turn on linting on Jenkins after this.