### PR TITLE
Db 1748 b rule fixes zeroes allowed

### DIFF
--- a/dataactvalidator/config/sqlrules/b11_award_financial_1.sql
+++ b/dataactvalidator/config/sqlrules/b11_award_financial_1.sql
@@ -4,4 +4,4 @@ SELECT
 FROM award_financial AS af
 WHERE af.submission_id = {}
 AND af.object_class NOT IN (SELECT object_class_code FROM object_class)
-AND af.object_class NOT IN ('000', '00', '0')
+AND af.object_class NOT IN ('0000', '000', '00', '0')

--- a/dataactvalidator/config/sqlrules/b11_award_financial_2.sql
+++ b/dataactvalidator/config/sqlrules/b11_award_financial_2.sql
@@ -3,4 +3,4 @@ SELECT
     af.object_class
 FROM award_financial AS af
 WHERE af.submission_id = {}
-AND af.object_class IN ('000', '00', '0')
+AND af.object_class IN ('0000', '000', '00', '0')

--- a/dataactvalidator/config/sqlrules/b11_object_class_program_activity_1.sql
+++ b/dataactvalidator/config/sqlrules/b11_object_class_program_activity_1.sql
@@ -4,4 +4,4 @@ SELECT
 FROM object_class_program_activity AS op
 WHERE op.submission_id = {}
 AND op.object_class NOT IN (SELECT object_class_code FROM object_class)
-AND op.object_class NOT IN ('000', '00', '0')
+AND op.object_class NOT IN ('0000', '000', '00', '0')

--- a/dataactvalidator/config/sqlrules/b11_object_class_program_activity_2.sql
+++ b/dataactvalidator/config/sqlrules/b11_object_class_program_activity_2.sql
@@ -1,7 +1,35 @@
+CREATE OR REPLACE function pg_temp.is_zero(numeric) returns integer AS $$
+BEGIN
+    perform CAST($1 AS numeric);
+    CASE WHEN $1 <> 0
+        THEN return 1;
+        ELSE return 0;
+    END CASE;
+EXCEPTION WHEN others THEN
+    return 0;
+END;
+$$ LANGUAGE plpgsql;
+
 SELECT
     op.row_number,
     op.object_class
 FROM object_class_program_activity AS op
 WHERE op.submission_id = {}
-AND op.object_class IN ('000', '00', '0')
+AND op.object_class IN ('0000', '000', '00', '0')
+AND pg_temp.is_zero(op.deobligations_recov_by_pro_cpe) + pg_temp.is_zero(op.gross_outlay_amount_by_pro_cpe) +
+    pg_temp.is_zero(op.gross_outlay_amount_by_pro_fyb) + pg_temp.is_zero(op.gross_outlays_delivered_or_cpe) +
+    pg_temp.is_zero(op.gross_outlays_delivered_or_fyb) + pg_temp.is_zero(op.gross_outlays_undelivered_cpe) +
+    pg_temp.is_zero(op.gross_outlays_undelivered_fyb) + pg_temp.is_zero(op.obligations_delivered_orde_cpe) +
+    pg_temp.is_zero(op.obligations_delivered_orde_fyb) + pg_temp.is_zero(op.obligations_incurred_by_pr_cpe) +
+    pg_temp.is_zero(op.obligations_undelivered_or_cpe) + pg_temp.is_zero(op.obligations_undelivered_or_fyb) +
+    pg_temp.is_zero(op.ussgl480100_undelivered_or_cpe) + pg_temp.is_zero(op.ussgl480100_undelivered_or_fyb) +
+    pg_temp.is_zero(op.ussgl480200_undelivered_or_cpe) + pg_temp.is_zero(op.ussgl480200_undelivered_or_fyb) +
+    pg_temp.is_zero(op.ussgl483100_undelivered_or_cpe) + pg_temp.is_zero(op.ussgl483200_undelivered_or_cpe) +
+    pg_temp.is_zero(op.ussgl487100_downward_adjus_cpe) + pg_temp.is_zero(op.ussgl487200_downward_adjus_cpe) +
+    pg_temp.is_zero(op.ussgl488100_upward_adjustm_cpe) + pg_temp.is_zero(op.ussgl488200_upward_adjustm_cpe) +
+    pg_temp.is_zero(op.ussgl490100_delivered_orde_cpe) + pg_temp.is_zero(op.ussgl490100_delivered_orde_fyb) +
+    pg_temp.is_zero(op.ussgl490200_delivered_orde_cpe) + pg_temp.is_zero(op.ussgl490800_authority_outl_cpe) +
+    pg_temp.is_zero(op.ussgl490800_authority_outl_fyb) + pg_temp.is_zero(op.ussgl493100_delivered_orde_cpe) +
+    pg_temp.is_zero(op.ussgl497100_downward_adjus_cpe) + pg_temp.is_zero(op.ussgl497200_downward_adjus_cpe) +
+    pg_temp.is_zero(op.ussgl498100_upward_adjustm_cpe) + pg_temp.is_zero(op.ussgl498200_upward_adjustm_cpe) <> 0;
 

