### PR TITLE
Return 0 for filesize if S3 file not found

### DIFF
--- a/dataactcore/aws/s3UrlHandler.py
+++ b/dataactcore/aws/s3UrlHandler.py
@@ -98,8 +98,8 @@ class s3UrlHandler:
         s3connection = boto.s3.connect_to_region(s3UrlHandler.REGION)
         bucket = s3connection.get_bucket(CONFIG_BROKER['aws_bucket'])
         key = bucket.get_key(filename)
-        if(key == None):
-            return False
+        if key is None:
+            return 0
         else:
             return key.size
 


### PR DESCRIPTION
This is a hotfix to address an issue we had with initial validations getting stuck on dev. There's more to unpack here (_e.g._, is there a way to prevent the app from getting stuck when there's an unhandled exception like this, why is this suddenly a problem), but this should at least get folks past that first validation screen.