### PR TITLE
Separate out superuser logic

### DIFF
--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -1,7 +1,7 @@
 from flask import request, session
 from dataactbroker.handlers.fileHandler import (
     FileHandler, narratives_for_submission, update_narratives)
-from dataactbroker.permissions import permissions_check
+from dataactbroker.permissions import permissions_check, requires_login
 from dataactbroker.handlers.aws.session import LoginSession
 from dataactbroker.exceptions.invalid_usage import InvalidUsage
 
@@ -27,37 +27,37 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return fileManager.finalize()
 
     @app.route("/v1/check_status/", methods = ["POST"])
-    @permissions_check
+    @requires_login
     def check_status():
         fileManager = FileHandler(request,isLocal=IS_LOCAL, serverPath=SERVER_PATH)
         return fileManager.getStatus()
 
     @app.route("/v1/submission_error_reports/", methods = ["POST"])
-    @permissions_check
+    @requires_login
     def submission_error_reports():
         fileManager = FileHandler(request,isLocal=IS_LOCAL, serverPath=SERVER_PATH)
         return fileManager.getErrorReportURLsForSubmission()
 
     @app.route("/v1/submission_warning_reports/", methods = ["POST"])
-    @permissions_check
+    @requires_login
     def submission_warning_reports():
         fileManager = FileHandler(request,isLocal=IS_LOCAL, serverPath=SERVER_PATH)
         return fileManager.getErrorReportURLsForSubmission(True)
 
     @app.route("/v1/error_metrics/", methods = ["POST"])
-    @permissions_check
+    @requires_login
     def submission_error_metrics():
         fileManager = FileHandler(request,isLocal=IS_LOCAL ,serverPath=SERVER_PATH)
         return fileManager.get_error_metrics()
 
     @app.route("/v1/local_upload/", methods = ["POST"])
-    @permissions_check
+    @requires_login
     def upload_local_file():
         fileManager = FileHandler(request,isLocal=IS_LOCAL, serverPath=SERVER_PATH)
         return fileManager.uploadFile()
 
     @app.route("/v1/list_submissions/", methods = ["GET"])
-    @permissions_check
+    @requires_login
     def list_submissions():
         """ List submission IDs associated with the current user """
 
@@ -88,7 +88,7 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return file_manager.list_submissions(page, limit, certified)
 
     @app.route("/v1/get_protected_files/", methods=["GET"])
-    @permissions_check
+    @requires_login
     def get_protected_files():
         """ Return signed URLs for all help page files """
         fileManager = FileHandler(request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)
@@ -102,7 +102,7 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return fileManager.generateFile()
 
     @app.route("/v1/check_generation_status/", methods=["POST"])
-    @permissions_check
+    @requires_login
     def check_generation_status():
         """ Return status of file generation job """
         fileManager = FileHandler(request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)
@@ -114,13 +114,13 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return fileManager.completeGeneration(generationId)
 
     @app.route("/v1/get_obligations/", methods = ["POST"])
-    @permissions_check
+    @requires_login
     def get_obligations():
         fileManager = FileHandler(request,isLocal=IS_LOCAL, serverPath=SERVER_PATH)
         return fileManager.getObligations()
 
     @app.route("/v1/sign_submission_file", methods = ["POST"])
-    @permissions_check
+    @requires_login
     def sign_submission_file():
         fileManager = FileHandler(request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)
         return fileManager.get_signed_url_for_submission_file()

--- a/dataactbroker/handlers/accountHandler.py
+++ b/dataactbroker/handlers/accountHandler.py
@@ -277,7 +277,7 @@ class AccountHandler:
                 filter(CGAC.cgac_code == cgac_code).\
                 one_or_none()
             agency_name = "Unknown" if agency_name is None else agency_name
