### PR TITLE
Removing job manager

### DIFF
--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -1,1 +1,0 @@
-BROKER_TRANSPORT_OPTIONS = {'confirm_publish': True}

--- a/dataactbroker/handlers/fileGenerationHandler.py
+++ b/dataactbroker/handlers/fileGenerationHandler.py
@@ -1,15 +1,10 @@
 from contextlib import contextmanager
 import logging
 
-from celery import Celery
-from celery.exceptions import MaxRetriesExceededError
 from flask import Flask
-import requests
 
-from dataactcore.config import CONFIG_DB, CONFIG_SERVICES, CONFIG_JOB_QUEUE
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.interfaces.function_bag import mark_job_status
-from dataactcore.logging import configure_logging
 from dataactcore.models.jobModels import Job
 from dataactcore.models.stagingModels import AwardFinancialAssistance, AwardProcurement
 from dataactcore.models.domainModels import ExecutiveCompensation
@@ -20,36 +15,8 @@ from dataactvalidator.filestreaming.csv_selection import write_csv
 logger = logging.getLogger(__name__)
 
 
-def broker_url(host):
-    """We use a different broker_url when running the workers than when
-    running within the flask app. Generate an appropriate URL with that in
-    mind"""
-    return '{broker_scheme}://{username}:{password}@{host}:{port}//'.format(host=host, **CONFIG_JOB_QUEUE)
-
-
-# Set up backend persistent URL
-backendUrl = 'db+{scheme}://{username}:{password}@{host}/{job_queue_db_name}'.format(**CONFIG_DB)
-celery_app = Celery('tasks', backend=backendUrl, broker=broker_url(CONFIG_JOB_QUEUE['url']))
-celery_app.config_from_object('celeryconfig')
-
-
-@celery_app.task(name='jobQueue.enqueue')
-def enqueue(job_id):
-    """POST a job to the validator"""
-    logger.info('Adding job %s to the queue', job_id)
-    validator_url = '{validator_host}:{validator_port}'.format(**CONFIG_SERVICES)
-    if 'http://' not in validator_url:
-        validator_url = 'http://' + validator_url
-    validator_url += '/validate/'
-    params = {'job_id': job_id}
-    response = requests.post(validator_url, json=params)
-    logger.info('Job %s has completed validation', job_id)
-    logger.info('Validator response: %s', response.json())
-    return response.json()
-
-
 @contextmanager
-def job_context(task, job_id):
+def job_context(job_id):
     """Common context for file E and F generation. Handles marking the job
     finished and/or failed"""
     # Flask context ensures we have access to global.g
@@ -60,30 +27,23 @@ def job_context(task, job_id):
             logger.debug('Marking job as finished')
             mark_job_status(job_id, "finished")
         except Exception as e:
-            logger.debug('EXCEPTION CAUGHT')
             # logger.exception() automatically adds traceback info
-            logger.exception('Job %s failed, retrying', job_id)
-            try:
-                raise task.retry()
-            except MaxRetriesExceededError:
-                logger.warning('Job %s completely failed', job_id)
-                # Log the error
-                job = sess.query(Job).filter_by(job_id=job_id).one_or_none()
-                if job:
-                    job.error_message = str(e)
-                    sess.commit()
-                    mark_job_status(job_id, "failed")
+            logger.exception('Job %s failed', job_id)
+            job = sess.query(Job).filter_by(job_id=job_id).one_or_none()
+            if job:
+                job.error_message = str(e)
+                sess.commit()
+                mark_job_status(job_id, "failed")
         finally:
             GlobalDB.close()
 
 
-@celery_app.task(name='jobQueue.generate_f_file', max_retries=0, bind=True)
-def generate_f_file(task, submission_id, job_id, timestamped_name, upload_file_name, is_local):
+def generate_f_file(submission_id, job_id, timestamped_name, upload_file_name, is_local):
     """Write rows from fileF.generate_f_rows to an appropriate CSV."""
 
     logger.debug('Starting file F generation')
 
-    with job_context(task, job_id):
+    with job_context(job_id):
         logger.debug('Calling genearte_f_rows')
         rows_of_dicts = fileF.generate_f_rows(submission_id)
         header = [key for key in fileF.mappings]    # keep order
