### PR TITLE
Modify B12 to be able to submit blank D/R fields to 4831, 4832, and 4931

### DIFF
--- a/dataactvalidator/config/sqlrules/b12_award_financial_1.sql
+++ b/dataactvalidator/config/sqlrules/b12_award_financial_1.sql
@@ -5,15 +5,12 @@ FROM award_financial AS af
 WHERE af.submission_id = {} AND (
     ussgl480100_undelivered_or_fyb IS NOT NULL
     OR ussgl480100_undelivered_or_cpe IS NOT NULL
-    OR ussgl483100_undelivered_or_cpe IS NOT NULL
     OR ussgl488100_upward_adjustm_cpe IS NOT NULL
     OR ussgl490100_delivered_orde_fyb IS NOT NULL
     OR ussgl490100_delivered_orde_cpe IS NOT NULL
-    OR ussgl493100_delivered_orde_cpe IS NOT NULL
     OR ussgl498100_upward_adjustm_cpe IS NOT NULL
     OR ussgl480200_undelivered_or_fyb IS NOT NULL
     OR ussgl480200_undelivered_or_cpe IS NOT NULL
-    OR ussgl483200_undelivered_or_cpe IS NOT NULL
     OR ussgl488200_upward_adjustm_cpe IS NOT NULL
     OR ussgl490200_delivered_orde_cpe IS NOT NULL
     OR ussgl490800_authority_outl_fyb IS NOT NULL

--- a/dataactvalidator/config/sqlrules/b12_object_class_program_activity_1.sql
+++ b/dataactvalidator/config/sqlrules/b12_object_class_program_activity_1.sql
@@ -6,7 +6,6 @@ FROM object_class_program_activity as op
 WHERE op.submission_id = {} AND (
     COALESCE(op.ussgl480100_undelivered_or_fyb, 0) <> 0
     OR COALESCE(op.ussgl480100_undelivered_or_cpe, 0) <> 0
-    OR COALESCE(op.ussgl483100_undelivered_or_cpe, 0) <> 0
     OR COALESCE(op.ussgl488100_upward_adjustm_cpe, 0) <> 0
     OR COALESCE(op.ussgl490100_delivered_orde_fyb, 0) <> 0
     OR COALESCE(op.ussgl490100_delivered_orde_cpe, 0) <> 0

--- a/dataactvalidator/config/sqlrules/b12_object_class_program_activity_1.sql
+++ b/dataactvalidator/config/sqlrules/b12_object_class_program_activity_1.sql
@@ -9,11 +9,9 @@ WHERE op.submission_id = {} AND (
     OR COALESCE(op.ussgl488100_upward_adjustm_cpe, 0) <> 0
     OR COALESCE(op.ussgl490100_delivered_orde_fyb, 0) <> 0
     OR COALESCE(op.ussgl490100_delivered_orde_cpe, 0) <> 0
-    OR COALESCE(op.ussgl493100_delivered_orde_cpe, 0) <> 0
     OR COALESCE(op.ussgl498100_upward_adjustm_cpe, 0) <> 0
     OR COALESCE(op.ussgl480200_undelivered_or_cpe, 0) <> 0
     OR COALESCE(op.ussgl480200_undelivered_or_fyb, 0) <> 0
-    OR COALESCE(op.ussgl483200_undelivered_or_cpe, 0) <> 0
     OR COALESCE(op.ussgl488200_upward_adjustm_cpe, 0) <> 0
     OR COALESCE(op.ussgl490200_delivered_orde_cpe, 0) <> 0
     OR COALESCE(op.ussgl490800_authority_outl_fyb, 0) <> 0

--- a/tests/unit/dataactvalidator/test_b12_award_financial_1.py
+++ b/tests/unit/dataactvalidator/test_b12_award_financial_1.py
@@ -40,19 +40,19 @@ def test_failure(database):
     by_direct_reimbursable_fun is empty the rule fails """
 
     af_dict = {'by_direct_reimbursable_fun': None, 'ussgl480100_undelivered_or_fyb': None,
-               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None, 
-               'ussgl490100_delivered_orde_fyb': None, 'ussgl490100_delivered_orde_cpe': None, 
+               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None,
+               'ussgl490100_delivered_orde_fyb': None, 'ussgl490100_delivered_orde_cpe': None,
                'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
-               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None, 
-               'ussgl490200_delivered_orde_cpe': None, 'ussgl490800_authority_outl_fyb': None, 
+               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None,
+               'ussgl490200_delivered_orde_cpe': None, 'ussgl490800_authority_outl_fyb': None,
                'ussgl490800_authority_outl_cpe': None, 'ussgl498200_upward_adjustm_cpe': None}
 
     keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe',
-            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 
-            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 
+            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb',
+            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe',
             'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe',
-            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe', 
-            'ussgl490800_authority_outl_fyb', 'ussgl490800_authority_outl_cpe', 
+            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe',
+            'ussgl490800_authority_outl_fyb', 'ussgl490800_authority_outl_cpe',
             'ussgl498200_upward_adjustm_cpe']
 
     for i in range(len(keys)):

--- a/tests/unit/dataactvalidator/test_b12_award_financial_1.py
+++ b/tests/unit/dataactvalidator/test_b12_award_financial_1.py
@@ -20,15 +20,12 @@ def test_success(database):
 
     af = AwardFinancialFactory(ussgl480100_undelivered_or_fyb=None,
                                ussgl480100_undelivered_or_cpe=None,
-                               ussgl483100_undelivered_or_cpe=None,
                                ussgl488100_upward_adjustm_cpe=None,
                                ussgl490100_delivered_orde_fyb=None,
                                ussgl490100_delivered_orde_cpe=None,
-                               ussgl493100_delivered_orde_cpe=None,
                                ussgl498100_upward_adjustm_cpe=None,
                                ussgl480200_undelivered_or_fyb=None,
                                ussgl480200_undelivered_or_cpe=None,
-                               ussgl483200_undelivered_or_cpe=None,
                                ussgl488200_upward_adjustm_cpe=None,
                                ussgl490200_delivered_orde_cpe=None,
                                ussgl490800_authority_outl_fyb=None,
@@ -43,21 +40,20 @@ def test_failure(database):
     by_direct_reimbursable_fun is empty the rule fails """
 
     af_dict = {'by_direct_reimbursable_fun': None, 'ussgl480100_undelivered_or_fyb': None,
-               'ussgl480100_undelivered_or_cpe': None, 'ussgl483100_undelivered_or_cpe': None,
-               'ussgl488100_upward_adjustm_cpe': None, 'ussgl490100_delivered_orde_fyb': None,
-               'ussgl490100_delivered_orde_cpe': None, 'ussgl493100_delivered_orde_cpe': None,
+               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None, 
+               'ussgl490100_delivered_orde_fyb': None, 'ussgl490100_delivered_orde_cpe': None, 
                'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
-               'ussgl480200_undelivered_or_cpe': None, 'ussgl483200_undelivered_or_cpe': None,
-               'ussgl488200_upward_adjustm_cpe': None, 'ussgl490200_delivered_orde_cpe': None,
-               'ussgl490800_authority_outl_fyb': None, 'ussgl490800_authority_outl_cpe': None,
-               'ussgl498200_upward_adjustm_cpe': None}
+               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None, 
+               'ussgl490200_delivered_orde_cpe': None, 'ussgl490800_authority_outl_fyb': None, 
+               'ussgl490800_authority_outl_cpe': None, 'ussgl498200_upward_adjustm_cpe': None}
 
-    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe', 'ussgl483100_undelivered_or_cpe',
-            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 'ussgl490100_delivered_orde_cpe',
-            'ussgl493100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 'ussgl498100_upward_adjustm_cpe',
-            'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe', 'ussgl483200_undelivered_or_cpe',
-            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe', 'ussgl490800_authority_outl_fyb',
-            'ussgl490800_authority_outl_cpe', 'ussgl498200_upward_adjustm_cpe']
+    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe',
+            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 
+            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 
+            'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe',
+            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe', 
+            'ussgl490800_authority_outl_fyb', 'ussgl490800_authority_outl_cpe', 
+            'ussgl498200_upward_adjustm_cpe']
 
     for i in range(len(keys)):
         af_dict_copy = copy.deepcopy(af_dict)

