### PR TITLE
Use affiliations to determine permissions, part 1

### DIFF
--- a/dataactbroker/handlers/accountHandler.py
+++ b/dataactbroker/handlers/accountHandler.py
@@ -467,6 +467,9 @@ def set_max_perms(user, max_group_list):
     or
     {parent-group}-CGAC_SYS to indicate website_admin"""
     prefix = CONFIG_BROKER['parent_group'] + '-CGAC_'
+
+    # Each group name that we care about begins with the prefix, but once we
+    # have that list, we don't need the prefix anymore, so trim it off.
     perms = [group_name[len(prefix):]
              for group_name in max_group_list.split(',')
              if group_name.startswith(prefix)]

--- a/dataactbroker/handlers/accountHandler.py
+++ b/dataactbroker/handlers/accountHandler.py
@@ -1,6 +1,8 @@
+import logging
+from operator import attrgetter
 import re
-import time
 import requests
+import time
 import xmltodict
 
 from dateutil.parser import parse
@@ -21,7 +23,11 @@ from dataactcore.models.jobModels import Submission
 from dataactcore.utils.statusCode import StatusCode
 from dataactcore.interfaces.function_bag import get_email_template, check_correct_password, updateLastLogin
 from dataactcore.config import CONFIG_BROKER
-from dataactcore.models.lookups import USER_STATUS_DICT, PERMISSION_TYPE_DICT, PERMISSION_MAP
+from dataactcore.models.lookups import (
+    PERMISSION_SHORT_DICT, PERMISSION_TYPE_DICT, USER_STATUS_DICT)
+
+
+logger = logging.getLogger(__name__)
 
 
 class AccountHandler:
@@ -140,20 +146,16 @@ class AccountHandler:
             # Obtain POST content
             ticket = safeDictionary.getValue("ticket")
             service = safeDictionary.getValue('service')
-            parent_group = CONFIG_BROKER['parent_group']
 
             # Call MAX's serviceValidate endpoint and retrieve the response
             max_dict = self.get_max_dict(ticket, service)
 
             if not 'cas:authenticationSuccess' in max_dict['cas:serviceResponse']:
                 raise ValueError("You have failed to login successfully with MAX")
+            cas_attrs = max_dict['cas:serviceResponse']['cas:authenticationSuccess']['cas:attributes']
 
             # Grab the email and list of groups from MAX's response
-            email = max_dict['cas:serviceResponse']['cas:authenticationSuccess']['cas:attributes']['maxAttribute:Email-Address']
-            group_list_all = max_dict['cas:serviceResponse']['cas:authenticationSuccess']['cas:attributes']['maxAttribute:GroupList'].split(',')
-            group_list = [g for g in group_list_all if g.startswith(parent_group)]
-
-            cgac_group = [g for g in group_list if g.startswith(parent_group+"-CGAC_")]
+            email = cas_attrs['maxAttribute:Email-Address']
 
             try:
                 sess = GlobalDB.db().session
@@ -164,12 +166,9 @@ class AccountHandler:
                 if user is None:
                     user = User()
 
-                    first_name = max_dict["cas:serviceResponse"]['cas:authenticationSuccess']['cas:attributes'][
-                        'maxAttribute:First-Name']
-                    middle_name = max_dict["cas:serviceResponse"]['cas:authenticationSuccess']['cas:attributes'][
-                        'maxAttribute:Middle-Name']
-                    last_name = max_dict["cas:serviceResponse"]['cas:authenticationSuccess']['cas:attributes'][
-                        'maxAttribute:Last-Name']
+                    first_name = cas_attrs['maxAttribute:First-Name']
+                    middle_name = cas_attrs['maxAttribute:Middle-Name']
+                    last_name = cas_attrs['maxAttribute:Last-Name']
 
                     user.email = email
 
@@ -182,13 +181,7 @@ class AccountHandler:
                     user.user_status_id = user.user_status_id = USER_STATUS_DICT['approved']
 
 
-                # update user's cgac based on their current membership
-                # If part of the SYS agency, use that as the cgac otherwise
-                # use the first agency provided
-                if [g for g in cgac_group if g.endswith("SYS")]:
-                    grant_superuser(user)
-                else:
-                    grant_highest_permission(user, group_list, cgac_group)
+                set_max_perms(user, cas_attrs['maxAttribute:GroupList'])
 
                 sess.add(user)
                 sess.commit()
@@ -430,39 +423,67 @@ class AccountHandler:
         return JsonResponse.create(StatusCode.OK, {"message": "Emails successfully sent"})
 
 
-def grant_superuser(user):
-    user.cgac_code = 'SYS'
-    user.website_admin = True
-    user.permission_type_id = PERMISSION_TYPE_DICT['writer']
+def perms_to_affiliations(perms):
+    """Convert a list of perms from MAX to a list of UserAffiliations. Filter
+    out and log any malformed perms"""
+    available_codes = {
+        cgac.cgac_code:cgac
+        for cgac in GlobalDB.db().session.query(CGAC)
+    }
+    for perm in perms:
+        components = perm.split('-PERM_')
+        if len(components) != 2:
+            logger.warning('Malformed permission: %s', perm)
+            continue
+
+        cgac_code, perm_level = components
+        perm_level = perm_level.lower()
+        if cgac_code not in available_codes or perm_level not in 'rws':
+            logger.warning('Malformed permission: %s', perm)
+            continue
+
+        yield UserAffiliation(
+            cgac=available_codes[cgac_code],
+            permission_type_id=PERMISSION_SHORT_DICT[perm_level]
+        )
 
 
-def grant_highest_permission(user, group_list, cgac_group_list):
-    """Find the highest permission within the provided cgac_group; set that as
-    the user's permission_type_id"""
-    sess = GlobalDB.db().session
-    user.website_admin = False
-    if not cgac_group_list:
-        user.cgac_code = None
-        user.permission_type_id = None
-        return
+def best_affiliation(affiliations):
+    """If a user has multiple permissions for a single agency, select the
+    best"""
+    by_agency = {}
+    affiliations = sorted(affiliations, key=attrgetter('permission_type_id'))
+    for affiliation in affiliations:
+        by_agency[affiliation.cgac] = affiliation
+    return by_agency.values()
 