-            for user in sess.query(User).filter_by(permission_type_id=PERMISSION_TYPE_DICT['website_admin']):
+            for user in sess.query(User).filter_by(website_admin=True):
                 email_template = {'[REG_NAME]': username, '[REG_TITLE]':title, '[REG_AGENCY_NAME]':agency_name,
                                  '[REG_CGAC_CODE]': cgac_code,'[REG_EMAIL]' : user_email,'[URL]':link}
                 new_email = sesEmail(user.email, system_email,templateType="account_creation",parameters=email_template)
@@ -869,13 +869,15 @@ class AccountHandler:
 
 def grant_superuser(user):
     user.cgac_code = 'SYS'
-    user.permission_type_id = PERMISSION_TYPE_DICT['website_admin']
+    user.website_admin = True
+    user.permission_type_id = PERMISSION_TYPE_DICT['writer']
 
 
 def grant_highest_permission(user, group_list, cgac_group):
     """Find the highest permission within the provided cgac_group; set that as
     the user's permission_type_id"""
     user.cgac_code = cgac_group[-3:]
+    user.website_admin = False
     permission_group = [g for g in group_list
                         if g.startswith(cgac_group + "-PERM_")]
     # Check if a user has been placed in a specific group. If not, deny access

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -57,7 +57,7 @@ def user_agency_matches(submission):
     return (
         submission_cgac == user_cgac
         or submission.user_id == user_id
-        or user_cgac == 'sys'
+        or user.website_admin
     )
 
 

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -11,19 +11,11 @@ from dataactcore.models.userModel import User
 from dataactbroker.exceptions.invalid_usage import InvalidUsage
 from dataactcore.models.lookups import PERMISSION_TYPE_DICT, PERMISSION_MAP, PERMISSION_TYPE_DICT_ID
 
-# This is used in conjunction with PERMISSION_TYPE_DICT to check if the permission passed in is part of the valid
-# set of values we allow to be checked.
-temp_perm_list = ["check_email_token", "check_password_token"]
-
-
 NOT_AUTHORIZED_MSG = ("You are not authorized to perform the requested task. "
                       "Please contact your administrator.")
 
-def permissions_check(f=None,permission=None):
-
-    # This will change to "if permission is not None and permission not in PERMISSION_TYPE_DICT" once the temp
-    # perms above are removed during the local login refactor
-    if permission is not None and permission not in list(PERMISSION_TYPE_DICT.keys()) + temp_perm_list:
+def permissions_check(f=None, permission=None):
+    if permission is not None and permission not in PERMISSION_TYPE_DICT:
         raise ValueError("{} not a valid permission".format(permission))
 
     def actual_decorator(f):
@@ -32,17 +24,7 @@ def permissions_check(f=None,permission=None):
             try:
                 sess = GlobalDB.db().session
                 error_message = "Login Required"
-                if permission == "check_email_token":
-                    if LoginSession.isRegistering(session):
-                        return f(*args, **kwargs)
-                    else :
-                        error_message = "unauthorized"
-                elif permission == "check_password_token":
-                    if LoginSession.isResetingPassword(session):
-                        return f(*args, **kwargs)
-                    else :
-                        error_message  = "unauthorized"
-                elif LoginSession.isLogin(session):
+                if LoginSession.isLogin(session):
                     user = sess.query(User).filter(User.user_id == session["name"]).one()
                     valid_user = True
 

--- a/dataactbroker/userRoutes.py
+++ b/dataactbroker/userRoutes.py
@@ -1,6 +1,6 @@
 from flask import request, session
 from dataactbroker.handlers.accountHandler import AccountHandler
-from dataactbroker.permissions import permissions_check
+from dataactbroker.permissions import permissions_check, requires_admin
 
 
 def add_user_routes(app,system_email,bcrypt):
@@ -21,14 +21,14 @@ def add_user_routes(app,system_email,bcrypt):
         return accountManager.register(system_email, session)
 
     @app.route("/v1/update_user/", methods=["POST"])