--- a/dataactvalidator/config/sqlrules/b18_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b18_object_class_program_activity.sql
@@ -1,8 +1,38 @@
+CREATE OR REPLACE function pg_temp.is_zero(numeric) returns integer AS $$
+BEGIN
+    perform CAST($1 AS numeric);
+    CASE WHEN $1 <> 0
+        THEN return 1;
+        ELSE return 0;
+    END CASE;
+EXCEPTION WHEN others THEN
+    return 0;
+END;
+$$ LANGUAGE plpgsql;
+
 SELECT
     op.row_number,
     op.object_class,
     op.by_direct_reimbursable_fun
 FROM object_class_program_activity AS op
-WHERE op.submission_id = {} AND length(op.object_class) = 4 AND NOT COALESCE(op.by_direct_reimbursable_fun,'') = ''
-AND NOT (SUBSTRING(op.object_class,1,1) = '1' AND lower(op.by_direct_reimbursable_fun) = 'd')
-AND NOT (SUBSTRING(op.object_class,1,1) = '2' AND lower(op.by_direct_reimbursable_fun) = 'r')
+WHERE op.submission_id = {}
+    AND length(op.object_class) = 4
+    AND NOT COALESCE(op.by_direct_reimbursable_fun,'') = ''
+    AND NOT (SUBSTRING(op.object_class,1,1) = '1' AND lower(op.by_direct_reimbursable_fun) = 'd')
+    AND NOT (SUBSTRING(op.object_class,1,1) = '2' AND lower(op.by_direct_reimbursable_fun) = 'r')
+    AND pg_temp.is_zero(op.deobligations_recov_by_pro_cpe) + pg_temp.is_zero(op.gross_outlay_amount_by_pro_cpe) +
+        pg_temp.is_zero(op.gross_outlay_amount_by_pro_fyb) + pg_temp.is_zero(op.gross_outlays_delivered_or_cpe) +
+        pg_temp.is_zero(op.gross_outlays_delivered_or_fyb) + pg_temp.is_zero(op.gross_outlays_undelivered_cpe) +
+        pg_temp.is_zero(op.gross_outlays_undelivered_fyb) + pg_temp.is_zero(op.obligations_delivered_orde_cpe) +
+        pg_temp.is_zero(op.obligations_delivered_orde_fyb) + pg_temp.is_zero(op.obligations_incurred_by_pr_cpe) +
+        pg_temp.is_zero(op.obligations_undelivered_or_cpe) + pg_temp.is_zero(op.obligations_undelivered_or_fyb) +
+        pg_temp.is_zero(op.ussgl480100_undelivered_or_cpe) + pg_temp.is_zero(op.ussgl480100_undelivered_or_fyb) +
+        pg_temp.is_zero(op.ussgl480200_undelivered_or_cpe) + pg_temp.is_zero(op.ussgl480200_undelivered_or_fyb) +
+        pg_temp.is_zero(op.ussgl483100_undelivered_or_cpe) + pg_temp.is_zero(op.ussgl483200_undelivered_or_cpe) +
+        pg_temp.is_zero(op.ussgl487100_downward_adjus_cpe) + pg_temp.is_zero(op.ussgl487200_downward_adjus_cpe) +
+        pg_temp.is_zero(op.ussgl488100_upward_adjustm_cpe) + pg_temp.is_zero(op.ussgl488200_upward_adjustm_cpe) +
+        pg_temp.is_zero(op.ussgl490100_delivered_orde_cpe) + pg_temp.is_zero(op.ussgl490100_delivered_orde_fyb) +
+        pg_temp.is_zero(op.ussgl490200_delivered_orde_cpe) + pg_temp.is_zero(op.ussgl490800_authority_outl_cpe) +
+        pg_temp.is_zero(op.ussgl490800_authority_outl_fyb) + pg_temp.is_zero(op.ussgl493100_delivered_orde_cpe) +
+        pg_temp.is_zero(op.ussgl497100_downward_adjus_cpe) + pg_temp.is_zero(op.ussgl497200_downward_adjus_cpe) +
+        pg_temp.is_zero(op.ussgl498100_upward_adjustm_cpe) + pg_temp.is_zero(op.ussgl498200_upward_adjustm_cpe) <> 0

