### PR TITLE
Db 1770 fix c9 warnings

### DIFF
--- a/dataactvalidator/config/sqlrules/c9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/c9_award_financial.sql
@@ -1,18 +1,28 @@
-SELECT afa.row_number, afa.fain, afa.uri
-FROM award_financial_assistance AS afa
-WHERE afa.submission_id = {0}
-    AND (COALESCE(afa.federal_action_obligation, 0) <> 0
+WITH award_financial_assistance_c9_{0} AS
+    (SELECT submission_id,
+		row_number,
+		federal_action_obligation,
+		original_loan_subsidy_cost,
+		fain,
+		uri
+	FROM award_financial_assistance
+	WHERE submission_id = {0})
+SELECT
+    afa.row_number,
+    afa.fain,
+    afa.uri
+FROM award_financial_assistance_c9_{0} AS afa
+WHERE (COALESCE(afa.federal_action_obligation, 0) <> 0
         OR COALESCE(CAST(afa.original_loan_subsidy_cost as numeric),0) <> 0
     ) AND (afa.fain IS NOT NULL
             OR afa.uri IS NOT NULL
 	) AND afa.row_number NOT IN (
             SELECT afa.row_number
-            FROM award_financial_assistance AS afa
+            FROM award_financial_assistance_c9_{0} AS afa
                 JOIN award_financial AS af
                     ON afa.submission_id = af.submission_id
                         AND (afa.fain = af.fain
                             OR (afa.fain IS NULL AND af.fain IS NULL))
                         AND (afa.uri = af.uri
                             OR (afa.uri IS NULL AND af.uri IS NULL))
-            WHERE afa.submission_id = {0}
         );

--- a/dataactvalidator/config/sqlrules/c9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/c9_award_financial.sql
@@ -5,23 +5,14 @@ WHERE afa.submission_id = {0}
         OR COALESCE(CAST(afa.original_loan_subsidy_cost as numeric),0) <> 0
     ) AND (afa.fain IS NOT NULL
             OR afa.uri IS NOT NULL
-	) AND (afa.row_number NOT IN (
+	) AND afa.row_number NOT IN (
             SELECT afa.row_number
             FROM award_financial_assistance AS afa
                 JOIN award_financial AS af
                     ON afa.submission_id = af.submission_id
-                        AND afa.fain = af.fain
+                        AND (afa.fain = af.fain
+                            OR (afa.fain IS NULL AND af.fain IS NULL))
+                        AND (afa.uri = af.uri
+                            OR (afa.uri IS NULL AND af.uri IS NULL))
             WHERE afa.submission_id = {0}
-        ) AND afa.row_number NOT IN (
-            SELECT afa.row_number
-            FROM award_financial_assistance AS afa
-                JOIN award_financial AS af
-                    ON afa.submission_id = af.submission_id
-                        AND afa.uri = af.uri
-            WHERE afa.submission_id = {0}
-        )
-    ) AND NOT EXISTS(
-	      SELECT transaction_obligated_amou
-	      FROM award_financial AS af
-	      WHERE transaction_obligated_amou IS NULL
-    );
+        );

--- a/dataactvalidator/config/sqlrules/c9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/c9_award_financial.sql
@@ -1,12 +1,12 @@
 WITH award_financial_assistance_c9_{0} AS
     (SELECT submission_id,
-		row_number,
-		federal_action_obligation,
-		original_loan_subsidy_cost,
-		fain,
-		uri
-	FROM award_financial_assistance
-	WHERE submission_id = {0})
+        row_number,
+        federal_action_obligation,
+        original_loan_subsidy_cost,
+        fain,
+        uri
+    FROM award_financial_assistance
+    WHERE submission_id = {0})
 SELECT
     afa.row_number,
     afa.fain,
@@ -16,13 +16,11 @@ WHERE (COALESCE(afa.federal_action_obligation, 0) <> 0
         OR COALESCE(CAST(afa.original_loan_subsidy_cost as numeric),0) <> 0
     ) AND (afa.fain IS NOT NULL
             OR afa.uri IS NOT NULL
-	) AND afa.row_number NOT IN (
+    ) AND afa.row_number NOT IN (
             SELECT afa.row_number
             FROM award_financial_assistance_c9_{0} AS afa
                 JOIN award_financial AS af
                     ON afa.submission_id = af.submission_id
-                        AND (afa.fain = af.fain
-                            OR (afa.fain IS NULL AND af.fain IS NULL))
-                        AND (afa.uri = af.uri
-                            OR (afa.uri IS NULL AND af.uri IS NULL))
+                        AND afa.fain IS NOT DISTINCT FROM af.fain
+                        AND afa.uri IS NOT DISTINCT FROM af.uri
         );

--- a/tests/unit/dataactvalidator/test_c9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_c9_award_financial.py
@@ -14,8 +14,7 @@ def test_column_headers(database):
 
 
 def test_equal_fain(database):
