### PR TITLE
DB-1759 I need to see my previous C12 warnings

### DIFF
--- a/dataactvalidator/config/sqlrules/c12_cross_file.sql
+++ b/dataactvalidator/config/sqlrules/c12_cross_file.sql
@@ -5,25 +5,16 @@ SELECT
     ap.parent_award_id
 FROM award_procurement AS ap
 WHERE ap.submission_id = {}
-    AND COALESCE(ap.federal_action_obligation, 0) <> 0
     AND ap.piid IS NOT NULL
-    AND ((ap.parent_award_id IS NULL
-          AND NOT EXISTS (
-              SELECT 1
-              FROM award_financial AS af
-              WHERE af.submission_id = ap.submission_id
-                  AND af.piid = ap.piid)
-         )
-         OR (ap.parent_award_id IS NOT NULL
-             AND NOT EXISTS (
-                 SELECT 1
-                 FROM award_financial AS af
-                 WHERE af.submission_id = ap.submission_id
-                     AND af.piid = ap.piid
-                     AND af.parent_award_id IS NOT DISTINCT FROM ap.parent_award_id)
-         )
-    )
+    AND COALESCE(ap.federal_action_obligation, 0) <> 0
     AND NOT EXISTS (
+        SELECT 1
+        FROM award_financial AS af
+        WHERE af.submission_id = ap.submission_id
+            AND af.piid = ap.piid
+            AND af.parent_award_id IS NOT DISTINCT FROM ap.parent_award_id
+    )
+    AND NOT EXISTS(
         SELECT af.transaction_obligated_amou
         FROM award_financial AS af
         WHERE af.transaction_obligated_amou IS NULL

--- a/dataactvalidator/config/sqlrules/c12_cross_file.sql
+++ b/dataactvalidator/config/sqlrules/c12_cross_file.sql
@@ -14,8 +14,3 @@ WHERE ap.submission_id = {}
             AND af.piid = ap.piid
             AND af.parent_award_id IS NOT DISTINCT FROM ap.parent_award_id
     )
-    AND NOT EXISTS(
-        SELECT af.transaction_obligated_amou
-        FROM award_financial AS af
-        WHERE af.transaction_obligated_amou IS NULL
-    )

--- a/tests/unit/dataactvalidator/test_c12_cross_file.py
+++ b/tests/unit/dataactvalidator/test_c12_cross_file.py
@@ -32,35 +32,17 @@ def test_success(database):
 
     assert number_of_errors(_FILE, database, models=[ap, af]) == 0
 
-    # Not perform when no transaction obligated amount value in the field
-    ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id', federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_other_piid', parent_award_id='some_parent_award_id',
-                               transaction_obligated_amou=None)
-
-    assert number_of_errors(_FILE, database, models=[af, ap]) == 0
-
-    # Not perform when no transaction obligated amount value in the field
-    ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id', federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_other_parent_award_id',
-                               transaction_obligated_amou=None)
-
-    assert number_of_errors(_FILE, database, models=[af, ap]) == 0
-
 
 def test_failure(database):
     """ Unique PIID, ParentAwardId from file D1 doesn't exist in file C during the same reporting period,
         except D1 records with zero FederalActionObligation """
 
-    # Perform when there's a transaction obligated amount value in the field
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id', federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_other_piid', parent_award_id='some_parent_award_id',
-                               transaction_obligated_amou='1234')
+    af = AwardFinancialFactory(piid='some_other_piid', parent_award_id='some_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 1
 
-    # Perform when there's a transaction obligated amount value in the field
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id', federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_other_parent_award_id',
-                               transaction_obligated_amou='1234')
+    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_other_parent_award_id')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 1

--- a/tests/unit/dataactvalidator/test_c12_cross_file.py
+++ b/tests/unit/dataactvalidator/test_c12_cross_file.py
@@ -46,12 +46,6 @@ def test_success(database):
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 0
 
-    ap = AwardProcurementFactory(piid=None, parent_award_id=None, federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_other_parent_award_id',
-                               transaction_obligated_amou=None)
-
-    assert number_of_errors(_FILE, database, models=[af, ap]) == 0
-
 
 def test_failure(database):
     """ Unique PIID, ParentAwardId from file D1 doesn't exist in file C during the same reporting period,
@@ -67,12 +61,6 @@ def test_failure(database):
     # Perform when there's a transaction obligated amount value in the field
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_parent_award_id', federal_action_obligation=1)
     af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_other_parent_award_id',
-                               transaction_obligated_amou='1234')
-
-    assert number_of_errors(_FILE, database, models=[af, ap]) == 1
-
-    ap = AwardProcurementFactory(piid='some_piid', parent_award_id=None, federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_other_piid', parent_award_id='some_parent_award_id',
                                transaction_obligated_amou='1234')
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 1


### PR DESCRIPTION
As an agency user, I need to see my previous C12 warnings
Acceptance Criteria:
If a PIID and PAID combination exists in D1, it should show a warning if it does not exist in C
If a PIID (with null PAID) is in D1, it should show a warning if it does not exist in C

Technical changes: 
SQL rules (Change the rule back to previous commit)