### PR TITLE
Use affiliations to determine permissions, part 2

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -22,7 +22,15 @@ dataactbroker/
 The `/dataactbroker/scripts` folder contains the install scripts needed to setup the broker API for a local install. For complete instructions on running your own copy of the API and other DATA Act broker components, please refer to the [documentation in the DATA Act core responsitory](https://github.com/fedspendingtransparency/data-act-broker-backend/blob/master/doc/INSTALL.md "DATA Act broker installation guide").
 
 ### Handlers
-The `dataactbroker/handlers` folder contains the logic to handle requests that are dispatched from the `loginRoutes.py`, `fileRoutes.py`, and 'userRoutes.py' files. Routes defined in these files may include the `@permissions_check` tag to the route definition. This tag adds a wrapper that checks if there exists a session for the current user and if the user is logged in, as well as checking the user's permissions to determine if the user has access to this route. If user is not logged in to the system or does not have access to the route, a 401 HTTP error will be returned. This tag is defined in `dataactbroker/permissions.py`.
+The `dataactbroker/handlers` folder contains the logic to handle requests that
+are dispatched from the `loginRoutes.py`, `fileRoutes.py`, and 'userRoutes.py'
+files. Routes defined in these files may include the `@requires_login` and
+`@requires_submission_perms` tags to the route definition. This tag adds a
+wrapper that checks if there exists a session for the current user and if the
+user is logged in, as well as checking the user's permissions to determine if
+the user has access to this route. If user is not logged in to the system or
+does not have access to the route, a 401 HTTP error will be returned. This
+tags are defined in `dataactbroker/permissions.py`.
 
 `accountHandler.py` contains the functions to check logins and to log users out.
 

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -22,15 +22,7 @@ dataactbroker/
 The `/dataactbroker/scripts` folder contains the install scripts needed to setup the broker API for a local install. For complete instructions on running your own copy of the API and other DATA Act broker components, please refer to the [documentation in the DATA Act core responsitory](https://github.com/fedspendingtransparency/data-act-broker-backend/blob/master/doc/INSTALL.md "DATA Act broker installation guide").
 
 ### Handlers
-The `dataactbroker/handlers` folder contains the logic to handle requests that
-are dispatched from the `loginRoutes.py`, `fileRoutes.py`, and 'userRoutes.py'
-files. Routes defined in these files may include the `@requires_login` and
-`@requires_submission_perms` tags to the route definition. This tag adds a
-wrapper that checks if there exists a session for the current user and if the
-user is logged in, as well as checking the user's permissions to determine if
-the user has access to this route. If user is not logged in to the system or
-does not have access to the route, a 401 HTTP error will be returned. This
-tags are defined in `dataactbroker/permissions.py`.
+The `dataactbroker/handlers` folder contains the logic to handle requests that are dispatched from the `loginRoutes.py`, `fileRoutes.py`, and 'userRoutes.py' files. Routes defined in these files may include the `@requires_login` and `@requires_submission_perms` tags to the route definition. This tag adds a wrapper that checks if there exists a session for the current user and if the user is logged in, as well as checking the user's permissions to determine if the user has access to this route. If user is not logged in to the system or does not have access to the route, a 401 HTTP error will be returned. This tags are defined in `dataactbroker/permissions.py`.
 
 `accountHandler.py` contains the functions to check logins and to log users out.
 

--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -7,8 +7,7 @@ from dataactbroker.handlers.fileHandler import (
     FileHandler, get_error_metrics, get_status, narratives_for_submission,
     update_narratives
 )
-from dataactbroker.permissions import (
-    permissions_check, requires_login, requires_submission_perms)
+from dataactbroker.permissions import requires_login, requires_submission_perms
 from dataactcore.utils.requestDictionary import RequestDictionary
 from dataactcore.utils.responseException import ResponseException
 from dataactcore.utils.statusCode import StatusCode
@@ -111,14 +110,14 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return file_manager.generate_file(submission_id)
 
     @app.route("/v1/generate_detached_file/", methods=["POST"])
-    @permissions_check(permission="reader")
+    @requires_login
     def generate_detached_file():
         """ Generate a file from external API, independent from a submission """
         fileManager = FileHandler(request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)
         return fileManager.generate_detached_file()
 
     @app.route("/v1/check_detached_generation_status/", methods=["POST"])
-    @permissions_check
+    @requires_login
     def check_detached_generation_status():
         """ Return status of file generation job """
         fileManager = FileHandler(request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)

--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -146,11 +146,13 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return JsonResponse.create(
             StatusCode.OK, get_submission_stats(submission.submission_id))
 
-    @app.route("/v1/sign_submission_file", methods = ["POST"])
-    @requires_login
-    def sign_submission_file():
-        fileManager = FileHandler(request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)
-        return fileManager.get_signed_url_for_submission_file()
+    @app.route("/v1/sign_submission_file", methods=["POST"])
+    @convert_to_submission_id
+    @requires_submission_perms('reader')
+    def sign_submission_file(submission):
+        file_handler = FileHandler(
+            request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)
+        return file_handler.get_signed_url_for_submission_file(submission)
 
     @app.route("/v1/submission/<int:submission_id>/narrative", methods=['GET'])
     @requires_submission_perms('reader')

--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -1,8 +1,10 @@
 from flask import request
+
+from dataactbroker.exceptions.invalid_usage import InvalidUsage
 from dataactbroker.handlers.fileHandler import (
     FileHandler, narratives_for_submission, update_narratives)
-from dataactbroker.permissions import permissions_check, requires_login
-from dataactbroker.exceptions.invalid_usage import InvalidUsage
+from dataactbroker.permissions import (
+    permissions_check, requires_login, requires_submission_perms)
 
 
 # Add the file submission route
@@ -139,15 +141,15 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return fileManager.get_signed_url_for_submission_file()
 
     @app.route("/v1/submission/<int:submission_id>/narrative", methods=['GET'])
-    @permissions_check(permission='reader')
-    def get_submission_narratives(submission_id):
-        return narratives_for_submission(int(submission_id))
+    @requires_submission_perms('reader')
+    def get_submission_narratives(submission):
+        return narratives_for_submission(submission)
 
     @app.route("/v1/submission/<int:submission_id>/narrative", methods=['POST'])
-    @permissions_check(permission='writer')
-    def post_submission_narratives(submission_id):
+    @requires_submission_perms('writer')
+    def post_submission_narratives(submission):
         json = request.json or {}
         # clean input
         json = {key.upper():value.strip() for key, value in json.items()
                 if isinstance(value, str) and value.strip()}
-        return update_narratives(int(submission_id), json)
+        return update_narratives(submission, json)

--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -4,7 +4,9 @@ from flask import request
 
 from dataactbroker.exceptions.invalid_usage import InvalidUsage
 from dataactbroker.handlers.fileHandler import (
-    FileHandler, get_status, narratives_for_submission, update_narratives)
+    FileHandler, get_error_metrics, get_status, narratives_for_submission,
+    update_narratives
+)
 from dataactbroker.permissions import (
     permissions_check, requires_login, requires_submission_perms)
 from dataactcore.utils.requestDictionary import RequestDictionary
@@ -50,11 +52,11 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         fileManager = FileHandler(request,isLocal=IS_LOCAL, serverPath=SERVER_PATH)
         return fileManager.getErrorReportURLsForSubmission(True)
 
-    @app.route("/v1/error_metrics/", methods = ["POST"])
-    @requires_login
-    def submission_error_metrics():
-        fileManager = FileHandler(request,isLocal=IS_LOCAL ,serverPath=SERVER_PATH)
-        return fileManager.get_error_metrics()
+    @app.route("/v1/error_metrics/", methods=["POST"])
+    @convert_to_submission_id
+    @requires_submission_perms('reader')
+    def submission_error_metrics(submission):
+        return get_error_metrics(submission)
 
     @app.route("/v1/local_upload/", methods = ["POST"])
     @requires_login

--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -14,7 +14,7 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
     SERVER_PATH  = serverPath
     # Keys for the post route will correspond to the four types of files
     @app.route("/v1/submit_files/", methods = ["POST"])
-    @permissions_check(permission="writer")
+    @requires_login
     def submit_files():
         fileManager = FileHandler(request,isLocal=IS_LOCAL, serverPath=SERVER_PATH)
         return fileManager.submit(CreateCredentials)

--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -20,7 +20,7 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return fileManager.submit(CreateCredentials)
 
     @app.route("/v1/finalize_job/", methods = ["POST"])
-    @permissions_check(permission="writer")
+    @requires_login
     def finalize_submission():
         fileManager = FileHandler(request,isLocal=IS_LOCAL, serverPath=SERVER_PATH)
         return fileManager.finalize()

--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -103,11 +103,12 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return fileManager.getProtectedFiles()
 
     @app.route("/v1/generate_file/", methods=["POST"])
-    @permissions_check(permission="writer")
-    def generate_file():
+    @convert_to_submission_id
+    def generate_file(submission_id):
         """ Generate file from external API """
-        fileManager = FileHandler(request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)
-        return fileManager.generateFile()
+        file_manager = FileHandler(
+            request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)
+        return file_manager.generate_file(submission_id)
 
     @app.route("/v1/generate_detached_file/", methods=["POST"])
     @permissions_check(permission="reader")
@@ -124,11 +125,13 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return fileManager.check_detached_generation()
 
     @app.route("/v1/check_generation_status/", methods=["POST"])
-    @requires_login
-    def check_generation_status():
+    @convert_to_submission_id
+    @requires_submission_perms('reader')
+    def check_generation_status(submission):
         """ Return status of file generation job """
-        fileManager = FileHandler(request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)
-        return fileManager.checkGeneration()
+        file_manager = FileHandler(
+            request, isLocal=IS_LOCAL, serverPath=SERVER_PATH)
+        return file_manager.check_generation(submission)
 
     @app.route("/v1/complete_generation/<generationId>/", methods=["POST"])
     def complete_generation(generationId):

--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -7,7 +7,9 @@ from dataactbroker.handlers.fileHandler import (
     FileHandler, get_error_metrics, get_status, narratives_for_submission,
     update_narratives
 )
+from dataactcore.interfaces.function_bag import get_submission_stats
 from dataactbroker.permissions import requires_login, requires_submission_perms
+from dataactcore.utils.jsonResponse import JsonResponse
 from dataactcore.utils.requestDictionary import RequestDictionary
 from dataactcore.utils.responseException import ResponseException
 from dataactcore.utils.statusCode import StatusCode
@@ -138,10 +140,11 @@ def add_file_routes(app,CreateCredentials,isLocal,serverPath,bcrypt):
         return fileManager.complete_generation(generationId)
 
     @app.route("/v1/get_obligations/", methods = ["POST"])
-    @requires_login
-    def get_obligations():
-        fileManager = FileHandler(request,isLocal=IS_LOCAL, serverPath=SERVER_PATH)
-        return fileManager.getObligations()
+    @convert_to_submission_id
+    @requires_submission_perms('reader')
+    def get_obligations(submission):
+        return JsonResponse.create(
+            StatusCode.OK, get_submission_stats(submission.submission_id))
 
     @app.route("/v1/sign_submission_file", methods = ["POST"])
     @requires_login

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -36,9 +36,10 @@ from dataactcore.utils.responseException import ResponseException
 from dataactcore.utils.statusCode import StatusCode
 from dataactcore.utils.stringCleaner import StringCleaner
 from dataactcore.interfaces.function_bag import (
-    checkNumberOfErrorsByJobId, getErrorType, run_job_checks,
-    getErrorMetricsByJobId, get_submission_stats, get_submission_status,
-    mark_job_status, create_submission, create_jobs)
+    checkNumberOfErrorsByJobId, create_jobs, create_submission,
+    getErrorMetricsByJobId, getErrorType, get_submission_status,
+    mark_job_status, run_job_checks
+)
 from dataactvalidator.filestreaming.csv_selection import write_csv
 
 _debug_logger = logging.getLogger('deprecated.debug')
