### PR TITLE
Include agency_name in submission info

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -387,12 +387,13 @@ status objects for each job under the key "jobs", and other submission-level dat
         - original_label: Label of the rule as it appears in the practices and procedures document
     * warning_data: Holds the same information as error_data, but for warnings instead of errors
 - agency_name: Which agency this submission is attached to
+- cgac_code: The CGAC code associated with that agency
 - reporting_period_start_date: Specified by user at time of submission
 - reporting_period_end_date: Specified by user at time of submission
 - number_of_errors: Total number of errors that have occurred throughout the submission
-- number_of_warnings: Total number of warnings throughout submission
-- number_of_rows: 446
-- created_on": Date the submission was originally created
+- number_of_rows: Total number of rows in the submission
+- created_on: Date the submission was originally created
+- last_updated: Date + time of last modification to this submission
 
 
 Example input:
@@ -409,70 +410,66 @@ Example output:
 {
   "jobs": [
     {
-    "job_id": 3005,
-    "job_status": "invalid",
-    "file_type": "appropriations",
-    "job_type": "file_upload",
-    "filename": "approp.csv",
-    "file_status" : "header_error",
-    "missing_headers": ["header_1", "header_2"],
-    "duplicated_headers": ["header_3", "header_4"],
-    "file_size": 4508,
-    "number_of_rows": 500,
-    "error_type": "header_error",
-    "error_data": [],
-    "warning_data": []
-    },
-    {
-    "job_id": 3006,
-    "job_status": "finished",
-    "file_type": "appropriations",
-    "job_type": "file_upload",
-    "filename": "approp.csv",
-    "file_status" : "complete",
-    "missing_headers": [],
-    "duplicated_headers": [],
-    "file_size": 4508,
-    "number_of_rows": 500,
-    "error_type": "record_level_error",
-    "error_data":  [
-    {
-    "field_name": "allocationtransferagencyid",
-    "error_name": "type_error",
-    "error_description": "The value provided was of the wrong type",
-    "occurrences": 27,
-    "rule_failed": "",
-    "original_label":""
-    },
-    {
-    "field_name": "availabilitytypecode",
-    "error_name": "rule_failed",
-    "error_description": "Failed rule: Indicator must be X, F, A, or blank",
-    "occurrences": 27,
-    "rule_failed": "Failed rule: Indicator must be X, F, A, or blank",
-    "original_label":"A21"
-    }
-    ],
-    "warning_data": [
-    {
-    "field_name": "allocationtransferagencyid",
-    "error_name": "rule_failed",
-    "error_description": "BorrowingAuthorityAmountTotal_CPE= CPE aggregate value for GTAS SF 133 line #1340 + #1440",
-    "occurrences": 27,
-    "rule_failed": "BorrowingAuthorityAmountTotal_CPE= CPE aggregate value for GTAS SF 133 line #1340 + #1440",
-    "original_label":"A10"
-    },
-    {
-    "field_name": "availabilitytypecode",
-    "error_name": "rule_failed",
-    "error_description": "Failed rule: Indicator must be X, F, A, or blank",
-    "occurrences": 27,
-    "rule_failed": "Failed rule: Indicator must be X, F, A, or blank",
-    "original_label":"A21"
-    }
-    ]
-    },
-    {
+      "job_id": 3005,
+      "job_status": "invalid",
+      "file_type": "appropriations",
+      "job_type": "file_upload",
+      "filename": "approp.csv",
+      "file_status" : "header_error",
+      "missing_headers": ["header_1", "header_2"],
+      "duplicated_headers": ["header_3", "header_4"],
+      "file_size": 4508,
+      "number_of_rows": 500,
+      "error_type": "header_error",
+      "error_data": [],
+      "warning_data": []
+    }, {
+      "job_id": 3006,
+      "job_status": "finished",
+      "file_type": "appropriations",
+      "job_type": "file_upload",
+      "filename": "approp.csv",
+      "file_status" : "complete",
+      "missing_headers": [],
+      "duplicated_headers": [],
+      "file_size": 4508,
+      "number_of_rows": 500,
+      "error_type": "record_level_error",
+      "error_data":  [
+        {
+          "field_name": "allocationtransferagencyid",
+          "error_name": "type_error",
+          "error_description": "The value provided was of the wrong type",
+          "occurrences": 27,
+          "rule_failed": "",
+          "original_label":""
+        }, {
+          "field_name": "availabilitytypecode",
+          "error_name": "rule_failed",
+          "error_description": "Failed rule: Indicator must be X, F, A, or blank",
+          "occurrences": 27,
+          "rule_failed": "Failed rule: Indicator must be X, F, A, or blank",
+          "original_label":"A21"
+        }
+      ],
+      "warning_data": [
+        {
+          "field_name": "allocationtransferagencyid",
+          "error_name": "rule_failed",
+          "error_description": "BorrowingAuthorityAmountTotal_CPE= CPE aggregate value for GTAS SF 133 line #1340 + #1440",
+          "occurrences": 27,
+          "rule_failed": "BorrowingAuthorityAmountTotal_CPE= CPE aggregate value for GTAS SF 133 line #1340 + #1440",
+          "original_label":"A10"
+        }, {
+          "field_name": "availabilitytypecode",
+          "error_name": "rule_failed",
+          "error_description": "Failed rule: Indicator must be X, F, A, or blank",
+          "occurrences": 27,
+          "rule_failed": "Failed rule: Indicator must be X, F, A, or blank",
+          "original_label":"A21"
+        }
+      ]
+    }, {
       "job_status": "finished",
       "error_data": [
         {
@@ -482,8 +479,7 @@ Example output:
           "occurrences": "11",
           "rule_failed": "Must have either a piid, fain, or uri",
           "original_label":""
-        },
-        {
+        }, {
           "error_description": "A rule failed for this value",
           "error_name": "rule_failed",
           "field_name": "award",
@@ -506,11 +502,13 @@ Example output:
     }
   ],
   "agency_name": "Name of the agency",
+  "cgac_code": "012",
   "reporting_period_start_date": "03/31/2016",
   "reporting_period_end_date": "03/31/2016",
   "number_of_errors": 54,
   "number_of_rows": 446,
   "created_on": "04/01/2016"
+  "last_updated": "2016-04-01T09:10:11"
 }
 ```
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1091,9 +1091,9 @@ def reporting_date(submission):
         return submission.reporting_start_date.strftime("%m/%Y")
 
 
-def submission_to_dict(submission):
+def submission_to_dict_for_status(submission):
     """Convert a Submission model into a dictionary, ready to be serialized as
-    JSON"""
+    JSON for the get_status function"""
     sess = GlobalDB.db().session
 
     number_of_rows = sess.query(func.sum(Job.number_of_rows)).\
@@ -1139,7 +1139,7 @@ def get_status(submission):
     """
     try:
         return JsonResponse.create(
-            StatusCode.OK, submission_to_dict(submission))
+            StatusCode.OK, submission_to_dict_for_status(submission))
     except ResponseException as e:
         return JsonResponse.error(e,e.status)
     except Exception as e:

--- a/dataactcore/models/errorModels.py
+++ b/dataactcore/models/errorModels.py
@@ -3,6 +3,7 @@
 from sqlalchemy import Column, Integer, Text, ForeignKey
 from sqlalchemy.orm import relationship
 from dataactcore.models.baseModel import Base
+from dataactcore.models.lookups import FILE_STATUS_DICT_ID
 
 
 class FileStatus(Base):
@@ -31,6 +32,10 @@ class File(Base):
     file_status = relationship("FileStatus", uselist=False)
     headers_missing = Column(Text, nullable=True)
     headers_duplicated = Column(Text, nullable=True)
+
+    @property
+    def file_status_name(self):
+        return FILE_STATUS_DICT_ID.get(self.file_status_id)
 
 class ErrorMetadata(Base):
     __tablename__ = "error_metadata"

--- a/dataactcore/models/jobModels.py
+++ b/dataactcore/models/jobModels.py
@@ -5,6 +5,8 @@ from sqlalchemy import (
     UniqueConstraint) 
 from sqlalchemy.orm import relationship
 from dataactcore.models.baseModel import Base
+from dataactcore.models.lookups import (
+    FILE_TYPE_DICT_ID, JOB_STATUS_DICT_ID, JOB_TYPE_DICT_ID)
 
 
 def generateFiscalYear(context):
@@ -89,6 +91,19 @@ class Job(Base):
     start_date = Column(Date)
     end_date = Column(Date)
     user_id = Column(Integer, ForeignKey("users.user_id", ondelete="SET NULL", name="fk_job_user"), nullable=True)
+
+    @property
+    def job_type_name(self):
+        return JOB_TYPE_DICT_ID.get(self.job_type_id)
+
+    @property
+    def job_status_name(self):
+        return JOB_STATUS_DICT_ID.get(self.job_status_id)
+
+    @property
+    def file_type_name(self):
+        return FILE_TYPE_DICT_ID.get(self.file_type_id)
+
 
 class JobDependency(Base):
     __tablename__ = "job_dependency"

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -21,6 +21,7 @@ FILE_STATUS = [
     LookupType(6, 'incomplete', 'File has not yet been validated')
 ]
 FILE_STATUS_DICT = {item.name: item.id for item in FILE_STATUS}
+FILE_STATUS_DICT_ID = {item.id: item.name for item in FILE_STATUS}
 
 ERROR_TYPE = [
     LookupType(1, 'type_error', 'The value provided was of the wrong type'),
@@ -52,6 +53,7 @@ JOB_TYPE = [
     LookupType(5, 'external_validation', 'new information must be validated against external sources')
 ]
 JOB_TYPE_DICT = {item.name: item.id for item in JOB_TYPE}
+JOB_TYPE_DICT_ID = {item.id: item.name for item in JOB_TYPE}
 
 PUBLISH_STATUS = [
     LookupType(1, 'unpublished', 'Has not yet been moved to data store'),

--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -260,13 +260,13 @@ def test_submission_bad_dates(start_date, end_date, quarter_flag, submission):
         fh.check_submission_dates(start_date, end_date, quarter_flag, submission)
 
 
-def test_submission_to_dict(database):
+def test_submission_to_dict_for_status(database):
     cgac = CGACFactory(cgac_code='abcdef', agency_name='Age')
     sub = SubmissionFactory(cgac_code='abcdef', number_of_errors=1234)
     database.session.add_all([cgac, sub])
     database.session.commit()
 
-    result = fileHandler.submission_to_dict(sub)
+    result = fileHandler.submission_to_dict_for_status(sub)
     assert result['cgac_code'] == 'abcdef'
     assert result['agency_name'] == 'Age'
     assert result['number_of_errors'] == 1234

--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -258,3 +258,15 @@ def test_submission_bad_dates(start_date, end_date, quarter_flag, submission):
     fh = fileHandler.FileHandler(Mock())
     with pytest.raises(ResponseException):
         fh.check_submission_dates(start_date, end_date, quarter_flag, submission)
+
+
+def test_submission_to_dict(database):
+    cgac = CGACFactory(cgac_code='abcdef', agency_name='Age')
+    sub = SubmissionFactory(cgac_code='abcdef', number_of_errors=1234)
+    database.session.add_all([cgac, sub])
+    database.session.commit()
+
+    result = fileHandler.submission_to_dict(sub)
+    assert result['cgac_code'] == 'abcdef'
+    assert result['agency_name'] == 'Age'
+    assert result['number_of_errors'] == 1234


### PR DESCRIPTION
We can look up this information by calling the agency list API, but why do that when we can include it in the agency response? This also gave a good opportunity to disentangle some of the submission/job-to-dictionary logic into separate functions.