--- a/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
@@ -1,12 +1,17 @@
+CREATE OR REPLACE function pg_temp.is_zero(numeric) returns integer AS $$
+BEGIN
+    perform CAST($1 AS numeric);
+    CASE WHEN $1 <> 0
+        THEN return 1;
+        ELSE return 0;
+    END CASE;
+EXCEPTION WHEN others THEN
+    return 0;
+END;
+$$ LANGUAGE plpgsql;
+
 WITH object_class_program_activity_b9_{0} AS
-    (SELECT submission_id,
-        row_number,
-        beginning_period_of_availa,
-        agency_identifier,
-        allocation_transfer_agency,
-        main_account_code,
-        program_activity_name,
-        program_activity_code
+    (SELECT *
     FROM object_class_program_activity
     WHERE submission_id = {0})
 SELECT op.row_number,
@@ -31,4 +36,23 @@ WHERE op.submission_id = {0}
 				AND op.main_account_code IS NOT DISTINCT FROM pa.account_number
 				AND LOWER(op.program_activity_name) IS NOT DISTINCT FROM LOWER(pa.program_activity_name)
 				AND op.program_activity_code IS NOT DISTINCT FROM pa.program_activity_code)
-	);
+	)
+	AND (CASE WHEN op.program_activity_name = ''
+	        THEN pg_temp.is_zero(op.deobligations_recov_by_pro_cpe) + pg_temp.is_zero(op.gross_outlay_amount_by_pro_cpe) +
+            pg_temp.is_zero(op.gross_outlay_amount_by_pro_fyb) + pg_temp.is_zero(op.gross_outlays_delivered_or_cpe) +
+            pg_temp.is_zero(op.gross_outlays_delivered_or_fyb) + pg_temp.is_zero(op.gross_outlays_undelivered_cpe) +
+            pg_temp.is_zero(op.gross_outlays_undelivered_fyb) + pg_temp.is_zero(op.obligations_delivered_orde_cpe) +
+            pg_temp.is_zero(op.obligations_delivered_orde_fyb) + pg_temp.is_zero(op.obligations_incurred_by_pr_cpe) +
+            pg_temp.is_zero(op.obligations_undelivered_or_cpe) + pg_temp.is_zero(op.obligations_undelivered_or_fyb) +
+            pg_temp.is_zero(op.ussgl480100_undelivered_or_cpe) + pg_temp.is_zero(op.ussgl480100_undelivered_or_fyb) +
+            pg_temp.is_zero(op.ussgl480200_undelivered_or_cpe) + pg_temp.is_zero(op.ussgl480200_undelivered_or_fyb) +
+            pg_temp.is_zero(op.ussgl483100_undelivered_or_cpe) + pg_temp.is_zero(op.ussgl483200_undelivered_or_cpe) +
+            pg_temp.is_zero(op.ussgl487100_downward_adjus_cpe) + pg_temp.is_zero(op.ussgl487200_downward_adjus_cpe) +
+            pg_temp.is_zero(op.ussgl488100_upward_adjustm_cpe) + pg_temp.is_zero(op.ussgl488200_upward_adjustm_cpe) +
+            pg_temp.is_zero(op.ussgl490100_delivered_orde_cpe) + pg_temp.is_zero(op.ussgl490100_delivered_orde_fyb) +
+            pg_temp.is_zero(op.ussgl490200_delivered_orde_cpe) + pg_temp.is_zero(op.ussgl490800_authority_outl_cpe) +
+            pg_temp.is_zero(op.ussgl490800_authority_outl_fyb) + pg_temp.is_zero(op.ussgl493100_delivered_orde_cpe) +
+            pg_temp.is_zero(op.ussgl497100_downward_adjus_cpe) + pg_temp.is_zero(op.ussgl497200_downward_adjus_cpe) +
+            pg_temp.is_zero(op.ussgl498100_upward_adjustm_cpe) + pg_temp.is_zero(op.ussgl498200_upward_adjustm_cpe)
+            ELSE 1
+            END) <> 0;

