### PR TITLE
db-1599 Map correct/incorrect deobligationsrecoveriesrefunds

### DIFF
--- a/dataactvalidator/filestreaming/csvAbstractReader.py
+++ b/dataactvalidator/filestreaming/csvAbstractReader.py
@@ -247,6 +247,10 @@ def use_long_headers(header_row, long_to_short_dict):
 def normalize_headers(header_row, long_headers, long_to_short_dict):
     for header in header_row:
         header = FieldCleaner.clean_string(header)
+        # Replace correctly spelled header (which does NOT match the db) with the
+        # misspelling that DOES match the db
+        if header == 'deobligationsrecoveriesrefundsofprioryearbyprogramobjectclass_cpe':
+            header = 'deobligationsrecoveriesrefundsdofprioryearbyprogramobjectclass_cpe'
         if long_headers and header in long_to_short_dict:
             yield FieldCleaner.clean_string(long_to_short_dict[header])
         else:


### PR DESCRIPTION
As an agency user, I want to be able to submit a B file that doesn't have a typo in the field
A/C:

- User can submit a file B file that either does or doesn't have the typo in the DeobligationsRecoveriesRefundsdOfPriorYearByProgramObjectClass_CPE field.

Technical changes:
Need to run `python scripts/initialize.py -i`.