### PR TITLE
Add back all of the model types

### DIFF
--- a/dataactcore/migrations/env.py
+++ b/dataactcore/migrations/env.py
@@ -7,7 +7,11 @@ import sys
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from dataactcore.models import baseModel
+# Load all DB tables into metadata object
+# @todo - load these dynamically
+from dataactcore.models import (baseModel, domainModels, fsrs, errorModels, jobModels, stagingModels, # noqa
+                                userModel, validationModels)
+
 from dataactcore.config import CONFIG_DB
 from dataactcore.interfaces.db import dbURI
 from dataactcore.logging import configure_logging


### PR DESCRIPTION
Alembic needs to know about all of the app's models, which means we need to
import them. This line was taken out during a recent refactor, but we still
need it until we can load those models dynamically.

This fixes alembic migration generation; it _may_ be required to upgrade the database.