--- a/tests/unit/dataactvalidator/test_b11_award_financial_2.py
+++ b/tests/unit/dataactvalidator/test_b11_award_financial_2.py
@@ -24,7 +24,10 @@ def test_success(database):
 def test_failure(database):
     """ Test invalid object class code (3 digits) """
 
-    # This should return because if it's '000', '00', '0' a warning should be returned
+    # This should return because if it's '0000' '000', '00', '0' a warning should be returned
+    af = AwardFinancialFactory(object_class='0000')
+    assert number_of_errors(_FILE, database, models=[af]) == 1
+
     af = AwardFinancialFactory(object_class='000')
     assert number_of_errors(_FILE, database, models=[af]) == 1
 

--- a/tests/unit/dataactvalidator/test_b11_object_class_program_activity_2.py
+++ b/tests/unit/dataactvalidator/test_b11_object_class_program_activity_2.py
@@ -21,10 +21,36 @@ def test_success(database):
     assert number_of_errors(_FILE, database, models=[op, oc]) == 0
 
 
+def test_success_all_zero(database):
+    """ Test not returning a warning on '000' when all monetary values are 0 """
+
+    op = ObjectClassProgramActivityFactory(object_class='000', deobligations_recov_by_pro_cpe=0,
+                                           gross_outlay_amount_by_pro_cpe=0, gross_outlay_amount_by_pro_fyb=0,
+                                           gross_outlays_delivered_or_cpe=0, gross_outlays_delivered_or_fyb=0,
+                                           gross_outlays_undelivered_cpe=0, gross_outlays_undelivered_fyb=0,
+                                           obligations_delivered_orde_cpe=0, obligations_delivered_orde_fyb=0,
+                                           obligations_incurred_by_pr_cpe=0, obligations_undelivered_or_cpe=0,
+                                           obligations_undelivered_or_fyb=0, ussgl480100_undelivered_or_cpe=0,
+                                           ussgl480100_undelivered_or_fyb=0, ussgl480200_undelivered_or_cpe=0,
+                                           ussgl480200_undelivered_or_fyb=0, ussgl483100_undelivered_or_cpe=0,
+                                           ussgl483200_undelivered_or_cpe=0, ussgl487100_downward_adjus_cpe=0,
+                                           ussgl487200_downward_adjus_cpe=0, ussgl488100_upward_adjustm_cpe=0,
+                                           ussgl488200_upward_adjustm_cpe=0, ussgl490100_delivered_orde_cpe=0,
+                                           ussgl490100_delivered_orde_fyb=0, ussgl490200_delivered_orde_cpe=0,
+                                           ussgl490800_authority_outl_cpe=0, ussgl490800_authority_outl_fyb=0,
+                                           ussgl493100_delivered_orde_cpe=0, ussgl497100_downward_adjus_cpe=0,
+                                           ussgl497200_downward_adjus_cpe=0, ussgl498100_upward_adjustm_cpe=0,
+                                           ussgl498200_upward_adjustm_cpe=0)
+    assert number_of_errors(_FILE, database, models=[op]) == 0
+
+
 def test_failure(database):
     """ Test invalid object class code (3 digits) """
 
-    # This should return because if it's '000', '00', '0' a warning should be returned
+    # This should return because if it's '0000' '000', '00', '0' a warning should be returned
+    op = ObjectClassProgramActivityFactory(object_class='0000')
+    assert number_of_errors(_FILE, database, models=[op]) == 1
+
     op = ObjectClassProgramActivityFactory(object_class='000')
     assert number_of_errors(_FILE, database, models=[op]) == 1
 
@@ -32,4 +58,28 @@ def test_failure(database):
     assert number_of_errors(_FILE, database, models=[op]) == 1
 
     op = ObjectClassProgramActivityFactory(object_class='0')