-    """Tests that File D2 (award financial assistance) fain matches
-    File C (award financial) fain."""
+    """ Tests that File D2 (award financial assistance) fain matches File C (award financial) fain. """
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='1')
@@ -26,8 +25,7 @@ def test_equal_fain(database):
 
 
 def test_equal_uri(database):
-    """Tests that File D2 (award financial assistance) uri matches
-    File C (award financial) uri."""
+    """ Tests that File D2 (award financial assistance) uri matches File C (award financial) uri. """
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain=None, uri='xyz', federal_action_obligation=1,
                                           original_loan_subsidy_cost='1')
@@ -38,8 +36,8 @@ def test_equal_uri(database):
 
 
 def test_null_uri_fain(database):
-    """Tests File D2 (award financial assistance) and File C (award financial)
-    having NULL values for both fain and uri."""
+    """ Tests File D2 (award financial assistance) and File C (award financial)
+        having NULL values for both fain and uri. """
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain=None, uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='1')
@@ -50,7 +48,7 @@ def test_null_uri_fain(database):
 
 
 def test_both_fain_and_url_supplied(database):
-    """Tests File D2 (award financial assistance) having both uri and fain populated."""
+    """ Tests File D2 (award financial assistance) having both uri and fain populated. """
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri='xyz', federal_action_obligation=1,
                                           original_loan_subsidy_cost='1')
@@ -61,7 +59,7 @@ def test_both_fain_and_url_supplied(database):
 
 
 def test_unequal_fain(database):
-    """Tests File D2 (award financial assistance) fain different than File C (award financial) fain."""
+    """ Tests File D2 (award financial assistance) fain different than File C (award financial) fain. """
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='1')
@@ -72,7 +70,7 @@ def test_unequal_fain(database):
 
 
 def test_unequal_uri(database):
-    """Tests File D2 (award financial assistance) uri different than File C (award financial) uri."""
+    """ Tests File D2 (award financial assistance) uri different than File C (award financial) uri. """
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain=None, uri='abc', federal_action_obligation=1,
                                           original_loan_subsidy_cost='1')
@@ -83,8 +81,7 @@ def test_unequal_uri(database):
 
 
 def test_unequal_fain_null(database):
-    """Tests non-NULL File D2 (award financial assistance) fain compared to a NULL
-    fain in File C (award financial)."""
+    """Tests non-NULL File D2 (award financial assistance) fain compared to a NULL fain in File C (award financial)."""
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='1')
@@ -95,8 +92,7 @@ def test_unequal_fain_null(database):
 
 
 def test_unequal_uri_null(database):
-    """Tests NULL File D2 (award financial assistance) uri compared to a non-NULL
-    uri in File C (award financial)."""
+    """ Tests NULL File D2 (award financial assistance) uri compared to a non-NULL uri in File C (award financial). """
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain=None, uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='1')
@@ -107,8 +103,8 @@ def test_unequal_uri_null(database):
 
 
 def test_zero_federal_action_obligation_and_original_loan_subsidy_cost(database):
-    """Tests that a single warning is thrown for both a federal action obligation of 0
-     and an original loan subsidy cost of 0"""
+    """ Tests that a single warning is thrown for both a federal action obligation of 0
+        and an original loan subsidy cost of 0 """
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=0,
                                           original_loan_subsidy_cost='0')
@@ -117,42 +113,28 @@ def test_zero_federal_action_obligation_and_original_loan_subsidy_cost(database)
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 0
 
-    tas = _TAS
-    afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=0,
-                                          original_loan_subsidy_cost='1')
-    # Not perform when no transaction obligated amount value in the field
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
-                               transaction_obligated_amou=None)
-
-    errors = number_of_errors(_FILE, database, models=[afa, af])
-    assert errors == 0
-
 
 def test_zero_federal_action_obligation_and_positive_original_loan_subsidy_cost(database):
-    """Tests that a single warning is thrown for both a federal action obligation of 0
-     and an original loan subsidy cost of 0"""
+    """ Tests that a single warning is thrown for both a federal action obligation of 0
+        and an original loan subsidy cost of 0 """
 
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=0,
                                           original_loan_subsidy_cost='1')
-    # Perform when there's a transaction obligated amount value in the field
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
-                               transaction_obligated_amou='1234')
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 1
 
 
 def test_positive_federal_action_obligation_and_zero_original_loan_subsidy_cost(database):
-    """Tests that a single warning is thrown for both a federal action obligation of 0
-     and an original loan subsidy cost of 0"""
+    """ Tests that a single warning is thrown for both a federal action obligation of 0
+        and an original loan subsidy cost of 0 """
 
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='0')
-    # Perform when there's a transaction obligated amount value in the field
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
-                               transaction_obligated_amou='12345')
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 1


### PR DESCRIPTION
Stop using transaction_obligated_amou in this check.

Also making sure that any combination of fain/uri (including nulls) from D2 must be replicated exactly in C for this warning to not go off.

Adding a "with" to speed things up.