### PR TITLE
Bug fix for B9/10 Validation for File C only

### DIFF
--- a/dataactvalidator/config/sqlrules/b9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/b9_award_financial.sql
@@ -16,10 +16,8 @@ WHERE af.submission_id = {0}
 				AND af.agency_identifier IS NOT DISTINCT FROM pa.agency_id
 				AND af.allocation_transfer_agency IS NOT DISTINCT FROM pa.allocation_transfer_id
 				AND af.main_account_code IS NOT DISTINCT FROM pa.account_number
-				AND (
-					(af.program_activity_name IS NOT DISTINCT FROM pa.program_activity_name AND af.program_activity_code IS NOT DISTINCT FROM pa.program_activity_code)
-					OR (af.program_activity_name IS NULL AND af.program_activity_code IS NULL)
-				)
-			)
+				AND af.program_activity_name IS NOT DISTINCT FROM pa.program_activity_name
+				AND af.program_activity_code IS NOT DISTINCT FROM pa.program_activity_code)
+				OR (af.program_activity_name IS NULL AND af.program_activity_code IS NULL)
 		WHERE af.submission_id = {0}
 	);

--- a/tests/unit/dataactvalidator/test_b9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_b9_award_financial.py
@@ -78,4 +78,4 @@ def test_failure_program_activity_null(database):
     pa = ProgramActivityFactory(budget_year=2016, agency_id='test', allocation_transfer_id='test',
                                 account_number='test')
 
-    assert number_of_errors(_FILE, database, models=[af, pa]) == 1
+    assert number_of_errors(_FILE, database, models=[af, pa]) == 0

--- a/tests/unit/dataactvalidator/test_b9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_b9_award_financial.py
@@ -69,7 +69,7 @@ def test_failure_program_activity_code(database):
     assert number_of_errors(_FILE, database, models=[af, pa]) == 1
 
 
-def test_failure_program_activity_null(database):
+def test_success_null_program_activity(database):
     """program activity name/code as null"""
     af = AwardFinancialFactory(row_number=1, beginning_period_of_availa=2016, agency_identifier='test_wrong',
                                allocation_transfer_agency='test', main_account_code='test',


### PR DESCRIPTION
Updating B9/10 for File C to exclude those rows with both a null program activity code and null program activity name, updated tests