+    assert number_of_errors(_FILE, database, models=[op]) == 1
+
+
+def test_fail_nonzero(database):
+    """ Test returning a warning on '000' when not all monetary values are 0 """
+
+    # even one non-zero should return a warning
+    op = ObjectClassProgramActivityFactory(object_class='000', deobligations_recov_by_pro_cpe=1,
+                                           gross_outlay_amount_by_pro_cpe=0, gross_outlay_amount_by_pro_fyb=0,
+                                           gross_outlays_delivered_or_cpe=0, gross_outlays_delivered_or_fyb=0,
+                                           gross_outlays_undelivered_cpe=0, gross_outlays_undelivered_fyb=0,
+                                           obligations_delivered_orde_cpe=0, obligations_delivered_orde_fyb=0,
+                                           obligations_incurred_by_pr_cpe=0, obligations_undelivered_or_cpe=0,
+                                           obligations_undelivered_or_fyb=0, ussgl480100_undelivered_or_cpe=0,
+                                           ussgl480100_undelivered_or_fyb=0, ussgl480200_undelivered_or_cpe=0,
+                                           ussgl480200_undelivered_or_fyb=0, ussgl483100_undelivered_or_cpe=0,
+                                           ussgl483200_undelivered_or_cpe=0, ussgl487100_downward_adjus_cpe=0,
+                                           ussgl487200_downward_adjus_cpe=0, ussgl488100_upward_adjustm_cpe=0,
+                                           ussgl488200_upward_adjustm_cpe=0, ussgl490100_delivered_orde_cpe=0,
+                                           ussgl490100_delivered_orde_fyb=0, ussgl490200_delivered_orde_cpe=0,
+                                           ussgl490800_authority_outl_cpe=0, ussgl490800_authority_outl_fyb=0,
+                                           ussgl493100_delivered_orde_cpe=0, ussgl497100_downward_adjus_cpe=0,
+                                           ussgl497200_downward_adjus_cpe=0, ussgl498100_upward_adjustm_cpe=0,
+                                           ussgl498200_upward_adjustm_cpe=0)
     assert number_of_errors(_FILE, database, models=[op]) == 1

--- a/tests/unit/dataactvalidator/test_b18_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b18_object_class_program_activity.py
@@ -32,6 +32,47 @@ def test_match_r_value(database):
                 by_direct_reimbursable_fun="r"), 0)
 
 
