### PR TITLE
Queries should be based on published status, not the unpublished status

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1269,9 +1269,9 @@ def list_submissions(page, limit, certified, sort='modified', order='desc'):
                                     Submission.user_id == g.user.user_id))
     if certified != 'mixed':
         if certified == 'true':
-            query = query.filter(Submission.publish_status_id == PUBLISH_STATUS_DICT['published'])
+            query = query.filter(Submission.publish_status_id != PUBLISH_STATUS_DICT['unpublished'])
         else:
-            query = query.filter(Submission.publish_status_id != PUBLISH_STATUS_DICT['published'])
+            query = query.filter(Submission.publish_status_id == PUBLISH_STATUS_DICT['unpublished'])
 
     arr = [serialize_submission(s) for s in query]
 


### PR DESCRIPTION
Properly populates the submission table for the dashboard and adds publish status for the recent activity table