@@ -973,20 +974,6 @@ class FileHandler:
         except NoResultFound as e:
             # Did not find file generation task
             return JsonResponse.error(ResponseException("Generation task key not found", StatusCode.CLIENT_ERROR), StatusCode.CLIENT_ERROR)
-
-    def getObligations(self):
-        sess = GlobalDB.db().session
-        input_dictionary = RequestDictionary(self.request)
-
-        # Get submission
-        submission_id = input_dictionary.getValue("submission_id")
-        submission = sess.query(Submission).filter_by(submission_id=submission_id).one()
-
-        user_agency_must_match(submission)
-
-        obligations_info = get_submission_stats(submission_id)
-
-        return JsonResponse.create(StatusCode.OK,obligations_info)
 
     def list_submissions(self, page, limit, certified):
         """ List submission based on current page and amount to display. If provided, filter based on

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -47,28 +47,6 @@ _smx_logger = logging.getLogger('deprecated.smx')
 logger = logging.getLogger(__name__)
 
 
-def user_agency_matches(submission):
-    """Does the currently logged in user have an agency that matches this
-    submission?"""
-    sess = GlobalDB.db().session
-    submission_cgac = StringCleaner.cleanString(submission.cgac_code)
-    user_cgac = StringCleaner.cleanString(g.user.cgac_code)
-    return (
-        submission_cgac == user_cgac
-        or submission.user_id == g.user.user_id
-        or g.user.website_admin
-    )
-
-
-def user_agency_must_match(submission):
-    """Raise an exception if the logged in user doesn't have an agency match
-    with this submission"""
-    if not user_agency_matches(submission):
-        raise ResponseException(
-            "User does not have permission to view that submission",
-            StatusCode.PERMISSION_DENIED)
-
-
 class FileHandler:
     """ Responsible for all tasks relating to file upload
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -151,18 +151,13 @@ class FileHandler:
             # Unexpected exception, this is a 500 server error
             return JsonResponse.error(e, StatusCode.INTERNAL_ERROR)
 