+def test_ignore_all_zero(database):
+    check_query(database,
+                ObjectClassProgramActivityFactory(object_class=randint(1000, 1999), by_direct_reimbursable_fun="r",
+                                                  deobligations_recov_by_pro_cpe=0, gross_outlay_amount_by_pro_cpe=0,
+                                                  gross_outlay_amount_by_pro_fyb=0, gross_outlays_delivered_or_cpe=0,
+                                                  gross_outlays_delivered_or_fyb=0, gross_outlays_undelivered_cpe=0,
+                                                  gross_outlays_undelivered_fyb=0, obligations_delivered_orde_cpe=0,
+                                                  obligations_delivered_orde_fyb=0, obligations_incurred_by_pr_cpe=0,
+                                                  obligations_undelivered_or_cpe=0, obligations_undelivered_or_fyb=0,
+                                                  ussgl480100_undelivered_or_cpe=0, ussgl480100_undelivered_or_fyb=0,
+                                                  ussgl480200_undelivered_or_cpe=0, ussgl480200_undelivered_or_fyb=0,
+                                                  ussgl483100_undelivered_or_cpe=0, ussgl483200_undelivered_or_cpe=0,
+                                                  ussgl487100_downward_adjus_cpe=0, ussgl487200_downward_adjus_cpe=0,
+                                                  ussgl488100_upward_adjustm_cpe=0, ussgl488200_upward_adjustm_cpe=0,
+                                                  ussgl490100_delivered_orde_cpe=0, ussgl490100_delivered_orde_fyb=0,
+                                                  ussgl490200_delivered_orde_cpe=0, ussgl490800_authority_outl_cpe=0,
+                                                  ussgl490800_authority_outl_fyb=0, ussgl493100_delivered_orde_cpe=0,
+                                                  ussgl497100_downward_adjus_cpe=0, ussgl497200_downward_adjus_cpe=0,
+                                                  ussgl498100_upward_adjustm_cpe=0, ussgl498200_upward_adjustm_cpe=0),
+                0)
+    check_query(database,
+                ObjectClassProgramActivityFactory(object_class=randint(2000, 2999), by_direct_reimbursable_fun="d",
+                                                  deobligations_recov_by_pro_cpe=0, gross_outlay_amount_by_pro_cpe=0,
+                                                  gross_outlay_amount_by_pro_fyb=0, gross_outlays_delivered_or_cpe=0,
+                                                  gross_outlays_delivered_or_fyb=0, gross_outlays_undelivered_cpe=0,
+                                                  gross_outlays_undelivered_fyb=0, obligations_delivered_orde_cpe=0,
+                                                  obligations_delivered_orde_fyb=0, obligations_incurred_by_pr_cpe=0,
+                                                  obligations_undelivered_or_cpe=0, obligations_undelivered_or_fyb=0,
+                                                  ussgl480100_undelivered_or_cpe=0, ussgl480100_undelivered_or_fyb=0,
+                                                  ussgl480200_undelivered_or_cpe=0, ussgl480200_undelivered_or_fyb=0,
+                                                  ussgl483100_undelivered_or_cpe=0, ussgl483200_undelivered_or_cpe=0,
+                                                  ussgl487100_downward_adjus_cpe=0, ussgl487200_downward_adjus_cpe=0,
+                                                  ussgl488100_upward_adjustm_cpe=0, ussgl488200_upward_adjustm_cpe=0,
+                                                  ussgl490100_delivered_orde_cpe=0, ussgl490100_delivered_orde_fyb=0,
+                                                  ussgl490200_delivered_orde_cpe=0, ussgl490800_authority_outl_cpe=0,
+                                                  ussgl490800_authority_outl_fyb=0, ussgl493100_delivered_orde_cpe=0,
+                                                  ussgl497100_downward_adjus_cpe=0, ussgl497200_downward_adjus_cpe=0,
+                                                  ussgl498100_upward_adjustm_cpe=0, ussgl498200_upward_adjustm_cpe=0),
+                0)
+
+
 def test_mismatch_d_value(database):
     check_query(database, ObjectClassProgramActivityFactory(object_class=randint(2000, 2999),
                 by_direct_reimbursable_fun="d"), 1)

--- a/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
@@ -68,6 +68,34 @@ def test_success_ignore_case(database):
     assert number_of_errors(_FILE, database, models=[op, pa]) == 0
 
 
+def test_success_ignore_blank_program_activity_name(database):
+    """ Testing program activity name validation to ignore blanks if monetary sum is 0 """
+    op = ObjectClassProgramActivityFactory(row_number=1, beginning_period_of_availa=2016, agency_identifier='test',
+                                           allocation_transfer_agency='test', main_account_code='test',
+                                           program_activity_name='', program_activity_code='test',
+                                           deobligations_recov_by_pro_cpe=0, gross_outlay_amount_by_pro_cpe=0,
+                                           gross_outlay_amount_by_pro_fyb=0, gross_outlays_delivered_or_cpe=0,
+                                           gross_outlays_delivered_or_fyb=0, gross_outlays_undelivered_cpe=0,
+                                           gross_outlays_undelivered_fyb=0, obligations_delivered_orde_cpe=0,
+                                           obligations_delivered_orde_fyb=0, obligations_incurred_by_pr_cpe=0,
+                                           obligations_undelivered_or_cpe=0, obligations_undelivered_or_fyb=0,
+                                           ussgl480100_undelivered_or_cpe=0, ussgl480100_undelivered_or_fyb=0,
+                                           ussgl480200_undelivered_or_cpe=0, ussgl480200_undelivered_or_fyb=0,
+                                           ussgl483100_undelivered_or_cpe=0, ussgl483200_undelivered_or_cpe=0,
+                                           ussgl487100_downward_adjus_cpe=0, ussgl487200_downward_adjus_cpe=0,
+                                           ussgl488100_upward_adjustm_cpe=0, ussgl488200_upward_adjustm_cpe=0,
+                                           ussgl490100_delivered_orde_cpe=0, ussgl490100_delivered_orde_fyb=0,
+                                           ussgl490200_delivered_orde_cpe=0, ussgl490800_authority_outl_cpe=0,
+                                           ussgl490800_authority_outl_fyb=0, ussgl493100_delivered_orde_cpe=0,
+                                           ussgl497100_downward_adjus_cpe=0, ussgl497200_downward_adjus_cpe=0,
+                                           ussgl498100_upward_adjustm_cpe=0, ussgl498200_upward_adjustm_cpe=0)
+
+    pa = ProgramActivityFactory(budget_year=2016, agency_id='test', allocation_transfer_id='test',
+                                account_number='test', program_activity_name='test', program_activity_code='test')
+
+    assert number_of_errors(_FILE, database, models=[op, pa]) == 0
+
+
 def test_failure_program_activity_name(database):
     """ Testing invalid program activity name for the corresponding TAS/TAFS as defined in Section 82 of OMB Circular
     A-11. """