-    cgac_group = cgac_group_list[0]
-    permission_group = [g for g in group_list
-                        if g.startswith(cgac_group + "-PERM_")]
-    # Check if a user has been placed in a specific group. If not, deny access
-    if not permission_group:
-        user.permission_type_id = None
+
+def set_max_perms(user, max_group_list):
+    """Convert the user group lists present on MAX into a list of
+    UserAffiliations and/or website_admin status.
+
+    Permissions are encoded as a comma-separated list of
+    {parent-group}-CGAC_{cgac-code}-PERM_{one-of-R-W-S}
+    or
+    {parent-group}-CGAC_SYS to indicate website_admin"""
+    prefix = CONFIG_BROKER['parent_group'] + '-CGAC_'
+    perms = [group_name[len(prefix):]
+             for group_name in max_group_list.split(',')
+             if group_name.startswith(prefix)]
+    if 'SYS' in perms:
+        user.affiliations = []
+        user.cgac_code = 'SYS'
+        user.website_admin = True
+        user.permission_type_id = PERMISSION_TYPE_DICT['writer']
     else:
-        user.cgac_code = cgac_group[-3:]
-        perms = [perm[-1].lower() for perm in permission_group]
-        ordered_perms = sorted(
-            PERMISSION_MAP.items(), key=lambda pair: pair[1]['order'])
-        for key, permission in ordered_perms:
-            name = permission['name']
-            if key in perms:
-                user.permission_type_id = PERMISSION_TYPE_DICT[name]
-                break
-    user.affiliations = [UserAffiliation(
-        cgac=sess.query(CGAC).filter_by(cgac_code=user.cgac_code).one(),
-        permission_type_id=user.permission_type_id
-    )]
+        affiliations = list(best_affiliation(perms_to_affiliations(perms)))
+
+        if affiliations:
+            user.cgac_code = affiliations[0].cgac.cgac_code
+            user.permission_type_id = affiliations[0].permission_type_id
+        else:
+            user.cgac_code = None
+            user.prmission_type_id = None
+
+        user.affiliations = affiliations
+        user.website_admin = False

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.exc import NoResultFound
 from werkzeug import secure_filename
 
+from dataactbroker.permissions import current_user_can_on_submission
 from dataactcore.aws.s3UrlHandler import s3UrlHandler
 from dataactcore.config import CONFIG_BROKER, CONFIG_SERVICES
 from dataactcore.interfaces.db import GlobalDB
