### PR TITLE
MAX account help page access

### DIFF
--- a/dataactbroker/handlers/accountHandler.py
+++ b/dataactbroker/handlers/accountHandler.py
@@ -155,10 +155,6 @@ class AccountHandler:
 
             cgac_group = [g for g in group_list if g.startswith(parent_group+"-CGAC_")]
 
-            # Deny access if they are not aligned with an agency
-            if not cgac_group:
-                raise ValueError("You have logged in with MAX but do not have permission to access the broker.")
-
             try:
                 sess = GlobalDB.db().session
                 user = sess.query(User).filter(func.lower(User.email) == func.lower(email)).one_or_none()
@@ -192,7 +188,7 @@ class AccountHandler:
                 if [g for g in cgac_group if g.endswith("SYS")]:
                     grant_superuser(user)
                 else:
-                    grant_highest_permission(user, group_list, cgac_group[0])
+                    grant_highest_permission(user, group_list, cgac_group)
 
                 sess.add(user)
                 sess.commit()
@@ -880,17 +876,23 @@ def grant_superuser(user):
     user.permission_type_id = PERMISSION_TYPE_DICT['writer']
 
 
-def grant_highest_permission(user, group_list, cgac_group):
+def grant_highest_permission(user, group_list, cgac_group_list):
     """Find the highest permission within the provided cgac_group; set that as
     the user's permission_type_id"""
-    user.cgac_code = cgac_group[-3:]
     user.website_admin = False
+    if not cgac_group_list:
+        user.cgac_code = None
+        user.permission_type_id = None
+        return
+
+    cgac_group = cgac_group_list[0]
     permission_group = [g for g in group_list
                         if g.startswith(cgac_group + "-PERM_")]
     # Check if a user has been placed in a specific group. If not, deny access
     if not permission_group:
         user.permission_type_id = None
     else:
+        user.cgac_code = cgac_group[-3:]
         perms = [perm[-1].lower() for perm in permission_group]
         ordered_perms = sorted(
             PERMISSION_MAP.items(), key=lambda pair: pair[1]['order'])

--- a/tests/unit/dataactbroker/test_account_handler.py
+++ b/tests/unit/dataactbroker/test_account_handler.py
@@ -44,6 +44,33 @@ def test_max_login_success(database, user_constants, monkeypatch):
 
     assert "Login successful" == json.loads(json_response.get_data().decode("utf-8"))['message']
 
+    max_dict = {
+        'cas:serviceResponse':
+            {
+                'cas:authenticationSuccess':
+                    {
+                        'cas:attributes':
+                            {
+                                'maxAttribute:Email-Address': 'test-user-1@email.com',
+                                'maxAttribute:GroupList': '',
+                                'maxAttribute:First-Name': 'test-1',
+                                'maxAttribute:Middle-Name': '',
+                                'maxAttribute:Last-Name': 'user-1'
+                            }
+                    }
+            }
+    }
+    monkeypatch.setattr(ah, 'get_max_dict', Mock(return_value=max_dict))
+
+    # If it gets to this point, that means the user was in all the right groups aka successful login
+    monkeypatch.setattr(ah, 'create_session_and_response',
+                        Mock(return_value=JsonResponse.create(StatusCode.OK, {"message": "Login successful"})))
+    json_response = ah.max_login(Mock())
+
+    print(json.loads(json_response.get_data().decode("utf-8")))
+
+    assert "Login successful" == json.loads(json_response.get_data().decode("utf-8"))['message']
+
 
 def test_max_login_failure(monkeypatch):
     ah = accountHandler.AccountHandler(Mock())
@@ -62,56 +89,16 @@ def test_max_login_failure(monkeypatch):
     # Did not get a successful response from MAX
     assert error_message == json.loads(json_response.get_data().decode("utf-8"))['message']
 
-    max_dict = {
-                    'cas:serviceResponse':
-                    {
-                        'cas:authenticationSuccess':
-                        {
-                            'cas:attributes':
-                            {
-                                'maxAttribute:Email-Address': '',
-                                'maxAttribute:GroupList': ''
-                            }
-                        }
-                     }
-                }
-    monkeypatch.setattr(ah, 'get_max_dict', Mock(return_value=max_dict))
-    json_response = ah.max_login(Mock())
-    error_message = "You have logged in with MAX but do not have permission to access the broker."
-
-    # Not in parent group
-    assert error_message == json.loads(json_response.get_data().decode("utf-8"))['message']
-
-    max_dict = {
-        'cas:serviceResponse':
-            {
-                'cas:authenticationSuccess':
-                    {
-                        'cas:attributes':
-                            {
-                                'maxAttribute:Email-Address': '',
-                                'maxAttribute:GroupList': 'parent-group'
-                            }
-                    }
-            }
-    }
-    monkeypatch.setattr(ah, 'get_max_dict', Mock(return_value=max_dict))
-    json_response = ah.max_login(Mock())
-    error_message = "You have logged in with MAX but do not have permission to access the broker."
-
-    # Not in cgac group
-    assert error_message == json.loads(json_response.get_data().decode("utf-8"))['message']
-
 
 def test_grant_highest_permission():
     """Verify that we get the _highest_ permission within our CGAC"""
     user = UserFactory()
     group_list = ['prefix-ABC-PERM_R', 'prefix-ABC-PERM_S']
-    accountHandler.grant_highest_permission(user, group_list, 'prefix-ABC')
+    accountHandler.grant_highest_permission(user, group_list, ['prefix-ABC'])
     assert user.cgac_code == 'ABC'
     assert user.permission_type_id == PERMISSION_TYPE_DICT['submitter']
 
     group_list = ['prefix-ABC-PERM_W']
-    accountHandler.grant_highest_permission(user, group_list, 'prefix-ABC')
+    accountHandler.grant_highest_permission(user, group_list, ['prefix-ABC'])
     assert user.cgac_code == 'ABC'
     assert user.permission_type_id == PERMISSION_TYPE_DICT['writer']

--- a/tests/unit/dataactbroker/test_account_handler.py
+++ b/tests/unit/dataactbroker/test_account_handler.py
@@ -67,8 +67,6 @@ def test_max_login_success(database, user_constants, monkeypatch):
                         Mock(return_value=JsonResponse.create(StatusCode.OK, {"message": "Login successful"})))
     json_response = ah.max_login(Mock())
 
-    print(json.loads(json_response.get_data().decode("utf-8")))
-
     assert "Login successful" == json.loads(json_response.get_data().decode("utf-8"))['message']
 
 


### PR DESCRIPTION
Allowing anyone with a max account the ability to see the help pages by removing the CGAC check and only setting the CGAC if it's available.