@@ -99,3 +127,78 @@ def test_failure_program_activity_code(database):
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     assert number_of_errors(_FILE, database, models=[op_1, op_2, pa]) == 1
+
+
+def test_failure_empty_activity_name(database):
+    """ Testing program activity name validation to not ignore blanks if monetary sum is not 0 """
+    pa = ProgramActivityFactory(budget_year=2016, agency_id='test', allocation_transfer_id='test',
+                                account_number='test', program_activity_name='test', program_activity_code='test')
+
+    # one monetary amount not 0
+    op = ObjectClassProgramActivityFactory(row_number=1, beginning_period_of_availa=2016, agency_identifier='test',
+                                           allocation_transfer_agency='test', main_account_code='test',
+                                           program_activity_name='', program_activity_code='test',
+                                           deobligations_recov_by_pro_cpe=2, gross_outlay_amount_by_pro_cpe=0,
+                                           gross_outlay_amount_by_pro_fyb=0, gross_outlays_delivered_or_cpe=0,
+                                           gross_outlays_delivered_or_fyb=0, gross_outlays_undelivered_cpe=0,
+                                           gross_outlays_undelivered_fyb=0, obligations_delivered_orde_cpe=0,
+                                           obligations_delivered_orde_fyb=0, obligations_incurred_by_pr_cpe=0,
+                                           obligations_undelivered_or_cpe=0, obligations_undelivered_or_fyb=0,
+                                           ussgl480100_undelivered_or_cpe=0, ussgl480100_undelivered_or_fyb=0,
+                                           ussgl480200_undelivered_or_cpe=0, ussgl480200_undelivered_or_fyb=0,
+                                           ussgl483100_undelivered_or_cpe=0, ussgl483200_undelivered_or_cpe=0,
+                                           ussgl487100_downward_adjus_cpe=0, ussgl487200_downward_adjus_cpe=0,
+                                           ussgl488100_upward_adjustm_cpe=0, ussgl488200_upward_adjustm_cpe=0,
+                                           ussgl490100_delivered_orde_cpe=0, ussgl490100_delivered_orde_fyb=0,
+                                           ussgl490200_delivered_orde_cpe=0, ussgl490800_authority_outl_cpe=0,
+                                           ussgl490800_authority_outl_fyb=0, ussgl493100_delivered_orde_cpe=0,
+                                           ussgl497100_downward_adjus_cpe=0, ussgl497200_downward_adjus_cpe=0,
+                                           ussgl498100_upward_adjustm_cpe=0, ussgl498200_upward_adjustm_cpe=0)
+
+    assert number_of_errors(_FILE, database, models=[op, pa]) == 1
+
+    # several monetary amounts not 0
+    op = ObjectClassProgramActivityFactory(row_number=1, beginning_period_of_availa=2016, agency_identifier='test',
+                                           allocation_transfer_agency='test', main_account_code='test',
+                                           program_activity_name='', program_activity_code='test',
+                                           deobligations_recov_by_pro_cpe=2, gross_outlay_amount_by_pro_cpe=0,
+                                           gross_outlay_amount_by_pro_fyb=0, gross_outlays_delivered_or_cpe=0,
+                                           gross_outlays_delivered_or_fyb=0, gross_outlays_undelivered_cpe=0,
+                                           gross_outlays_undelivered_fyb=0, obligations_delivered_orde_cpe=0,
+                                           obligations_delivered_orde_fyb=-2, obligations_incurred_by_pr_cpe=0,
+                                           obligations_undelivered_or_cpe=0, obligations_undelivered_or_fyb=0,
+                                           ussgl480100_undelivered_or_cpe=0, ussgl480100_undelivered_or_fyb=0,
+                                           ussgl480200_undelivered_or_cpe=0, ussgl480200_undelivered_or_fyb=-0.4,
+                                           ussgl483100_undelivered_or_cpe=0, ussgl483200_undelivered_or_cpe=0,
+                                           ussgl487100_downward_adjus_cpe=0.4, ussgl487200_downward_adjus_cpe=0,
+                                           ussgl488100_upward_adjustm_cpe=0, ussgl488200_upward_adjustm_cpe=0,
+                                           ussgl490100_delivered_orde_cpe=0, ussgl490100_delivered_orde_fyb=0,
+                                           ussgl490200_delivered_orde_cpe=0, ussgl490800_authority_outl_cpe=0,
+                                           ussgl490800_authority_outl_fyb=0, ussgl493100_delivered_orde_cpe=0,
+                                           ussgl497100_downward_adjus_cpe=0, ussgl497200_downward_adjus_cpe=0,
+                                           ussgl498100_upward_adjustm_cpe=0, ussgl498200_upward_adjustm_cpe=0)
+
+    assert number_of_errors(_FILE, database, models=[op, pa]) == 1
+
+    # all monetary amounts not 0
+    op = ObjectClassProgramActivityFactory(row_number=1, beginning_period_of_availa=2016, agency_identifier='test',
+                                           allocation_transfer_agency='test', main_account_code='test',
+                                           program_activity_name='', program_activity_code='test',
+                                           deobligations_recov_by_pro_cpe=2, gross_outlay_amount_by_pro_cpe=100,
+                                           gross_outlay_amount_by_pro_fyb=-0.00003, gross_outlays_delivered_or_cpe=10,
+                                           gross_outlays_delivered_or_fyb=5, gross_outlays_undelivered_cpe=5,
+                                           gross_outlays_undelivered_fyb=5, obligations_delivered_orde_cpe=5,
+                                           obligations_delivered_orde_fyb=-2, obligations_incurred_by_pr_cpe=5,
+                                           obligations_undelivered_or_cpe=5, obligations_undelivered_or_fyb=5,
+                                           ussgl480100_undelivered_or_cpe=5, ussgl480100_undelivered_or_fyb=5,
+                                           ussgl480200_undelivered_or_cpe=5, ussgl480200_undelivered_or_fyb=-0.4,
+                                           ussgl483100_undelivered_or_cpe=5, ussgl483200_undelivered_or_cpe=5,
+                                           ussgl487100_downward_adjus_cpe=0.4, ussgl487200_downward_adjus_cpe=5,
+                                           ussgl488100_upward_adjustm_cpe=5, ussgl488200_upward_adjustm_cpe=5,
+                                           ussgl490100_delivered_orde_cpe=5, ussgl490100_delivered_orde_fyb=5,
+                                           ussgl490200_delivered_orde_cpe=5, ussgl490800_authority_outl_cpe=5,
+                                           ussgl490800_authority_outl_fyb=5, ussgl493100_delivered_orde_cpe=5,
+                                           ussgl497100_downward_adjus_cpe=5, ussgl497200_downward_adjus_cpe=5,
+                                           ussgl498100_upward_adjustm_cpe=5, ussgl498200_upward_adjustm_cpe=5)
+
+    assert number_of_errors(_FILE, database, models=[op, pa]) == 1


### PR DESCRIPTION
For TAS in file B that have zeros for each of the financial data elements (USSGL and related subtotals):
- Accept blanks for program activity name (B9) without warnings
- Accept 0000 for program activity code (B10) without warnings (note, it is ok for the 0 to be padded)
- Accept 000/0000 for object class (B11) without warnings (note, it is ok for the 0 to be padded)
- Accept D, R, or blank for D/R field regardless of whether a 3 or 4 digit object class is given (B12, B18) without warnings

Some of these already happened, but those that didn't have been updated.

Technical Release Notes:
- Updates to validation rules, need to reload them to the db