### PR TITLE
Use submission file when determining file size

### DIFF
--- a/dataactcore/aws/s3UrlHandler.py
+++ b/dataactcore/aws/s3UrlHandler.py
@@ -1,7 +1,12 @@
+import logging
 from datetime import datetime
 import boto
 from boto import sts
 from dataactcore.config import CONFIG_BROKER
+
+
+logger = logging.getLogger(__name__)
+
 
 class s3UrlHandler:
     """
@@ -99,6 +104,7 @@ class s3UrlHandler:
         bucket = s3connection.get_bucket(CONFIG_BROKER['aws_bucket'])
         key = bucket.get_key(filename)
         if key is None:
+            logger.warning("File doesn't exist on AWS: %s", filename)
             return 0
         else:
             return key.size

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -276,7 +276,7 @@ class ValidationManager:
 
         # Get file size and write to jobs table
         if CONFIG_BROKER["use_aws"]:
-            fileSize = s3UrlHandler.getFileSize(errorFileName)
+            fileSize = s3UrlHandler.getFileSize(fileName)
         else:
             fileSize = os.path.getsize(fileName)
         job.file_size = fileSize


### PR DESCRIPTION
We had been using the file size of an error report on AWS. This also adds a log message whenever we can't find the file to determine its size on AWS.