@@ -385,7 +386,7 @@ class FileHandler:
             # Compare user ID with user who submitted job, if no match return 400
             job = sess.query(Job).filter_by(job_id = job_id).one()
             submission = sess.query(Submission).filter_by(submission_id = job.submission_id).one()
-            if not user_agency_matches(submission):
+            if not current_user_can_on_submission('writer', submission):
                 # This user cannot finalize this job
                 raise ResponseException(
                     "Cannot finalize a job for a different agency",

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -368,7 +368,7 @@ class FileHandler:
 
         return start_date, end_date
 
-    def finalize(self, job_id=None):
+    def finalize(self):
         """ Set upload job in job tracker database to finished, allowing dependent jobs to be started
 
         Flask request should include key "upload_id", which holds the job_id for the file_upload job
@@ -379,9 +379,8 @@ class FileHandler:
         sess = GlobalDB.db().session
         response_dict = {}
         try:
-            if job_id is None:
-                input_dictionary = RequestDictionary(self.request)
-                job_id = input_dictionary.getValue("upload_id")
+            input_dictionary = RequestDictionary(self.request)
+            job_id = input_dictionary.getValue("upload_id")
 
             # Compare user ID with user who submitted job, if no match return 400
             job = sess.query(Job).filter_by(job_id = job_id).one()

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -875,7 +875,7 @@ class FileHandler:
             return error_response
 
         # Return same response as check generation route
-        return self.checkGeneration(submission_id, file_type)
+        return self.checkGeneration()
 
     def generate_detached_file(self):
         """ Start a file generation job for the specified file type """
@@ -949,7 +949,7 @@ class FileHandler:
 
         return JsonResponse.create(StatusCode.OK, response_dict)
 
-    def checkGeneration(self, submission_id=None, file_type=None):
+    def checkGeneration(self):
         """ Return information about file generation jobs
 
         Returns:
@@ -957,8 +957,7 @@ class FileHandler:
             If file_type is D1 or D2, also includes start and end.
         """
         sess = GlobalDB.db().session
-        if submission_id is None or file_type is None:
-            submission_id, file_type = self.get_request_params_for_generate()
+        submission_id, file_type = self.get_request_params_for_generate()
         # Check permission to submission
         self.check_submission_by_id(submission_id, file_type)
 

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -7,7 +7,7 @@ from dataactcore.utils.responseException import ResponseException
 from dataactcore.utils.statusCode import StatusCode
 from dataactcore.interfaces.db import GlobalDB
 from dataactbroker.exceptions.invalid_usage import InvalidUsage
-from dataactcore.models.lookups import PERMISSION_TYPE_DICT, PERMISSION_MAP, PERMISSION_TYPE_DICT_ID
+from dataactcore.models.lookups import PERMISSION_TYPE_DICT
 
 NOT_AUTHORIZED_MSG = ("You are not authorized to perform the requested task. "
                       "Please contact your administrator.")
@@ -26,12 +26,9 @@ def permissions_check(f=None, permission=None):
                     valid_user = True
 
                     if permission is not None and not g.user.website_admin:
-                        perm_hierarchy = {d['name']: d['order'] for d in PERMISSION_MAP.values()}
-                        # if the users permission is not higher than the one specified, check their permission
-                        # if user's perm order is < than what's passed in, it means they have higher permissions
-                        if perm_hierarchy[PERMISSION_TYPE_DICT_ID[g.user.permission_type_id]] > perm_hierarchy[permission]:
-                            if not g.user.permission_type_id == PERMISSION_TYPE_DICT[permission]:
-                                valid_user = False
+                        permission_id = PERMISSION_TYPE_DICT[permission]
+                        if g.user.permission_type_id < permission_id:
+                            valid_user = False
 
                     if valid_user:
                         return f(*args, **kwargs)

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -81,3 +81,22 @@ def requires_admin(func):
 
         return func(*args, **kwargs)
     return inner
+
+
+def current_user_can(permission, cgac_code):
+    """Can the current user perform the act (described by the permission
+    level) for the given cgac_code?"""
+    admin = hasattr(g, 'user') and g.user.website_admin
+    has_affil = hasattr(g, 'user') and any(
+        aff.cgac.cgac_code == cgac_code
+        and aff.permission_type_id >= PERMISSION_TYPE_DICT[permission]
+        for aff in g.user.affiliations
+    )
+    return admin or has_affil
+
+
+def current_user_can_on_submission(perm, submission):
+    """Submissions add another permission possibility: if a user created a
+    submission, they can do anything to it, regardless of submission agency"""
+    is_owner = hasattr(g, 'user') and submission.user_id == g.user.user_id
+    return is_owner or current_user_can(perm, submission.cgac_code)

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -92,8 +92,7 @@ PERMISSION_TYPE = [
 ]
 PERMISSION_TYPE_DICT = {item.name: item.id for item in PERMISSION_TYPE}
 PERMISSION_TYPE_DICT_ID = {item.id: item.name for item in PERMISSION_TYPE}
-PERMISSION_MAP = {'r': {'name': 'reader', 'order': 4}, 'w': {'name': 'writer', 'order': 3},
-                  's': {'name': 'submitter', 'order': 2}}
+PERMISSION_SHORT_DICT = {item.name[0]: item.id for item in PERMISSION_TYPE}
 
 FIELD_TYPE = [
     LookupType(1, 'INT', 'integer type'),

--- a/tests/integration/baseTestAPI.py
+++ b/tests/integration/baseTestAPI.py
@@ -11,7 +11,8 @@ from dataactbroker.app import createApp as createBrokerApp
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.interfaces.function_bag import createUserWithPassword, getPasswordHash
 from dataactcore.models import lookups
-from dataactcore.models.userModel import User, UserStatus
+from dataactcore.models.domainModels import CGAC
+from dataactcore.models.userModel import User, UserAffiliation, UserStatus
 from dataactcore.scripts.databaseSetup import dropDatabase
 from dataactcore.scripts.setupUserDB import setupUserDB
 from dataactcore.scripts.setupJobTrackerDB import setupJobTrackerDB
@@ -77,13 +78,19 @@ class BaseTestAPI(unittest.TestCase):
 
             # get user info and save as class variables for use by tests
             sess = GlobalDB.db().session
+            cgac = CGAC(cgac_code='000', agency_name='Example Agency')
 
             # set up users for status tests
             def add_status_user(email, status_name, website_admin=False):
                 sess.add(UserFactory(
                     email=email, user_status_id=USER_STATUS_DICT[status_name],
                     permission_type_id=PERMISSION_TYPE_DICT['writer'],
-                    website_admin=website_admin))
+                    website_admin=website_admin,
+                    affiliations=[UserAffiliation(
+                        cgac=cgac,
+                        permission_type_id=PERMISSION_TYPE_DICT['writer']
+                    )]
+                ))
             add_status_user('user@agency.gov', 'awaiting_confirmation')
             add_status_user('realEmail@agency.gov', 'email_confirmed')
             add_status_user('waiting@agency.gov', 'awaiting_approval')

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,7 @@
 from random import randint
 import os.path
 
+from flask import Flask, g
 import pytest
 
 import dataactcore.config
@@ -74,3 +75,13 @@ def mock_broker_config_paths(tmpdir):
 
     for key in keys_to_replace:
         dataactcore.config.CONFIG_BROKER[key] = original[key]
+
+@pytest.fixture
+def test_app(database):
+    """Gets us in the application context, where we can set/use g.
+    Particularly useful if we're checking `g` in multiple modules (and hence
+    Mocking them out would be a pain)"""
+    app = Flask('test-app')
+    with app.app_context():
+        g._db = database
+        yield app.test_client()

--- a/tests/unit/dataactbroker/test_account_handler.py
+++ b/tests/unit/dataactbroker/test_account_handler.py
@@ -9,6 +9,23 @@ from tests.unit.dataactcore.factories.domain import CGACFactory
 from tests.unit.dataactcore.factories.user import UserFactory
 
 
+def make_max_dict(group_str):
+    """We need to create mock MAX data at multiple points in these tests"""
+    return {
+        'cas:serviceResponse': {
+            'cas:authenticationSuccess': {
+                'cas:attributes': {
+                    'maxAttribute:Email-Address': 'test-user@email.com',
+                    'maxAttribute:GroupList': group_str,
+                    'maxAttribute:First-Name': 'test',
+                    'maxAttribute:Middle-Name': '',
+                    'maxAttribute:Last-Name': 'user'
+                }
+            }
+        }
+    }
+
+
 def test_max_login_success(database, user_constants, monkeypatch):
     ah = accountHandler.AccountHandler(Mock())
 
@@ -20,22 +37,7 @@ def test_max_login_success(database, user_constants, monkeypatch):
     monkeypatch.setattr(ah, 'get_max_dict', Mock(return_value=max_dict))
     config = {'parent_group': 'parent-group'}
     monkeypatch.setattr(accountHandler, 'CONFIG_BROKER', config)
-    max_dict = {
-        'cas:serviceResponse':
-            {
-                'cas:authenticationSuccess':
-                    {
-                        'cas:attributes':
-                            {
-                                'maxAttribute:Email-Address': 'test-user@email.com',
-                                'maxAttribute:GroupList': 'parent-group,parent-group-CGAC_SYS',
-                                'maxAttribute:First-Name': 'test',
-                                'maxAttribute:Middle-Name': '',
-                                'maxAttribute:Last-Name': 'user'
-                            }
-                    }
-            }
-    }
+    max_dict = make_max_dict('parent-group,parent-group-CGAC_SYS')
     monkeypatch.setattr(ah, 'get_max_dict', Mock(return_value=max_dict))
 
     # If it gets to this point, that means the user was in all the right groups aka successful login
@@ -45,22 +47,7 @@ def test_max_login_success(database, user_constants, monkeypatch):
 
     assert "Login successful" == json.loads(json_response.get_data().decode("utf-8"))['message']
 
-    max_dict = {
-        'cas:serviceResponse':
-            {
-                'cas:authenticationSuccess':
-                    {
-                        'cas:attributes':
-                            {
-                                'maxAttribute:Email-Address': 'test-user-1@email.com',
-                                'maxAttribute:GroupList': '',
-                                'maxAttribute:First-Name': 'test-1',
-                                'maxAttribute:Middle-Name': '',
-                                'maxAttribute:Last-Name': 'user-1'
-                            }
-                    }
-            }
-    }
+    max_dict = make_max_dict('')
     monkeypatch.setattr(ah, 'get_max_dict', Mock(return_value=max_dict))
 
     # If it gets to this point, that means the user was in all the right groups aka successful login
@@ -89,29 +76,43 @@ def test_max_login_failure(monkeypatch):
     assert error_message == json.loads(json_response.get_data().decode("utf-8"))['message']
 
 
-def test_grant_highest_permission(database, user_constants):
+def test_set_max_perms(database, monkeypatch, user_constants):
     """Verify that we get the _highest_ permission within our CGAC"""
-    cgac = CGACFactory(cgac_code='ABC')
+    cgac_abc = CGACFactory(cgac_code='ABC')
+    cgac_def = CGACFactory(cgac_code='DEF')
     user = UserFactory()
-    database.session.add_all([cgac, user])
+    database.session.add_all([cgac_abc, cgac_def, user])
     database.session.commit()
 
-    group_list = ['prefix-ABC-PERM_R', 'prefix-ABC-PERM_S']
-    accountHandler.grant_highest_permission(user, group_list, ['prefix-ABC'])
+    monkeypatch.setitem(accountHandler.CONFIG_BROKER, 'parent_group',
+                        'prefix')
+    accountHandler.set_max_perms(
+        user, 'prefix-CGAC_ABC-PERM_R,prefix-CGAC_ABC-PERM_S')
     database.session.commit()   # populate ids
     assert user.cgac_code == 'ABC'
     assert user.permission_type_id == PERMISSION_TYPE_DICT['submitter']
     assert len(user.affiliations) == 1
     affil = user.affiliations[0]
-    assert affil.cgac_id == cgac.cgac_id
+    assert affil.cgac_id == cgac_abc.cgac_id
     assert affil.permission_type_id == PERMISSION_TYPE_DICT['submitter']
 
-    group_list = ['prefix-ABC-PERM_W']
-    accountHandler.grant_highest_permission(user, group_list, ['prefix-ABC'])
+    accountHandler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_W')
     database.session.commit()   # populate ids
     assert user.cgac_code == 'ABC'
     assert user.permission_type_id == PERMISSION_TYPE_DICT['writer']
     assert len(user.affiliations) == 1
     affil = user.affiliations[0]
-    assert affil.cgac_id == cgac.cgac_id
+    assert affil.cgac_id == cgac_abc.cgac_id
     assert affil.permission_type_id == PERMISSION_TYPE_DICT['writer']
+
+    accountHandler.set_max_perms(
+        user, 'prefix-CGAC_ABC-PERM_R,prefix-CGAC_DEF-PERM_S')
+    database.session.commit()
+    assert len(user.affiliations) == 2
+    affiliations = list(sorted(user.affiliations,
+                               key=lambda a:a.cgac.cgac_code))
+    abc_aff, def_aff = affiliations
+    assert abc_aff.cgac.cgac_code == 'ABC'
+    assert abc_aff.permission_type_id == PERMISSION_TYPE_DICT['reader']
+    assert def_aff.cgac.cgac_code == 'DEF'
+    assert def_aff.permission_type_id == PERMISSION_TYPE_DICT['submitter']

--- a/tests/unit/dataactbroker/test_domainRoutes.py
+++ b/tests/unit/dataactbroker/test_domainRoutes.py
@@ -1,7 +1,6 @@
 import json
 from unittest.mock import Mock
 
-from flask import Flask
 import pytest
 
 from dataactbroker import domainRoutes
@@ -12,11 +11,9 @@ from tests.unit.dataactcore.factories.user import UserFactory
 
 
 @pytest.fixture
-def domain_app():
-    app = Flask('test-app')
-    domainRoutes.add_domain_routes(app)
-    app.teardown_appcontext(lambda exception: GlobalDB.close())
-    yield app.test_client()
+def domain_app(test_app):
+    domainRoutes.add_domain_routes(test_app.application)
+    yield test_app
 
 
 def test_list_agencies_limits(monkeypatch, user_constants, domain_app):

--- a/tests/unit/dataactbroker/test_permissions.py
+++ b/tests/unit/dataactbroker/test_permissions.py
@@ -1,0 +1,49 @@
+from unittest.mock import Mock
+
+from dataactbroker import permissions
+from dataactcore.models.lookups import PERMISSION_TYPE_DICT
+from dataactcore.models.userModel import UserAffiliation
+from tests.unit.dataactcore.factories.domain import CGACFactory
+from tests.unit.dataactcore.factories.job import SubmissionFactory
+from tests.unit.dataactcore.factories.user import UserFactory
+
+
+def test_current_user_can(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user = UserFactory(affiliations=[
+        UserAffiliation(cgac=user_cgac,
+                        permission_type_id=PERMISSION_TYPE_DICT['writer'])
+    ])
+    database.session.add_all([user_cgac, other_cgac, user])
+    database.session.commit()
+
+    monkeypatch.setattr(permissions, 'g', Mock(user=user))
+
+    # has permission level, but wrong agency
+    assert not permissions.current_user_can('reader', other_cgac.cgac_code)
+    # has agency, but not permission level
+    assert not permissions.current_user_can('submitter', user_cgac.cgac_code)
+    # right agency, right permission
+    assert permissions.current_user_can('writer', user_cgac.cgac_code)
+    assert permissions.current_user_can('reader', user_cgac.cgac_code)
+    # wrong permission level, wrong agency, but superuser
+    user.website_admin = True
+    assert permissions.current_user_can('submitter', user_cgac.cgac_code)
+
+
+def test_current_user_can_on_submission(monkeypatch, database):
+    submission = SubmissionFactory()
+    user = UserFactory()
+    database.session.add_all([submission, user])
+    database.session.commit()
+
+    current_user_can = Mock()
+    monkeypatch.setattr(permissions, 'g', Mock(user=user))
+    monkeypatch.setattr(permissions, 'current_user_can', current_user_can)
+
+    current_user_can.return_value = True
+    assert permissions.current_user_can_on_submission('reader', submission)
+    current_user_can.return_value = False
+    assert not permissions.current_user_can_on_submission('reader', submission)
+    submission.user_id = user.user_id
+    assert permissions.current_user_can_on_submission('reader', submission)


### PR DESCRIPTION
This includes the first half of an effort to replace our permissions checks (which rely on a user's _single_ permission level) to a per-agency check. Easiest to step through changeset by changeset, but this is largely foundation for part 2, which makes use of these functions.

* Read in multiple user affiliations from MAX
* Remove unused parameters
* Add functions to check user permission for a specific agency