-    @permissions_check(permission="website_admin")
+    @requires_admin
     def update_user():
         """ Updates editable fields for the specified user """
         accountManager = AccountHandler(request, bcrypt=bcrypt)
         return accountManager.update_user(system_email)
 
     @app.route("/v1/delete_user/", methods=["POST"])
-    @permissions_check(permission="website_admin")
+    @requires_admin
     def delete_user():
         """ Updates editable fields for the specified user """
         accountManager = AccountHandler(request, bcrypt=bcrypt)
@@ -53,7 +53,7 @@ def add_user_routes(app,system_email,bcrypt):
         return accountManager.checkPasswordToken(session)
 
     @app.route("/v1/list_users/", methods=["POST"])
-    @permissions_check(permission="website_admin")
+    @requires_admin
     def list_users():
         """ list all users """
         accountManager = AccountHandler(request,bcrypt = bcrypt)
@@ -67,7 +67,7 @@ def add_user_routes(app,system_email,bcrypt):
         return accountManager.list_user_emails()
 
     @app.route("/v1/list_users_with_status/", methods = ["POST"])
-    @permissions_check(permission="website_admin")
+    @requires_admin
     def list_users_with_status():
         """ Expects request to have key 'status', will list all users with that status """
         accountManager = AccountHandler(request,bcrypt = bcrypt)

--- a/dataactbroker/userRoutes.py
+++ b/dataactbroker/userRoutes.py
@@ -2,7 +2,7 @@ from flask import request, session
 
 from dataactbroker.handlers.accountHandler import AccountHandler
 from dataactbroker.handlers.aws.session import LoginSession
-from dataactbroker.permissions import permissions_check, requires_admin
+from dataactbroker.permissions import requires_admin, requires_login
 from dataactcore.utils.jsonResponse import JsonResponse
 from dataactcore.utils.statusCode import StatusCode
 
@@ -68,7 +68,7 @@ def add_user_routes(app,system_email,bcrypt):
         return accountManager.list_users()
 
     @app.route("/v1/list_user_emails/", methods=["GET"])
-    @permissions_check
+    @requires_login
     def list_user_emails():
         """ list all users """
         accountManager = AccountHandler(request, bcrypt=bcrypt)
@@ -98,21 +98,21 @@ def add_user_routes(app,system_email,bcrypt):
         return accountManager.reset_password(system_email, session)
 
     @app.route("/v1/current_user/", methods=["GET"])
-    @permissions_check
+    @requires_login
     def current_user():
         """ gets the current user information """
         accountManager = AccountHandler(request,bcrypt = bcrypt)
         return accountManager.get_current_user(session)
 
     @app.route("/v1/set_skip_guide/", methods=["POST"])
-    @permissions_check
+    @requires_login
     def set_skip_guide():
         """ Sets skip_guide param for current user """
         accountManager = AccountHandler(request,bcrypt = bcrypt)
         return accountManager.set_skip_guide(session)
 
     @app.route("/v1/email_users/", methods=["POST"])
