### PR TITLE
Account for non-existent attributes in file E

### DIFF
--- a/dataactcore/utils/fileE.py
+++ b/dataactcore/utils/fileE.py
@@ -72,14 +72,15 @@ Row = namedtuple('Row', (
 def sudsToRow(sudsObj):
     """Convert a Suds result object into a Row tuple. This accounts for the
     presence/absence of top-paid officers"""
-    comp = sudsObj.coreData.listOfExecutiveCompensationInformation
+    comp = getattr(sudsObj.coreData, 'listOfExecutiveCompensationInformation',
+                   '')
     officers = []
     officer_data = getattr(comp, 'executiveCompensationDetail', [])
     officer_data = sorted(officer_data, key=attrgetter('compensation'),
                           reverse=True)
     for data in officer_data:
-        officers.append(data.name)
-        officers.append(data.compensation)
+        officers.append(getattr(data, 'name', ''))
+        officers.append(getattr(data, 'compensation', ''))
 
     # Only top 5
     officers = officers[:10]

--- a/tests/unit/dataactcore/test_utils_fileE.py
+++ b/tests/unit/dataactcore/test_utils_fileE.py
@@ -56,6 +56,12 @@ def test_sudsToRow_no_compensation():
         'A Duns', 'Par Duns', 'Par Name', '', '', '', '', '', '', '', '',
         '', '')
 
+    del sudsObj.coreData.listOfExecutiveCompensationInformation
+    row = fileE.sudsToRow(sudsObj)
+    assert row == fileE.Row(
+        'A Duns', 'Par Duns', 'Par Name', '', '', '', '', '', '', '', '',
+        '', '')
+
 
 def test_sudsToRow_too_few_compensation():
     sudsObj = make_suds('B Duns', 'Par DunsB', 'Par NameB')


### PR DESCRIPTION
In some situations, these attributes are empty (represented by the empty
string); in other situations they are not present. Account for both
situations and test.

Found this bug while updating authentication credentials.