### PR TITLE
Change program activity to ignore case

### DIFF
--- a/dataactvalidator/config/sqlrules/b9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/b9_award_financial.sql
@@ -29,7 +29,7 @@ WHERE af.submission_id = {0}
 				AND af.agency_identifier IS NOT DISTINCT FROM pa.agency_id
 				AND af.allocation_transfer_agency IS NOT DISTINCT FROM pa.allocation_transfer_id
 				AND af.main_account_code IS NOT DISTINCT FROM pa.account_number
-				AND af.program_activity_name IS NOT DISTINCT FROM pa.program_activity_name
+				AND LOWER(af.program_activity_name) IS NOT DISTINCT FROM LOWER(pa.program_activity_name)
 				AND af.program_activity_code IS NOT DISTINCT FROM pa.program_activity_code)
 				OR (af.program_activity_name IS NULL AND af.program_activity_code IS NULL)
 	);

--- a/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
@@ -29,6 +29,6 @@ WHERE op.submission_id = {0}
 				AND op.agency_identifier IS NOT DISTINCT FROM pa.agency_id
 				AND op.allocation_transfer_agency IS NOT DISTINCT FROM pa.allocation_transfer_id
 				AND op.main_account_code IS NOT DISTINCT FROM pa.account_number
-				AND op.program_activity_name IS NOT DISTINCT FROM pa.program_activity_name
+				AND LOWER(op.program_activity_name) IS NOT DISTINCT FROM LOWER(pa.program_activity_name)
 				AND op.program_activity_code IS NOT DISTINCT FROM pa.program_activity_code)
 	);

--- a/tests/unit/dataactvalidator/test_b9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_b9_award_financial.py
@@ -68,6 +68,19 @@ def test_success_unknown_value(database):
     assert number_of_errors(_FILE, database, models=[af, pa]) == 0
 
 
+def test_success_ignore_case(database):
+    """ Testing program activity validation to ignore case """
+
+    af = AwardFinancialFactory(row_number=1, beginning_period_of_availa=2016, agency_identifier='test',
+                               allocation_transfer_agency='test', main_account_code='test',
+                               program_activity_name='test', program_activity_code='test')
+
+    pa = ProgramActivityFactory(budget_year=2016, agency_id='test', allocation_transfer_id='test',
+                                account_number='test', program_activity_name='TEST', program_activity_code='test')
+
+    assert number_of_errors(_FILE, database, models=[af, pa]) == 0
+
+
 def test_failure_program_activity_name(database):
     """ Testing invalid program activity name for the corresponding TAS/TAFS as defined in Section 82 of OMB Circular
     A-11. """

--- a/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
@@ -55,6 +55,19 @@ def test_success_unknown_value(database):
     assert number_of_errors(_FILE, database, models=[op, pa]) == 0
 
 
+def test_success_ignore_case(database):
+    """ Testing program activity validation to ignore case """
+
+    op = ObjectClassProgramActivityFactory(row_number=1, beginning_period_of_availa=2016, agency_identifier='test',
+                                           allocation_transfer_agency='test', main_account_code='test',
+                                           program_activity_name='test', program_activity_code='test')
+
+    pa = ProgramActivityFactory(budget_year=2016, agency_id='test', allocation_transfer_id='test',
+                                account_number='test', program_activity_name='TEST', program_activity_code='test')
+
+    assert number_of_errors(_FILE, database, models=[op, pa]) == 0
+
+
 def test_failure_program_activity_name(database):
     """ Testing invalid program activity name for the corresponding TAS/TAFS as defined in Section 82 of OMB Circular
     A-11. """


### PR DESCRIPTION
Acceptance Criteria:
- B9/B10 validations are not case sensitive when validating program activity name

Technical changes:
SQL validation changes

@kaitlin 
I can't replicate the error for the case sensitive. But added `LOWER` to the program activity name to make sure it ignores case.