### PR TITLE
Db 1819 allow large files to generate

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -502,7 +502,7 @@ class FileHandler:
                 if response.status_code != 200:
                     # Could not download the file, return False
                     return False
-                # write to file
+                # write (stream) to file
                 response.encoding = "utf-8"
                 for chunk in response.iter_content(chunk_size=1024):
                     if chunk:
@@ -540,9 +540,13 @@ class FileHandler:
                 job.error_message = "A problem occurred receiving data from {}".format(source)
 
                 raise ResponseException(job.error_message, StatusCode.CLIENT_ERROR)
-            # lines = get_lines_from_csv(full_file_path)
-            #
-            # write_csv(timestamped_name, upload_name, is_local, lines[0], lines[1:])
+
+            # we're streaming non-locally but locally we still need to write as a csv
+            # because copyfile doesn't do it
+            if self.isLocal:
+                lines = get_lines_from_csv(full_file_path)
+
+                write_csv(timestamped_name, upload_name, is_local, lines[0], lines[1:])
 
             logger.debug('Marking job id of %s', job_id)
             mark_job_status(job_id, "finished")

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -947,10 +947,11 @@ class FileHandler:
             # if it isn't local, we want to make the actual loading a thread because we need to quickly respond to
             # metrostar
             if not self.isLocal:
-                response = requests.get(url)
+                response = requests.get(url, stream=True)
                 if response.status_code != 200:
                     # Could not download the file, return False
                     raise ResponseException("Could not access download URL", StatusCode.CLIENT_ERROR)
+                logger.debug('Starting thread')
                 threading.Thread(target=self.load_d_file, args=(url, job.filename, job.original_filename, job.job_id,
                                                                 self.isLocal))
             # local shouldn't be a thread, just wait, no one is waiting on us.

--- a/dataactcore/aws/s3Handler.py
+++ b/dataactcore/aws/s3Handler.py
@@ -134,6 +134,17 @@ class S3Handler:
         return urls
 
     @staticmethod
+    def create_file_path(upload_name):
+        try:
+            S3Handler.REGION
+        except AttributeError:
+            S3Handler.REGION = CONFIG_BROKER["aws_region"]
+
+        bucket = CONFIG_BROKER['aws_bucket']
+        conn = boto.s3.connect_to_region(S3Handler.REGION).get_bucket(bucket).new_key(upload_name)
+        return conn
+
+    @staticmethod
     def copy_file(original_bucket, new_bucket, original_path, new_path):
         try:
             S3Handler.REGION


### PR DESCRIPTION
Hotfix to stream D files non-locally instead of saving to memory. Fixes the Memory Error we kept getting when DoD tried to generate their D1 file.

Also uses threads to continue the streaming so we don't make MetroStar wait too long on their callback response. If we do, it sends it again and we end up downloading multiple 1GB+ files