--- a/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
+++ b/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
@@ -27,16 +27,18 @@ def test_failure(database):
     by_direct_reimbursable_fun is empty the rule fails """
 
     op_dict = {'by_direct_reimbursable_fun': None, 'object_class': 123, 'ussgl480100_undelivered_or_fyb': None,
-               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None, 'ussgl490100_delivered_orde_fyb': None,
-               'ussgl490100_delivered_orde_cpe': None, 'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
-               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None, 'ussgl490200_delivered_orde_cpe': None,
-               'ussgl490800_authority_outl_fyb': None, 'ussgl490800_authority_outl_cpe': None, 'ussgl498200_upward_adjustm_cpe': None}
+               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None,
+               'ussgl490100_delivered_orde_fyb': None, 'ussgl490100_delivered_orde_cpe': None,
+               'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
+               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None,
+               'ussgl490200_delivered_orde_cpe': None, 'ussgl490800_authority_outl_fyb': None,
+               'ussgl490800_authority_outl_cpe': None, 'ussgl498200_upward_adjustm_cpe': None}
 
-    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe', 
-            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 
-            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 
-            'ussgl498100_upward_adjustm_cpe', 'ussgl480200_undelivered_or_fyb', 
-            'ussgl480200_undelivered_or_cpe', 'ussgl488200_upward_adjustm_cpe', 
+    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe',
+            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb',
+            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe',
+            'ussgl498100_upward_adjustm_cpe', 'ussgl480200_undelivered_or_fyb',
+            'ussgl480200_undelivered_or_cpe', 'ussgl488200_upward_adjustm_cpe',
             'ussgl490200_delivered_orde_cpe', 'ussgl490800_authority_outl_fyb',
             'ussgl490800_authority_outl_cpe', 'ussgl498200_upward_adjustm_cpe']
 

--- a/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
+++ b/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
@@ -37,9 +37,9 @@ def test_failure(database):
     keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe',
             'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb',
             'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe',
-            'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe', 
-            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe', 
-            'ussgl490800_authority_outl_fyb', 'ussgl490800_authority_outl_cpe', 
+            'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe',
+            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe',
+            'ussgl490800_authority_outl_fyb', 'ussgl490800_authority_outl_cpe',
             'ussgl498200_upward_adjustm_cpe']
 
     for i in range(len(keys)):

--- a/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
+++ b/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
@@ -27,20 +27,17 @@ def test_failure(database):
     by_direct_reimbursable_fun is empty the rule fails """
 
     op_dict = {'by_direct_reimbursable_fun': None, 'object_class': 123, 'ussgl480100_undelivered_or_fyb': None,
-               'ussgl480100_undelivered_or_cpe': None, 'ussgl483100_undelivered_or_cpe': None,
-               'ussgl488100_upward_adjustm_cpe': None, 'ussgl490100_delivered_orde_fyb': None,
-               'ussgl490100_delivered_orde_cpe': None, 'ussgl493100_delivered_orde_cpe': None,
-               'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
-               'ussgl480200_undelivered_or_cpe': None, 'ussgl483200_undelivered_or_cpe': None,
-               'ussgl488200_upward_adjustm_cpe': None, 'ussgl490200_delivered_orde_cpe': None,
-               'ussgl490800_authority_outl_fyb': None, 'ussgl490800_authority_outl_cpe': None,
-               'ussgl498200_upward_adjustm_cpe': None}
+               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None, 'ussgl490100_delivered_orde_fyb': None,
+               'ussgl490100_delivered_orde_cpe': None, 'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
+               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None, 'ussgl490200_delivered_orde_cpe': None,
+               'ussgl490800_authority_outl_fyb': None, 'ussgl490800_authority_outl_cpe': None, 'ussgl498200_upward_adjustm_cpe': None}
 
