### PR TITLE
B9 validate years

### DIFF
--- a/dataactvalidator/config/sqlrules/b12_award_financial_1.sql
+++ b/dataactvalidator/config/sqlrules/b12_award_financial_1.sql
@@ -5,15 +5,12 @@ FROM award_financial AS af
 WHERE af.submission_id = {} AND (
     ussgl480100_undelivered_or_fyb IS NOT NULL
     OR ussgl480100_undelivered_or_cpe IS NOT NULL
-    OR ussgl483100_undelivered_or_cpe IS NOT NULL
     OR ussgl488100_upward_adjustm_cpe IS NOT NULL
     OR ussgl490100_delivered_orde_fyb IS NOT NULL
     OR ussgl490100_delivered_orde_cpe IS NOT NULL
-    OR ussgl493100_delivered_orde_cpe IS NOT NULL
     OR ussgl498100_upward_adjustm_cpe IS NOT NULL
     OR ussgl480200_undelivered_or_fyb IS NOT NULL
     OR ussgl480200_undelivered_or_cpe IS NOT NULL
-    OR ussgl483200_undelivered_or_cpe IS NOT NULL
     OR ussgl488200_upward_adjustm_cpe IS NOT NULL
     OR ussgl490200_delivered_orde_cpe IS NOT NULL
     OR ussgl490800_authority_outl_fyb IS NOT NULL

--- a/dataactvalidator/config/sqlrules/b12_object_class_program_activity_1.sql
+++ b/dataactvalidator/config/sqlrules/b12_object_class_program_activity_1.sql
@@ -6,7 +6,6 @@ FROM object_class_program_activity as op
 WHERE op.submission_id = {} AND (
     COALESCE(op.ussgl480100_undelivered_or_fyb, 0) <> 0
     OR COALESCE(op.ussgl480100_undelivered_or_cpe, 0) <> 0
-    OR COALESCE(op.ussgl483100_undelivered_or_cpe, 0) <> 0
     OR COALESCE(op.ussgl488100_upward_adjustm_cpe, 0) <> 0
     OR COALESCE(op.ussgl490100_delivered_orde_fyb, 0) <> 0
     OR COALESCE(op.ussgl490100_delivered_orde_cpe, 0) <> 0

--- a/dataactvalidator/config/sqlrules/b12_object_class_program_activity_1.sql
+++ b/dataactvalidator/config/sqlrules/b12_object_class_program_activity_1.sql
@@ -9,11 +9,9 @@ WHERE op.submission_id = {} AND (
     OR COALESCE(op.ussgl488100_upward_adjustm_cpe, 0) <> 0
     OR COALESCE(op.ussgl490100_delivered_orde_fyb, 0) <> 0
     OR COALESCE(op.ussgl490100_delivered_orde_cpe, 0) <> 0
-    OR COALESCE(op.ussgl493100_delivered_orde_cpe, 0) <> 0
     OR COALESCE(op.ussgl498100_upward_adjustm_cpe, 0) <> 0
     OR COALESCE(op.ussgl480200_undelivered_or_cpe, 0) <> 0
     OR COALESCE(op.ussgl480200_undelivered_or_fyb, 0) <> 0
-    OR COALESCE(op.ussgl483200_undelivered_or_cpe, 0) <> 0
     OR COALESCE(op.ussgl488200_upward_adjustm_cpe, 0) <> 0
     OR COALESCE(op.ussgl490200_delivered_orde_cpe, 0) <> 0
     OR COALESCE(op.ussgl490800_authority_outl_fyb, 0) <> 0

--- a/dataactvalidator/config/sqlrules/b9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/b9_award_financial.sql
@@ -7,7 +7,7 @@ SELECT af.row_number,
 	af.program_activity_code
 FROM award_financial as af
 WHERE af.submission_id = {0}
-	AND CAST(COALESCE(af.beginning_period_of_availa,'0') AS integer) >= 2016
+	AND CAST(COALESCE(af.beginning_period_of_availa,'0') AS integer) IN (SELECT DISTINCT CAST(budget_year AS integer) FROM program_activity)
 	AND af.row_number NOT IN (
 		SELECT af.row_number
 		FROM award_financial as af

--- a/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
@@ -7,7 +7,7 @@ SELECT op.row_number,
 	op.program_activity_code
 FROM object_class_program_activity as op
 WHERE op.submission_id = {0}
-	AND CAST(COALESCE(op.beginning_period_of_availa,'0') AS integer) >= 2016
+	AND CAST(COALESCE(op.beginning_period_of_availa,'0') AS integer) IN (SELECT DISTINCT CAST(budget_year AS integer) FROM program_activity)
 	AND op.row_number NOT IN (
 		SELECT op.row_number
 		FROM object_class_program_activity as op

--- a/tests/unit/dataactvalidator/test_b12_award_financial_1.py
+++ b/tests/unit/dataactvalidator/test_b12_award_financial_1.py
@@ -40,19 +40,19 @@ def test_failure(database):
     by_direct_reimbursable_fun is empty the rule fails """
 
     af_dict = {'by_direct_reimbursable_fun': None, 'ussgl480100_undelivered_or_fyb': None,
-               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None, 
-               'ussgl490100_delivered_orde_fyb': None, 'ussgl490100_delivered_orde_cpe': None, 
+               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None,
+               'ussgl490100_delivered_orde_fyb': None, 'ussgl490100_delivered_orde_cpe': None,
                'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
-               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None, 
-               'ussgl490200_delivered_orde_cpe': None, 'ussgl490800_authority_outl_fyb': None, 
+               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None,
+               'ussgl490200_delivered_orde_cpe': None, 'ussgl490800_authority_outl_fyb': None,
                'ussgl490800_authority_outl_cpe': None, 'ussgl498200_upward_adjustm_cpe': None}
 
     keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe',
-            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 
-            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 
+            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb',
+            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe',
             'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe',
-            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe', 
-            'ussgl490800_authority_outl_fyb', 'ussgl490800_authority_outl_cpe', 
+            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe',
+            'ussgl490800_authority_outl_fyb', 'ussgl490800_authority_outl_cpe',
             'ussgl498200_upward_adjustm_cpe']
 
     for i in range(len(keys)):

--- a/tests/unit/dataactvalidator/test_b12_award_financial_1.py
+++ b/tests/unit/dataactvalidator/test_b12_award_financial_1.py
@@ -20,15 +20,12 @@ def test_success(database):
 
     af = AwardFinancialFactory(ussgl480100_undelivered_or_fyb=None,
                                ussgl480100_undelivered_or_cpe=None,
-                               ussgl483100_undelivered_or_cpe=None,
                                ussgl488100_upward_adjustm_cpe=None,
                                ussgl490100_delivered_orde_fyb=None,
                                ussgl490100_delivered_orde_cpe=None,
-                               ussgl493100_delivered_orde_cpe=None,
                                ussgl498100_upward_adjustm_cpe=None,
                                ussgl480200_undelivered_or_fyb=None,
                                ussgl480200_undelivered_or_cpe=None,
-                               ussgl483200_undelivered_or_cpe=None,
                                ussgl488200_upward_adjustm_cpe=None,
                                ussgl490200_delivered_orde_cpe=None,
                                ussgl490800_authority_outl_fyb=None,
@@ -43,21 +40,20 @@ def test_failure(database):
     by_direct_reimbursable_fun is empty the rule fails """
 
     af_dict = {'by_direct_reimbursable_fun': None, 'ussgl480100_undelivered_or_fyb': None,
-               'ussgl480100_undelivered_or_cpe': None, 'ussgl483100_undelivered_or_cpe': None,
-               'ussgl488100_upward_adjustm_cpe': None, 'ussgl490100_delivered_orde_fyb': None,
-               'ussgl490100_delivered_orde_cpe': None, 'ussgl493100_delivered_orde_cpe': None,
+               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None, 
+               'ussgl490100_delivered_orde_fyb': None, 'ussgl490100_delivered_orde_cpe': None, 
                'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
-               'ussgl480200_undelivered_or_cpe': None, 'ussgl483200_undelivered_or_cpe': None,
-               'ussgl488200_upward_adjustm_cpe': None, 'ussgl490200_delivered_orde_cpe': None,
-               'ussgl490800_authority_outl_fyb': None, 'ussgl490800_authority_outl_cpe': None,
-               'ussgl498200_upward_adjustm_cpe': None}
+               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None, 
+               'ussgl490200_delivered_orde_cpe': None, 'ussgl490800_authority_outl_fyb': None, 
+               'ussgl490800_authority_outl_cpe': None, 'ussgl498200_upward_adjustm_cpe': None}
 
-    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe', 'ussgl483100_undelivered_or_cpe',
-            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 'ussgl490100_delivered_orde_cpe',
-            'ussgl493100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 'ussgl498100_upward_adjustm_cpe',
-            'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe', 'ussgl483200_undelivered_or_cpe',
-            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe', 'ussgl490800_authority_outl_fyb',
-            'ussgl490800_authority_outl_cpe', 'ussgl498200_upward_adjustm_cpe']
+    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe',
+            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 
+            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 
+            'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe',
+            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe', 
+            'ussgl490800_authority_outl_fyb', 'ussgl490800_authority_outl_cpe', 
+            'ussgl498200_upward_adjustm_cpe']
 
     for i in range(len(keys)):
         af_dict_copy = copy.deepcopy(af_dict)

--- a/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
+++ b/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
@@ -27,16 +27,18 @@ def test_failure(database):
     by_direct_reimbursable_fun is empty the rule fails """
 
     op_dict = {'by_direct_reimbursable_fun': None, 'object_class': 123, 'ussgl480100_undelivered_or_fyb': None,
-               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None, 'ussgl490100_delivered_orde_fyb': None,
-               'ussgl490100_delivered_orde_cpe': None, 'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
-               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None, 'ussgl490200_delivered_orde_cpe': None,
-               'ussgl490800_authority_outl_fyb': None, 'ussgl490800_authority_outl_cpe': None, 'ussgl498200_upward_adjustm_cpe': None}
+               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None,
+               'ussgl490100_delivered_orde_fyb': None, 'ussgl490100_delivered_orde_cpe': None,
+               'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
+               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None,
+               'ussgl490200_delivered_orde_cpe': None, 'ussgl490800_authority_outl_fyb': None,
+               'ussgl490800_authority_outl_cpe': None, 'ussgl498200_upward_adjustm_cpe': None}
 
-    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe', 
-            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 
-            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 
-            'ussgl498100_upward_adjustm_cpe', 'ussgl480200_undelivered_or_fyb', 
-            'ussgl480200_undelivered_or_cpe', 'ussgl488200_upward_adjustm_cpe', 
+    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe',
+            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb',
+            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe',
+            'ussgl498100_upward_adjustm_cpe', 'ussgl480200_undelivered_or_fyb',
+            'ussgl480200_undelivered_or_cpe', 'ussgl488200_upward_adjustm_cpe',
             'ussgl490200_delivered_orde_cpe', 'ussgl490800_authority_outl_fyb',
             'ussgl490800_authority_outl_cpe', 'ussgl498200_upward_adjustm_cpe']
 

--- a/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
+++ b/tests/unit/dataactvalidator/test_b12_object_class_program_activity_1.py
@@ -27,20 +27,17 @@ def test_failure(database):
     by_direct_reimbursable_fun is empty the rule fails """
 
     op_dict = {'by_direct_reimbursable_fun': None, 'object_class': 123, 'ussgl480100_undelivered_or_fyb': None,
-               'ussgl480100_undelivered_or_cpe': None, 'ussgl483100_undelivered_or_cpe': None,
-               'ussgl488100_upward_adjustm_cpe': None, 'ussgl490100_delivered_orde_fyb': None,
-               'ussgl490100_delivered_orde_cpe': None, 'ussgl493100_delivered_orde_cpe': None,
-               'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
-               'ussgl480200_undelivered_or_cpe': None, 'ussgl483200_undelivered_or_cpe': None,
-               'ussgl488200_upward_adjustm_cpe': None, 'ussgl490200_delivered_orde_cpe': None,
-               'ussgl490800_authority_outl_fyb': None, 'ussgl490800_authority_outl_cpe': None,
-               'ussgl498200_upward_adjustm_cpe': None}
+               'ussgl480100_undelivered_or_cpe': None, 'ussgl488100_upward_adjustm_cpe': None, 'ussgl490100_delivered_orde_fyb': None,
+               'ussgl490100_delivered_orde_cpe': None, 'ussgl498100_upward_adjustm_cpe': None, 'ussgl480200_undelivered_or_fyb': None,
+               'ussgl480200_undelivered_or_cpe': None, 'ussgl488200_upward_adjustm_cpe': None, 'ussgl490200_delivered_orde_cpe': None,
+               'ussgl490800_authority_outl_fyb': None, 'ussgl490800_authority_outl_cpe': None, 'ussgl498200_upward_adjustm_cpe': None}
 
-    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe', 'ussgl483100_undelivered_or_cpe',
-            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 'ussgl490100_delivered_orde_cpe',
-            'ussgl493100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 'ussgl498100_upward_adjustm_cpe',
-            'ussgl480200_undelivered_or_fyb', 'ussgl480200_undelivered_or_cpe', 'ussgl483200_undelivered_or_cpe',
-            'ussgl488200_upward_adjustm_cpe', 'ussgl490200_delivered_orde_cpe', 'ussgl490800_authority_outl_fyb',
+    keys = ['ussgl480100_undelivered_or_fyb', 'ussgl480100_undelivered_or_cpe', 
+            'ussgl488100_upward_adjustm_cpe', 'ussgl490100_delivered_orde_fyb', 
+            'ussgl490100_delivered_orde_cpe', 'ussgl498100_upward_adjustm_cpe', 
+            'ussgl498100_upward_adjustm_cpe', 'ussgl480200_undelivered_or_fyb', 
+            'ussgl480200_undelivered_or_cpe', 'ussgl488200_upward_adjustm_cpe', 
+            'ussgl490200_delivered_orde_cpe', 'ussgl490800_authority_outl_fyb',
             'ussgl490800_authority_outl_cpe', 'ussgl498200_upward_adjustm_cpe']
 
     for i in range(len(keys)):

--- a/tests/unit/dataactvalidator/test_b9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_b9_award_financial.py
@@ -43,6 +43,19 @@ def test_success_null(database):
     assert number_of_errors(_FILE, database, models=[af, pa]) == 0
 
 
+def test_success_current_fy(database):
+    """ Tests valid FY (current year, when we don't yet have the domain values) """
+
+    af = AwardFinancialFactory(row_number=1, beginning_period_of_availa=2017, agency_identifier='test',
+                               allocation_transfer_agency='test', main_account_code='test',
+                               program_activity_name='test', program_activity_code='test')
+
+    pa = ProgramActivityFactory(budget_year=2017, agency_id='test', allocation_transfer_id='test',
+                                account_number='test', program_activity_name='test', program_activity_code='test')
+
+    assert number_of_errors(_FILE, database, models=[af, af, pa]) == 0
+
+
 def test_failure_program_activity_name(database):
     """ Testing invalid program activity name for the corresponding TAS/TAFS as defined in Section 82 of OMB Circular
     A-11. """
@@ -79,3 +92,16 @@ def test_success_null_program_activity(database):
                                 account_number='test')
 
     assert number_of_errors(_FILE, database, models=[af, pa]) == 0