@@ -97,10 +57,9 @@ def generate_f_file(task, submission_id, job_id, timestamped_name, upload_file_n
     logger.debug('Finished file F generation')
 
 
-@celery_app.task(name='jobQueue.generate_e_file', max_retires=3, bind=True)
-def generate_e_file(task, submission_id, job_id, timestamped_name, upload_file_name, is_local):
+def generate_e_file(submission_id, job_id, timestamped_name, upload_file_name, is_local):
     """Write file E to an appropriate CSV."""
-    with job_context(task, job_id) as session:
+    with job_context(job_id) as session:
         d1 = session.\
             query(AwardProcurement.awardee_or_recipient_uniqu).\
             filter(AwardProcurement.submission_id == submission_id).\
@@ -123,8 +82,3 @@ def generate_e_file(task, submission_id, job_id, timestamped_name, upload_file_n
         session.commit()
 
         write_csv(timestamped_name, upload_file_name, is_local, fileE.Row._fields, rows)
-
-
-if __name__ in ['__main__', 'jobQueue']:
-    configure_logging()
-    celery_app.conf.update(BROKER_URL=broker_url('localhost'))

--- a/dataactcore/config.py
+++ b/dataactcore/config.py
@@ -8,9 +8,8 @@ CONFIG_BROKER = {}
 CONFIG_SERVICES = {}
 CONFIG_DB = {}
 CONFIG_LOGGING = {}
-CONFIG_JOB_QUEUE = {}
 CONFIG_CATEGORIES = {"broker": CONFIG_BROKER, "services": CONFIG_SERVICES, "db": CONFIG_DB,
-                     "logging": CONFIG_LOGGING, "job-queue": CONFIG_JOB_QUEUE}
+                     "logging": CONFIG_LOGGING}
 
 # set the location of the DATA Act broker config files
 CONFIG_PATH = os.path.join(dirname(abspath(__file__)), 'config.yml')

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -177,19 +177,3 @@ logging:
             - scheme
         logging:
             - log_files
-        job-queue:
-            - url
-            - port
-            - broker_scheme
-
-job-queue:
-
-    # URL for the job queue server (do not add http)
-    url: dataactbroker.jobqueue.host.domain.com
-
-    # Port on which Celery is listening
-    port: 5672
-
-    # Broker scheme which must coordinate with the type of broker being used
-    # on the remote server. amqp corresponds to RabbitMQ.
-    broker_scheme: amqp

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -129,17 +129,6 @@ When running the broker, you have the option to use Amazon Web Services (AWS) to
 
 Using AWS is optional, and by default the broker will not use these services. If you'd like to use AWS, [follow these directions](AWS.md "set up Amazon Web Services") now.
 
-### Install RabbitMQ
-
-RabbitMQ is used to pass jobs to the validator, and requires Erlang to be installed before RabbitMQ.
-
-1.  Install Erlang based on the [download instructions](https://www.erlang.org/downloads)
-2.  Choose an installation guide based on your OS for [RabbitMQ](https://www.rabbitmq.com/download.html).  Be sure to install Erlang before installing RabbitMQ.  The default user and password is "guest"/"guest", if you change these you'll need to keep that information to be placed in the config files later in the process.
-
-Alternatively, a [Docker](https://www.docker.com/products/overview#/install_the_platform) setup is pretty straight forward:
-
-        $ docker run -d -p 5672:5672 rabbitmq:3
-
 ### Clone Broker Backend Code Repository
 
 Now we're ready to install the DATA Act broker itself. Before starting:
@@ -287,14 +276,6 @@ Make sure the validator is working by visiting by visiting the hostname and port
 Once the DATA Act broker's backend is up and running, you may also want to stand up a local version of the broker website. The directions for doing that are in the [website project's code repository](https://github.com/fedspendingtransparency/data-act-broker-web-app "DATA Act broker website").
 
 After following the website setup directions, you can log in with the admin e-mail and password you set in the [broker's backend config file](#create-broker-config-file "config file setup") (`admin_email` and `admin_password`).
-
-### Run Celery
-
-Celery puts jobs into the queue, which are then read into the validator. This will need to be running in the background while the app is running at all times.
-
-From the `data-act-broker-backend/dataactcore/utils/` directory:
-
-		$ celery -A jobQueue worker --loglevel=info
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ billiard==3.3.0.23
 boto==2.38.0
 botocore==1.4.1
 bz2file==0.98
-celery==3.1.23
 cffi==1.8.3
 click==6.6
 colorama==0.3.3

--- a/tests/unit/dataactbroker/test_file_generation_handler.py
+++ b/tests/unit/dataactbroker/test_file_generation_handler.py
@@ -3,8 +3,6 @@ import csv
 import os
 from unittest.mock import Mock
 
-import pytest
-
 from dataactcore.models.jobModels import FileType, JobStatus, JobType
 from dataactcore.utils import fileE
 from dataactbroker.handlers import fileGenerationHandler

--- a/tests/unit/dataactbroker/test_file_generation_handler.py
+++ b/tests/unit/dataactbroker/test_file_generation_handler.py
@@ -3,11 +3,11 @@ import csv
 import os
 from unittest.mock import Mock
 
-from celery.exceptions import MaxRetriesExceededError, Retry
 import pytest
 
 from dataactcore.models.jobModels import FileType, JobStatus, JobType
-from dataactcore.utils import fileE, jobQueue
+from dataactcore.utils import fileE
+from dataactbroker.handlers import fileGenerationHandler
 from tests.unit.dataactcore.factories.staging import AwardFinancialAssistanceFactory, AwardProcurementFactory
 from tests.unit.dataactcore.factories.job import JobFactory, SubmissionFactory
 
@@ -23,15 +23,15 @@ def test_generate_f_file(monkeypatch, mock_broker_config_paths):
     """A CSV with fields in the right order should be written to the file
     system"""
     file_f_mock = Mock()
-    monkeypatch.setattr(jobQueue, 'fileF', file_f_mock)
+    monkeypatch.setattr(fileGenerationHandler, 'fileF', file_f_mock)
     file_f_mock.generate_f_rows.return_value = [dict(key4='a', key11='b'), dict(key4='c', key11='d')]
 
     file_f_mock.mappings = OrderedDict([('key4', 'mapping4'), ('key11', 'mapping11')])
     file_path = str(mock_broker_config_paths['broker_files'].join('uniq1'))
     expected = [['key4', 'key11'], ['a', 'b'], ['c', 'd']]
 
-    monkeypatch.setattr(jobQueue, 'mark_job_status', Mock())
-    jobQueue.generate_f_file(1, 1, 'uniq1', 'uniq1', is_local=True)
+    monkeypatch.setattr(fileGenerationHandler, 'mark_job_status', Mock())
+    fileGenerationHandler.generate_f_file(1, 1, 'uniq1', 'uniq1', is_local=True)
     assert read_file_rows(file_path) == expected
 
     # re-order
@@ -39,8 +39,8 @@ def test_generate_f_file(monkeypatch, mock_broker_config_paths):
     file_path = str(mock_broker_config_paths['broker_files'].join('uniq2'))
     expected = [['key11', 'key4'], ['b', 'a'], ['d', 'c']]
 
-    monkeypatch.setattr(jobQueue, 'mark_job_status', Mock())
-    jobQueue.generate_f_file(1, 1, 'uniq2', 'uniq2', is_local=True)
+    monkeypatch.setattr(fileGenerationHandler, 'mark_job_status', Mock())
+    fileGenerationHandler.generate_f_file(1, 1, 'uniq2', 'uniq2', is_local=True)
     assert read_file_rows(file_path) == expected
 
 
@@ -65,13 +65,13 @@ def test_generate_e_file_query(monkeypatch, mock_broker_config_paths, database):
     database.session.add_all(aps + afas + [model, same_duns, unrelated])
     database.session.commit()
 
-    monkeypatch.setattr(jobQueue, 'mark_job_status', Mock())
-    monkeypatch.setattr(jobQueue.fileE, 'retrieve_rows', Mock(return_value=[]))
+    monkeypatch.setattr(fileGenerationHandler, 'mark_job_status', Mock())
+    monkeypatch.setattr(fileGenerationHandler.fileE, 'retrieve_rows', Mock(return_value=[]))
 
-    jobQueue.generate_e_file(sub.submission_id, 1, 'uniq', 'uniq', is_local=True)
+    fileGenerationHandler.generate_e_file(sub.submission_id, 1, 'uniq', 'uniq', is_local=True)
 
     # [0][0] gives us the first, non-keyword args
-    call_args = jobQueue.fileE.retrieve_rows.call_args[0][0]
+    call_args = fileGenerationHandler.fileE.retrieve_rows.call_args[0][0]
     expected = [ap.awardee_or_recipient_uniqu for ap in aps]
     expected.append(model.awardee_or_recipient_uniqu)
     expected.extend(afa.awardee_or_recipient_uniqu for afa in afas)
@@ -91,17 +91,17 @@ def test_generate_e_file_csv(monkeypatch, mock_broker_config_paths, database):
     sess.add(ap)
     sess.commit()
 
-    monkeypatch.setattr(jobQueue.fileE, 'row_to_dict', Mock())
-    jobQueue.fileE.row_to_dict.return_value = {}
+    monkeypatch.setattr(fileGenerationHandler.fileE, 'row_to_dict', Mock())
+    fileGenerationHandler.fileE.row_to_dict.return_value = {}
 
-    monkeypatch.setattr(jobQueue.fileE, 'retrieve_rows', Mock())
-    jobQueue.fileE.retrieve_rows.return_value = [
+    monkeypatch.setattr(fileGenerationHandler.fileE, 'retrieve_rows', Mock())
+    fileGenerationHandler.fileE.retrieve_rows.return_value = [
         fileE.Row('a', 'b', 'c', '1a', '1b', '2a', '2b', '3a', '3b', '4a', '4b', '5a', '5b'),
         fileE.Row('A', 'B', 'C', '1A', '1B', '2A', '2B', '3A', '3B', '4A', '4B', '5A', '5B')
     ]
 
-    monkeypatch.setattr(jobQueue, 'mark_job_status', Mock())
-    jobQueue.generate_e_file(ap.submission_id, 1, 'uniq', 'uniq', is_local=True)
+    monkeypatch.setattr(fileGenerationHandler, 'mark_job_status', Mock())
+    fileGenerationHandler.generate_e_file(ap.submission_id, 1, 'uniq', 'uniq', is_local=True)
 
     file_path = str(mock_broker_config_paths['broker_files'].join('uniq'))
     expected = [
@@ -130,7 +130,7 @@ def test_job_context_success(database, job_constants):
     sess.add(job)
     sess.commit()
 
-    with jobQueue.job_context(Mock(), job.job_id):
+    with fileGenerationHandler.job_context(job.job_id):
         pass    # i.e. be successful
 
     sess.refresh(job)
@@ -149,33 +149,9 @@ def test_job_context_fail(database, job_constants):
     sess.add(job)
     sess.commit()
 
-    task = Mock()
-    task.retry.return_value = MaxRetriesExceededError()
-    with jobQueue.job_context(task, job.job_id):
+    with fileGenerationHandler.job_context(job.job_id):
         raise Exception('This failed!')
 
     sess.refresh(job)
     assert job.job_status.name == 'failed'
     assert job.error_message == 'This failed!'
-
-
-def test_job_context_retry(database, job_constants):
-    """When a job raises an exception but can still retry, we should expect a
-    particular exception (which signifies to celery that it should retry)"""
-    sess = database.session
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='running').one(),
-        job_type=sess.query(JobType).filter_by(name='validation').one(),
-        file_type=sess.query(FileType).filter_by(name='sub_award').one(),
-    )
-    sess.add(job)
-    sess.commit()
-
-    task = Mock()
-    task.retry.return_value = Retry()
-    with pytest.raises(Retry):
-        with jobQueue.job_context(task, job.job_id):
-            raise Exception('This failed!')
-
-    sess.refresh(job)
-    assert job.job_status.name == 'running'     # still going


### PR DESCRIPTION
Moving job manager functionality for File E and F generation into the broker, which will now use threading to start the generation of the files.

Checklist:
- [x] Documentation updated
- [x] Config updated

Technical Release Notes:
- No longer using Celery & RabbitMQ for asynchronous job execution