-    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe', 'ussgl483100_undelivered_or_cpe',
-            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 'ussgl490100_delivered_orde_cpe',
-            'ussgl493100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 'ussgl498100_upward_adjustm_cpe',
-            'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe', 'ussgl483200_undelivered_or_cpe',
-            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe', 'ussgl490800_authority_outl_fyb',
+    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe', 
+            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 
+            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 
+            'ussgl498100_upward_adjustm_cpe', 'ussgl480200_undelivered_or_fyb', 
+            'ussgl480200_undelivered_or_cpe', 'ussgl488200_upward_adjustm_cpe', 
+            'ussgl490200_delivered_orde_cpe', 'ussgl490800_authority_outl_fyb',
             'ussgl490800_authority_outl_cpe', 'ussgl498200_upward_adjustm_cpe']
 
     for i in range(len(keys)):

--- a/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
+++ b/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
@@ -37,10 +37,10 @@ def test_failure(database):
     keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe',
             'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb',
             'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe',
-            'ussgl498100_upward_adjustm_cpe', 'ussgl480200_undelivered_or_fyb',
-            'ussgl480200_undelivered_or_cpe', 'ussgl488200_upward_adjustm_cpe',
-            'ussgl490200_delivered_orde_cpe', 'ussgl490800_authority_outl_fyb',
-            'ussgl490800_authority_outl_cpe', 'ussgl498200_upward_adjustm_cpe']
+            'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe', 
+            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe', 
+            'ussgl490800_authority_outl_fyb', 'ussgl490800_authority_outl_cpe', 
+            'ussgl498200_upward_adjustm_cpe']
 
     for i in range(len(keys)):
         op_dict_copy = copy.deepcopy(op_dict)


### PR DESCRIPTION
Modify implementation of B12 to also exclude 4831, 4832, and 4931 from requiring the D/R field to be populated. These USSGLs can also have the D/R field blank, just like the downward USSGLs (4x7x).