+
+
+def test_failure_current_fy(database):
+    """ Tests invalid FY (current year, when we don't yet have the domain values) """
+
+    af = AwardFinancialFactory(row_number=1, beginning_period_of_availa=2017, agency_identifier='test',
+                               allocation_transfer_agency='test', main_account_code='test',
+                               program_activity_name='test_wrong', program_activity_code='test')
+
+    pa = ProgramActivityFactory(budget_year=2017, agency_id='test', allocation_transfer_id='test',
+                                account_number='test', program_activity_name='test', program_activity_code='test')
+
+    assert number_of_errors(_FILE, database, models=[af, pa]) == 1

--- a/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
@@ -31,6 +31,19 @@ def test_success(database):
     assert number_of_errors(_FILE, database, models=[op_1, op_2, pa]) == 0
 
 
+def test_success_current_fy(database):
+    """ Tests valid FY (current year, when we don't yet have the domain values) """
+
+    op = ObjectClassProgramActivityFactory(row_number=1, beginning_period_of_availa=2017, agency_identifier='test',
+                                           allocation_transfer_agency='test', main_account_code='test',
+                                           program_activity_name='test', program_activity_code='test')
+
+    pa = ProgramActivityFactory(budget_year=2017, agency_id='test', allocation_transfer_id='test',
+                                account_number='test', program_activity_name='test', program_activity_code='test')
+
+    assert number_of_errors(_FILE, database, models=[op, pa]) == 0
+
+
 def test_failure_program_activity_name(database):
     """ Testing invalid program activity name for the corresponding TAS/TAFS as defined in Section 82 of OMB Circular
     A-11. """
@@ -51,6 +64,19 @@ def test_failure_program_activity_code(database):
                                            program_activity_name='test', program_activity_code='test_wrong')
 
     pa = ProgramActivityFactory(budget_year=2016, agency_id='test', allocation_transfer_id='test',
+                                account_number='test', program_activity_name='test', program_activity_code='test')
+
+    assert number_of_errors(_FILE, database, models=[op, pa]) == 1
+
+
+def test_failure_current_fy(database):
+    """ Tests invalid FY (current year, when we don't yet have the domain values) """
+
+    op = ObjectClassProgramActivityFactory(row_number=1, beginning_period_of_availa=2017, agency_identifier='test',
+                                           allocation_transfer_agency='test', main_account_code='test',
+                                           program_activity_name='test_wrong', program_activity_code='test')
+
+    pa = ProgramActivityFactory(budget_year=2017, agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     assert number_of_errors(_FILE, database, models=[op, pa]) == 1


### PR DESCRIPTION
- Broker only validates program activity if we have the domain values for that year
- Broker does not validate FY 2017 program activity data since we don't have the values