-    def get_signed_url_for_submission_file(self):
+    def get_signed_url_for_submission_file(self, submission):
         """ Gets the signed URL for the specified file """
         try:
             sess = GlobalDB.db().session
             self.s3manager = s3UrlHandler()
-            safe_dictionary = RequestDictionary(self.request)
-            file_name = safe_dictionary.getValue("file") + ".csv"
-            submission_id = safe_dictionary.getValue("submission")
-            submission = sess.query(Submission).filter_by(submission_id = submission_id).one()
-            # Check that user has access to submission
-            # If they don't, throw an exception
-            user_agency_must_match(submission)
+            safe_dictionary = RequestDictionary.derive(self.request)
+            file_name = safe_dictionary["file"] + ".csv"
 
             response_dict = {}
             if self.isLocal:

--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -390,13 +390,10 @@ def create_submission(user_id, submission_values, existing_submission):
     Returns:
         submission object
     """
-    sess = GlobalDB.db().session
-
     if existing_submission is None:
         submission = Submission(datetime_utc = datetime.utcnow(), **submission_values)
         submission.user_id = user_id
         submission.publish_status_id = PUBLISH_STATUS_DICT['unpublished']
-        sess.add(submission)
     else:
         submission = existing_submission
         if submission.publish_status_id == PUBLISH_STATUS_DICT['published']:
@@ -407,7 +404,6 @@ def create_submission(user_id, submission_values, existing_submission):
             # update existing submission with any values provided
             setattr(submission, key, submission_values[key])
 
-    sess.commit()
     return submission
 
 def create_jobs(upload_files, submission, existing_submission=False):

--- a/dataactcore/models/jobModels.py
+++ b/dataactcore/models/jobModels.py
@@ -52,6 +52,7 @@ class Submission(Base):
     submission_id = Column(Integer, primary_key=True)
     datetime_utc = Column(DateTime)
     user_id = Column(Integer, ForeignKey("users.user_id", ondelete="SET NULL", name="fk_submission_user"), nullable=True)
+    user = relationship("User")
     cgac_code = Column(Text)
     reporting_start_date = Column(Date, nullable=False)
     reporting_end_date = Column(Date, nullable=False)

--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -120,41 +120,6 @@ def test_list_submissions_failure(database, job_constants, monkeypatch):
     delete_models(database, [user, sub, job])
 
 
-def test_requires_submission_perm_no_submission(database, monkeypatch):
-    """If no submission exists, we should see an exception"""
-    monkeypatch.setattr(fileHandler, 'user_agency_matches',
-                        Mock(return_value=True))
-
-    sub = SubmissionFactory()
-    database.session.add(sub)
-    database.session.commit()
-
-    fn = fileHandler.requires_submission_perms(Mock())
-    # Does not raise exception
-    fn(sub.submission_id)
-    with pytest.raises(ResponseException):
-        fn(sub.submission_id + 1)   # different submission id
-
-
-def test_requires_submission_perm_check(database, monkeypatch):
-    """If the user doesn't have a matching agency, we should see an
-    exception"""
-    sub = SubmissionFactory()
-    database.session.add(sub)
-    database.session.commit()
-
-    fn = fileHandler.requires_submission_perms(Mock())
-    # Does not raise exception
-    monkeypatch.setattr(fileHandler, 'user_agency_matches',
-                        Mock(return_value=True))
-    fn(sub.submission_id)
-
-    monkeypatch.setattr(fileHandler, 'user_agency_matches',
-                        Mock(return_value=False))
-    with pytest.raises(ResponseException):
-        fn(sub.submission_id)
-
-
 def test_narratives(database, job_constants, monkeypatch):
     """Verify that we can add, retrieve, and update submission narratives. Not
     quite a unit test as it covers a few functions in sequence"""
@@ -166,14 +131,13 @@ def test_narratives(database, job_constants, monkeypatch):
 
     # Write some narratives
     result = fileHandler.update_narratives(
-        sub1.submission_id, {'B': 'BBBBBB', 'E': 'EEEEEE'})
+        sub1, {'B': 'BBBBBB', 'E': 'EEEEEE'})
     assert result.status_code == 200
-    result = fileHandler.update_narratives(
-        sub2.submission_id, {'A': 'Submission2'})
+    result = fileHandler.update_narratives(sub2, {'A': 'Submission2'})
     assert result.status_code == 200
 
     # Check the narratives
-    result = fileHandler.narratives_for_submission(sub1.submission_id)
+    result = fileHandler.narratives_for_submission(sub1)
     result = json.loads(result.get_data().decode('UTF-8'))
     assert result == {
         'A': '',
@@ -187,11 +151,11 @@ def test_narratives(database, job_constants, monkeypatch):
 
     # Replace the narratives
     result = fileHandler.update_narratives(
-        sub1.submission_id, {'A': 'AAAAAA', 'E': 'E2E2E2'})
+        sub1, {'A': 'AAAAAA', 'E': 'E2E2E2'})
     assert result.status_code == 200
 
     # Verify the change worked
-    result = fileHandler.narratives_for_submission(sub1.submission_id)
+    result = fileHandler.narratives_for_submission(sub1)
     result = json.loads(result.get_data().decode('UTF-8'))
     assert result == {
         'A': 'AAAAAA',

--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -120,11 +120,9 @@ def test_list_submissions_failure(database, job_constants, monkeypatch):
     delete_models(database, [user, sub, job])
 
 
-def test_narratives(database, job_constants, monkeypatch):
+def test_narratives(database, job_constants):
     """Verify that we can add, retrieve, and update submission narratives. Not
     quite a unit test as it covers a few functions in sequence"""
-    monkeypatch.setattr(fileHandler, 'user_agency_matches',
-                        Mock(return_value=True))
     sub1, sub2 = SubmissionFactory(), SubmissionFactory()
     database.session.add_all([sub1, sub2])
     database.session.commit()

--- a/tests/unit/dataactbroker/test_handlers_fileHandler_sign_url.py
+++ b/tests/unit/dataactbroker/test_handlers_fileHandler_sign_url.py
@@ -9,13 +9,12 @@ def test_get_signed_url_for_submission_file_local(database, monkeypatch):
     database.session.commit()
 
     file_handler = fileHandler.FileHandler(Mock(), isLocal=True, serverPath="/test/server/path/")
-    monkeypatch.setattr(fileHandler, 'user_agency_matches', Mock(return_value=True))
+    monkeypatch.setattr(fileHandler, 'RequestDictionary', Mock(derive=Mock(
+        return_value={'file': 'file_name'}
+    )))
 
-    mock_dict = Mock()
-    mock_dict.return_value.getValue.side_effect = ['file_name', str(submission.submission_id)]
-    monkeypatch.setattr(fileHandler, 'RequestDictionary', mock_dict)
 
-    json_response = file_handler.get_signed_url_for_submission_file()
+    json_response = file_handler.get_signed_url_for_submission_file(submission)
     assert json.loads(json_response.get_data().decode("utf-8"))['url'] == "/test/server/path/file_name.csv"
 
 def test_get_signed_url_for_submission_file_s3(database, monkeypatch):
@@ -24,16 +23,13 @@ def test_get_signed_url_for_submission_file_s3(database, monkeypatch):
     database.session.commit()
 
     file_handler = fileHandler.FileHandler(Mock(), isLocal=False)
-    monkeypatch.setattr(fileHandler, 'user_agency_matches', Mock(return_value=True))
-
-    mock_dict = Mock()
-    mock_dict.return_value.getValue.side_effect = ['file_name', str(submission.submission_id)]
-    monkeypatch.setattr(fileHandler, 'RequestDictionary', mock_dict)
+    monkeypatch.setattr(fileHandler, 'RequestDictionary', Mock(derive=Mock(
+        return_value={'file': 'file_name'}
+    )))
 
     mock_dict = Mock()
     mock_dict.return_value.getSignedUrl.return_value = '/signed/url/path/file_name.csv'
     monkeypatch.setattr(fileHandler, 's3UrlHandler', mock_dict)
-    file_handler.s3manager.getSignedUrl = Mock()
 
-    json_response = file_handler.get_signed_url_for_submission_file()
+    json_response = file_handler.get_signed_url_for_submission_file(submission)
     assert json.loads(json_response.get_data().decode("utf-8"))['url'] == '/signed/url/path/file_name.csv'

--- a/tests/unit/dataactbroker/test_permissions.py
+++ b/tests/unit/dataactbroker/test_permissions.py
@@ -1,8 +1,12 @@
 from unittest.mock import Mock
 
+from flask import g
+import pytest
+
 from dataactbroker import permissions
 from dataactcore.models.lookups import PERMISSION_TYPE_DICT
 from dataactcore.models.userModel import UserAffiliation
+from dataactcore.utils.responseException import ResponseException
 from tests.unit.dataactcore.factories.domain import CGACFactory
 from tests.unit.dataactcore.factories.job import SubmissionFactory
 from tests.unit.dataactcore.factories.user import UserFactory
@@ -47,3 +51,17 @@ def test_current_user_can_on_submission(monkeypatch, database):
     assert not permissions.current_user_can_on_submission('reader', submission)
     submission.user_id = user.user_id
     assert permissions.current_user_can_on_submission('reader', submission)
+
+
+def test_requires_submission_perm_no_submission(database, test_app):
+    """If no submission exists, we should see an exception"""
+    sub = SubmissionFactory(user=UserFactory())
+    database.session.add(sub)
+    database.session.commit()
+    g.user = sub.user
+
+    fn = permissions.requires_submission_perms('writer')(Mock())
+    # Does not raise exception
+    fn(sub.submission_id)
+    with pytest.raises(ResponseException):
+        fn(sub.submission_id + 1)   # different submission id


### PR DESCRIPTION
Builds on #467 ([diff](https://github.com/fedspendingtransparency/data-act-broker-backend/compare/db-1386-3-permission-setup...db-1386-4-use-permissions))

This adds goes through each of the `fileHandler` endpoints and switches each over to inspect user affiliations for permissions. A lot of code changes, but it's relatively repetitive after the foundation is laid in the first few commits.

Tested this locally as a `website_admin` and on sandbox as a `writer` (but not admin).