-    @permissions_check
+    @requires_login
     def email_users():
         """
         Sends email notifications to users that their submission is ready for review & publish viewing

--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -33,12 +33,16 @@ logger = logging.getLogger(__name__)
 HASH_ROUNDS = 12
 
 
-def createUserWithPassword(email, password, bcrypt, permission=1, cgac_code="SYS"):
+def createUserWithPassword(email, password, bcrypt, permission=1,
+                           cgac_code="SYS", website_admin=False):
     """Convenience function to set up fully-baked user (used for setup/testing only)."""
     sess = GlobalDB.db().session
     status = sess.query(UserStatus).filter(UserStatus.name == 'approved').one()
-    user = User(email=email, user_status=status, permission_type_id=permission,
-                cgac_code=cgac_code, name='Administrator', title='System Admin')
+    user = User(
+        email=email, user_status=status, permission_type_id=permission,
+        cgac_code=cgac_code, name='Administrator', title='System Admin',
+        website_admin=website_admin
+    )
     user.salt, user.password_hash = getPasswordHash(password, bcrypt)
     sess.add(user)
     sess.commit()

--- a/dataactcore/migrations/versions/963cad0fd72a_add_admin_field_to_user.py
+++ b/dataactcore/migrations/versions/963cad0fd72a_add_admin_field_to_user.py
@@ -1,0 +1,43 @@
+"""Add admin field to User
+
+Revision ID: 963cad0fd72a
+Revises: 9f7136e38e21
+Create Date: 2016-12-06 19:04:31.674777
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '963cad0fd72a'
+down_revision = '9f7136e38e21'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+
+
+
+def upgrade_data_broker():
+    op.add_column('users', sa.Column('website_admin', sa.Boolean(), server_default='False', nullable=False))
+    op.execute("""
+        UPDATE users SET website_admin = True, permission_type_id = 3
+        WHERE permission_type_id = 4
+    """)
+
+
+def downgrade_data_broker():
+    op.execute("""
+        UPDATE users SET permission_type_id = 4
+        WHERE website_admin = True
+    """)
+    op.drop_column('users', 'website_admin')

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -87,12 +87,12 @@ PERMISSION_TYPE = [
     LookupType(1, 'reader', 'This user is allowed to view any submission for their agency'),
     LookupType(2, 'writer', 'This user is allowed to create and edit any submission for their agency'),
     LookupType(3, 'submitter', 'This user is allowed to certify and submit any submission for their agency'),
-    LookupType(4, 'website_admin', 'This user is a super user and has full admin control')
+    # Placeholder 4: website_admin
 ]
 PERMISSION_TYPE_DICT = {item.name: item.id for item in PERMISSION_TYPE}
 PERMISSION_TYPE_DICT_ID = {item.id: item.name for item in PERMISSION_TYPE}
 PERMISSION_MAP = {'r': {'name': 'reader', 'order': 4}, 'w': {'name': 'writer', 'order': 3},
-                  's': {'name': 'submitter', 'order': 2}, 'a': {'name': 'website_admin', 'order': 1}}
+                  's': {'name': 'submitter', 'order': 2}}
 
 FIELD_TYPE = [
     LookupType(1, 'INT', 'integer type'),

--- a/dataactcore/models/userModel.py
+++ b/dataactcore/models/userModel.py
@@ -23,6 +23,8 @@ class User(Base):
     is_active = Column(Boolean, default=True, nullable=False, server_default="True")
     incorrect_password_attempts = Column(Integer, default=0, nullable=False, server_default='0')
     skip_guide = Column(Boolean, default=False,nullable=False,server_default="False")
+    website_admin = Column(Boolean, default=False, nullable=False,
+                           server_default="False")
 
 class PermissionType(Base):
     __tablename__ = "permission_type"

--- a/dataactcore/scripts/initialize.py
+++ b/dataactcore/scripts/initialize.py
@@ -18,7 +18,6 @@ from dataactvalidator.filestreaming.sqlLoader import SQLLoader
 from dataactvalidator.scripts.loadFile import loadDomainValues
 from dataactvalidator.scripts.load_sf133 import load_all_sf133
 from dataactvalidator.scripts.loadTas import loadTas
-from dataactcore.models.lookups import PERMISSION_TYPE_DICT
 
 logger = logging.getLogger(__name__)
 basePath = CONFIG_BROKER["path"]
@@ -44,7 +43,7 @@ def create_admin():
             # GlobalDB instead of databaseSession, move the app_context
             # creation up to initialize()
             user = createUserWithPassword(
-                admin_email, admin_pass, Bcrypt(), permission=PERMISSION_TYPE_DICT['website_admin'])
+                admin_email, admin_pass, Bcrypt(), website_admin=True)
     return user
 
 def load_tas_lookup():


### PR DESCRIPTION
We'll be allowing users to have multiple agencies with different levels of permission for each, so having the `website_admin` permission on the agency level doesn't make sense. This also removes two fictitious permission names.