### PR TITLE
db-1209 Performed only w a transaction obligated amount value

### DIFF
--- a/dataactvalidator/config/sqlrules/c11_cross_file.sql
+++ b/dataactvalidator/config/sqlrules/c11_cross_file.sql
@@ -5,6 +5,7 @@ SELECT
 FROM award_financial AS af
 WHERE af.submission_id = {}
     AND af.piid IS NOT NULL
+    AND af.transaction_obligated_amou IS NOT NULL
 	AND NOT EXISTS (
 		SELECT 1
 		FROM award_procurement AS ap

--- a/dataactvalidator/config/sqlrules/c12_cross_file.sql
+++ b/dataactvalidator/config/sqlrules/c12_cross_file.sql
@@ -12,4 +12,8 @@ WHERE ap.submission_id = {}
 		WHERE af.submission_id = ap.submission_id
 		    AND af.piid = ap.piid
 		    AND af.parent_award_id IS NOT DISTINCT FROM ap.parent_award_id
+	) AND NOT EXISTS(
+	  SELECT af.transaction_obligated_amou
+	  FROM award_financial AS af
+	  WHERE af.transaction_obligated_amou IS NULL
 	)

--- a/dataactvalidator/config/sqlrules/c8_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/c8_award_financial.sql
@@ -1,6 +1,7 @@
 SELECT af.row_number, af.fain, af.uri
 FROM award_financial AS af
 WHERE af.submission_id = {0}
+    AND af.transaction_obligated_amou IS NOT NULL
     AND NOT EXISTS (
         SELECT cgac_code
         FROM cgac

--- a/dataactvalidator/config/sqlrules/c9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/c9_award_financial.sql
@@ -20,4 +20,8 @@ WHERE afa.submission_id = {0}
                         AND afa.uri = af.uri
             WHERE afa.submission_id = {0}
         )
+    ) AND NOT EXISTS(
+	      SELECT transaction_obligated_amou
+	      FROM award_financial AS af
+	      WHERE transaction_obligated_amou IS NULL
     );

--- a/tests/unit/dataactvalidator/test_c11_cross_file.py
+++ b/tests/unit/dataactvalidator/test_c11_cross_file.py
@@ -15,24 +15,41 @@ def test_column_headers(database):
 def test_success(database):
     """ Unique PIID, ParentAwardId from file C exists in file D1 during the same reporting period. """
 
-    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id')
+    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id',
+                               transaction_obligated_amou='12345')
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 0
 
-    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id')
+    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id',
+                               transaction_obligated_amou='12345')
     ap_1 = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id')
     ap_2 = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap_1, ap_2]) == 0
 
-    af = AwardFinancialFactory(piid=None, parent_award_id='some_parent_award_id')
+    af = AwardFinancialFactory(piid=None, parent_award_id='some_parent_award_id',
+                               transaction_obligated_amou='12345')
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 0
 
-    af = AwardFinancialFactory(piid='some_piid', parent_award_id=None)
+    af = AwardFinancialFactory(piid='some_piid', parent_award_id=None, transaction_obligated_amou='12345')
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id=None)
+
+    assert number_of_errors(_FILE, database, models=[af, ap]) == 0
+
+    # Not perform when no transaction obligated amount value in the field
+    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id',
+                               allocation_transfer_agency=None, transaction_obligated_amou=None)
+    ap = AwardProcurementFactory(piid='some_other_piid', parent_award_id='some_parent_award_id')
+
+    assert number_of_errors(_FILE, database, models=[af, ap]) == 0
+
+    # Not perform when no transaction obligated amount value in the field
+    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id',
+                               allocation_transfer_agency='bad', transaction_obligated_amou=None)
+    ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_other_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 0
 
@@ -40,14 +57,16 @@ def test_success(database):
 def test_failure(database):
     """ Unique PIID, ParentAwardId from file C doesn't exist in file D1 during the same reporting period. """
 
+    # Perform when there's a transaction obligated amount value in the field
     af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id',
-                               allocation_transfer_agency=None)
+                               allocation_transfer_agency=None, transaction_obligated_amou='12345')
     ap = AwardProcurementFactory(piid='some_other_piid', parent_award_id='some_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 1
 
+    # Perform when there's a transaction obligated amount value in the field
     af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id',
-                               allocation_transfer_agency='bad')
+                               allocation_transfer_agency='bad', transaction_obligated_amou='12345')
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_other_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 1
@@ -57,8 +76,9 @@ def test_valid_allocation_transfer_agency(database):
     """If File C (award financial) record has a valid allocation transfer agency, rule always passes."""
 
     cgac = CGACFactory(cgac_code='good')
+    # Perform when there's a transaction obligated amount value in the field
     af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id',
-                               allocation_transfer_agency=cgac.cgac_code)
+                               allocation_transfer_agency=cgac.cgac_code, transaction_obligated_amou='12345')
     ap = AwardProcurementFactory(piid='some_other_piid', parent_award_id='some_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap, cgac]) == 0

--- a/tests/unit/dataactvalidator/test_c11_cross_file.py
+++ b/tests/unit/dataactvalidator/test_c11_cross_file.py
@@ -41,14 +41,14 @@ def test_success(database):
 
     # Not perform when no transaction obligated amount value in the field
     af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id',
-                               allocation_transfer_agency=None, transaction_obligated_amou=None)
+                               transaction_obligated_amou=None)
     ap = AwardProcurementFactory(piid='some_other_piid', parent_award_id='some_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 0
 
     # Not perform when no transaction obligated amount value in the field
     af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_award_id',
-                               allocation_transfer_agency='bad', transaction_obligated_amou=None)
+                               transaction_obligated_amou=None)
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_other_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 0

