### PR TITLE
Add exception for '0'/'00'

### DIFF
--- a/dataactvalidator/config/sqlrules/b11_award_financial_1.sql
+++ b/dataactvalidator/config/sqlrules/b11_award_financial_1.sql
@@ -4,4 +4,4 @@ SELECT
 FROM award_financial AS af
 WHERE af.submission_id = {}
 AND af.object_class NOT IN (SELECT object_class_code FROM object_class)
-AND af.object_class <> '000'
+AND af.object_class NOT IN ('000', '00', '0')

--- a/dataactvalidator/config/sqlrules/b11_award_financial_3.sql
+++ b/dataactvalidator/config/sqlrules/b11_award_financial_3.sql
@@ -3,4 +3,4 @@ SELECT
     af.object_class
 FROM award_financial AS af
 WHERE af.submission_id = {}
-AND af.object_class = '000'
+AND af.object_class IN ('000', '00', '0')

--- a/dataactvalidator/config/sqlrules/b11_object_class_program_activity_1.sql
+++ b/dataactvalidator/config/sqlrules/b11_object_class_program_activity_1.sql
@@ -4,4 +4,4 @@ SELECT
 FROM object_class_program_activity AS op
 WHERE op.submission_id = {}
 AND op.object_class NOT IN (SELECT object_class_code FROM object_class)
-AND op.object_class <> '000'
+AND op.object_class NOT IN ('000', '00', '0')

--- a/dataactvalidator/config/sqlrules/b11_object_class_program_activity_3.sql
+++ b/dataactvalidator/config/sqlrules/b11_object_class_program_activity_3.sql
@@ -3,4 +3,5 @@ SELECT
     op.object_class
 FROM object_class_program_activity AS op
 WHERE op.submission_id = {}
-AND op.object_class = '000'
+AND op.object_class IN ('000', '00', '0')
+

--- a/tests/unit/dataactvalidator/test_b11_award_financial_3.py
+++ b/tests/unit/dataactvalidator/test_b11_award_financial_3.py
@@ -24,7 +24,12 @@ def test_success(database):
 def test_failure(database):
     """ Test invalid object class code (3 digits) """
 
-    # This should return because if it's '000' a warning should be returned
+    # This should return because if it's '000', '00', '0' a warning should be returned
     af = AwardFinancialFactory(object_class='000')
+    assert number_of_errors(_FILE, database, models=[af]) == 1
 
+    af = AwardFinancialFactory(object_class='00')
+    assert number_of_errors(_FILE, database, models=[af]) == 1
+
+    af = AwardFinancialFactory(object_class='0')
     assert number_of_errors(_FILE, database, models=[af]) == 1

--- a/tests/unit/dataactvalidator/test_b11_object_class_program_activity_3.py
+++ b/tests/unit/dataactvalidator/test_b11_object_class_program_activity_3.py
@@ -24,6 +24,12 @@ def test_success(database):
 def test_failure(database):
     """ Test invalid object class code (3 digits) """
 
+    # This should return because if it's '000', '00', '0' a warning should be returned
     op = ObjectClassProgramActivityFactory(object_class='000')
+    assert number_of_errors(_FILE, database, models=[op]) == 1
 
+    op = ObjectClassProgramActivityFactory(object_class='00')
+    assert number_of_errors(_FILE, database, models=[op]) == 1
+
+    op = ObjectClassProgramActivityFactory(object_class='0')
     assert number_of_errors(_FILE, database, models=[op]) == 1


### PR DESCRIPTION
We can't pad the 0 value to 000 for the object class because it currently accept 3 and 4 digits.  The change to this commit is to add an exception for `0` and `00` and add test cases.