### PR TITLE
DB 1674 pad assistanceType

### DIFF
--- a/dataactvalidator/config/awardFields.csv
+++ b/dataactvalidator/config/awardFields.csv
@@ -1,7 +1,7 @@
 fieldname,fieldname_short,required,data_type,field_length,rule_labels,padded_flag
 actiondate,action_date,TRUE,str,8,"D3, D4",
 actiontype,action_type,FALSE,str,1,"D1, D2",
-assistancetype,assistance_type,TRUE,str,2,D1,
+assistancetype,assistance_type,TRUE,str,2,D1,TRUE
 awarddescription,award_description,FALSE,str,4000,D2,
 awardeeorrecipientlegalentityname,awardee_or_recipient_legal,TRUE,str,120,D22,
 awardeeorrecipientuniqueidentifier,awardee_or_recipient_uniqu,FALSE,str,9,"D2, D10",

--- a/dataactvalidator/config/detachedAwardFields.csv
+++ b/dataactvalidator/config/detachedAwardFields.csv
@@ -1,7 +1,7 @@
 fieldname,fieldname_short,required,data_type,field_length,rule_labels,padded_flag
 actiondate,action_date,TRUE,str,8,"D3, D4",
 actiontype,action_type,FALSE,str,1,"D1, D2",
-assistancetype,assistance_type,TRUE,str,2,D1,
+assistancetype,assistance_type,TRUE,str,2,D1,TRUE
 awarddescription,award_description,FALSE,str,4000,D2,
 awardeeorrecipientlegalentityname,awardee_or_recipient_legal,TRUE,str,120,D22,
 awardeeorrecipientuniqueidentifier,awardee_or_recipient_uniqu,FALSE,str,9,"D2, D10",


### PR DESCRIPTION
Pad assistancetype column so it always has 2 characters. Stops auto-truncating in excel from causing errors.

Technical Changes:
- file_column table updates, will need to reinitialize the table