--- a/tests/unit/dataactvalidator/test_c12_cross_file.py
+++ b/tests/unit/dataactvalidator/test_c12_cross_file.py
@@ -32,17 +32,35 @@ def test_success(database):
 
     assert number_of_errors(_FILE, database, models=[ap, af]) == 0
 
+    # Not perform when no transaction obligated amount value in the field
+    ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id', federal_action_obligation=1)
+    af = AwardFinancialFactory(piid='some_other_piid', parent_award_id='some_parent_award_id',
+                               transaction_obligated_amou=None)
+
+    assert number_of_errors(_FILE, database, models=[af, ap]) == 0
+
+    # Not perform when no transaction obligated amount value in the field
+    ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id', federal_action_obligation=1)
+    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_other_parent_award_id',
+                               transaction_obligated_amou=None)
+
+    assert number_of_errors(_FILE, database, models=[af, ap]) == 0
+
 
 def test_failure(database):
     """ Unique PIID, ParentAwardId from file D1 doesn't exist in file C during the same reporting period,
         except D1 records with zero FederalActionObligation """
 
+    # Perform when there's a transaction obligated amount value in the field
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id', federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_other_piid', parent_award_id='some_parent_award_id')
+    af = AwardFinancialFactory(piid='some_other_piid', parent_award_id='some_parent_award_id',
+                               transaction_obligated_amou='1234')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 1
 
+    # Perform when there's a transaction obligated amount value in the field
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id', federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_other_parent_award_id')
+    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_other_parent_award_id',
+                               transaction_obligated_amou='1234')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 1

--- a/tests/unit/dataactvalidator/test_c8_award_financial.py
+++ b/tests/unit/dataactvalidator/test_c8_award_financial.py
@@ -117,7 +117,9 @@ def test_invalid_allocation_transfer_agency(database):
     transfer agency in File C (award financial). Per rule C24."""
     tas = _TAS
     cgac = CGACFactory(cgac_code='good')
-    af = AwardFinancialFactory(tas=tas, fain='abc', uri='xyz', allocation_transfer_agency='bad')
+    # Perform when there's a transaction obligated amount value in the field
+    af = AwardFinancialFactory(tas=tas, fain='abc', uri='xyz', allocation_transfer_agency='bad',
+                               transaction_obligated_amou='12345')
     afa = AwardFinancialAssistanceFactory(tas=tas, submission_id=af.submission_id, fain='123', uri='456')
 
     errors = number_of_errors(_FILE, database, models=[af, afa, cgac])
@@ -129,8 +131,14 @@ def test_valid_allocation_transfer_agency(database):
     record has a valid allocation transfer agency."""
     tas = _TAS
     cgac = CGACFactory(cgac_code='good')
-    af = AwardFinancialFactory(tas=tas, fain='abc', uri='xyz', allocation_transfer_agency=cgac.cgac_code)
-    afa = AwardFinancialAssistanceFactory(tas=tas, submission_id=af.submission_id, fain='123', uri='456')
+    # Perform when there's a transaction obligated amount value in the field
+    af_1 = AwardFinancialFactory(tas=tas, fain='abc', uri='xyz', allocation_transfer_agency=cgac.cgac_code,
+                                 transaction_obligated_amou='12345')
+    # Not perform when no transaction obligated amount value in the field
+    af_2 = AwardFinancialFactory(tas=tas, fain='abc', uri='xyz', allocation_transfer_agency='bad',
+                                 transaction_obligated_amou=None)
+    afa_1 = AwardFinancialAssistanceFactory(tas=tas, submission_id=af_1.submission_id, fain='123', uri='456')
+    afa_2 = AwardFinancialAssistanceFactory(tas=tas, submission_id=af_2.submission_id, fain='123', uri='456')
 
-    errors = number_of_errors(_FILE, database, models=[af, afa, cgac])
+    errors = number_of_errors(_FILE, database, models=[af_1, af_2, afa_1, afa_2, cgac])
     assert errors == 0

--- a/tests/unit/dataactvalidator/test_c9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_c9_award_financial.py
@@ -117,14 +117,27 @@ def test_zero_federal_action_obligation_and_original_loan_subsidy_cost(database)
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 0
 
+    tas = _TAS
+    afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=0,
+                                          original_loan_subsidy_cost='1')
+    # Not perform when no transaction obligated amount value in the field
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
+                               transaction_obligated_amou=None)
+
+    errors = number_of_errors(_FILE, database, models=[afa, af])
+    assert errors == 0
+
 
 def test_zero_federal_action_obligation_and_positive_original_loan_subsidy_cost(database):
     """Tests that a single warning is thrown for both a federal action obligation of 0
      and an original loan subsidy cost of 0"""
+
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=0,
                                           original_loan_subsidy_cost='1')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
+    # Perform when there's a transaction obligated amount value in the field
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
+                               transaction_obligated_amou='1234')
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 1
@@ -133,10 +146,13 @@ def test_zero_federal_action_obligation_and_positive_original_loan_subsidy_cost(
 def test_positive_federal_action_obligation_and_zero_original_loan_subsidy_cost(database):
     """Tests that a single warning is thrown for both a federal action obligation of 0
      and an original loan subsidy cost of 0"""
+
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='0')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
+    # Perform when there's a transaction obligated amount value in the field
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
+                               transaction_obligated_amou='12345')
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 1


### PR DESCRIPTION
Acceptance Criteria:
- C8/C9 validation is only performed on rows in file C that have a transaction obligated amount value in the field
- C11/C12 validation is only performed on rows in file C that have a transaction obligated amount value in the field

Technical Changes:
SQL Rule Updates