### PR TITLE
Bug fixes for zip reading parsing

### DIFF
--- a/dataactcore/scripts/readZips.py
+++ b/dataactcore/scripts/readZips.py
@@ -2,6 +2,7 @@
 # Suggested to run on a weekend during off hours
 
 import os
+import re
 import logging
 import boto
 import urllib.request
@@ -127,7 +128,9 @@ def main():
         base_path = os.path.join(CONFIG_BROKER["path"], "dataactvalidator", "config", CONFIG_BROKER["zip_folder"])
         file_list = [f for f in os.listdir(base_path)]
         for file in file_list:
-            parse_zip4_file(open(os.path.join(base_path, file)), sess)
+            # ignore hidden files on Mac
+            if not re.match('^\.', file):
+                parse_zip4_file(open(os.path.join(base_path, file)), sess)
 
     logger.info("Zipcode script complete")
 

--- a/dataactvalidator/config/detachedAwardFields.csv
+++ b/dataactvalidator/config/detachedAwardFields.csv
@@ -26,7 +26,7 @@ legalentityaddressline2,legal_entity_address_line2,FALSE,str,150,,
 legalentityaddressline3,legal_entity_address_line3,FALSE,str,35,,
 legalentitycountrycode,legal_entity_country_code,TRUE,str,3,"D1, D2, D12",
 legalentityforeigncityname,legal_entity_foreign_city,FALSE,str,40,D9,
-legalentitycongressionaldistrict,legal_entity_congressional,FALSE,str,2,,
+legalentitycongressionaldistrict,legal_entity_congressional,FALSE,str,2,,TRUE
 legalentityforeignpostalcode,legal_entity_foreign_posta,FALSE,str,50,,
 legalentityforeignprovincename,legal_entity_foreign_provi,FALSE,str,25,,
 legalentityzip5,legal_entity_zip5,FALSE,str,5,"D2, D11",TRUE


### PR DESCRIPTION
Fixing a couple bugs:

- reading "all" files locally on a mac for the zip loader script would try to read hidden files as well (that's bad)
- padding congressional district no with leading 0s because it's either 2 letters or 2 numbers and the numbers get truncated sometimes.