### PR TITLE
.codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,5 @@
+---
+languages:
+  Python: true
+exclude_paths:
+- "dataactcore/migrations/versions"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,24 @@
 ---
 languages:
   Python: true
+
+engines:
+  radon:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        python:
+          # bump up the mass, as the default
+          # was creating some unnecessary noise
+          # in duplication reports
+          mass_threshold: 40
+
+ratings:
+   paths:
+   - "**.py"
+
 exclude_paths:
 - "dataactcore/migrations/versions"
 - "tests/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,3 +3,4 @@ languages:
   Python: true
 exclude_paths:
 - "dataactcore/migrations/versions"
+- "tests/"


### PR DESCRIPTION
First stab at a custom .codeclimate.yml for this project. It explicitly excludes alembic migrations (which were previously included) and anything in`tests/` (no change...these were excluded before).

In an effort to make the reports more actionable, also disabled the similar code check. The duplication engine is still enabled, but the similar code check specifically was turning up what I consider to be distracting false positives.

Obviously, open for discussion!