### PR TITLE
DB-2034 update d31 to include record_type and business_types check

### DIFF
--- a/dataactvalidator/config/sqlrules/d31_detached_award_financial_assistance_2.sql
+++ b/dataactvalidator/config/sqlrules/d31_detached_award_financial_assistance_2.sql
@@ -1,5 +1,6 @@
--- AwardeeOrRecipientUniqueIdentifier is required for AssistanceType of 02, 03, 04, or 05 whose
--- ActionDate after October 1, 2010.
+-- AwardeeOrRecipientUniqueIdentifier is required for AssistanceType of 02, 03, 04, or 05 whose ActionDate after 
+-- October 1, 2010, unless the record is an aggregate record (RecordType=1) or individual recipient (BusinessTypes 
+-- includes "P").
 
 CREATE OR REPLACE function pg_temp.is_date(str text) returns boolean AS $$
 BEGIN

--- a/dataactvalidator/config/sqlrules/d31_detached_award_financial_assistance_2.sql
+++ b/dataactvalidator/config/sqlrules/d31_detached_award_financial_assistance_2.sql
@@ -14,9 +14,12 @@ SELECT
     row_number,
     assistance_type,
     action_date,
-    awardee_or_recipient_uniqu
+    awardee_or_recipient_uniqu,
+    business_types,
+    record_type
 FROM detached_award_financial_assistance
 WHERE submission_id = {0}
+    AND NOT (record_type = 1 or LOWER(business_types) LIKE '%%p%%')
     AND COALESCE(assistance_type, '') IN ('02', '03', '04', '05')
     AND (CASE
             WHEN pg_temp.is_date(COALESCE(action_date, '0'))

--- a/tests/unit/dataactvalidator/test_d31_detached_award_financial_assistance_2.py
+++ b/tests/unit/dataactvalidator/test_d31_detached_award_financial_assistance_2.py
@@ -13,7 +13,8 @@ def test_column_headers(database):
 
 def test_success(database):
     """ Test success for AwardeeOrRecipientUniqueIdentifier is required for AssistanceType of 02, 03, 04, or 05 whose
-    ActionDate after October 1, 2010. """
+    ActionDate after October 1, 2010, unless the record is an aggregate record (RecordType=1) or individual recipient
+    (BusinessTypes includes 'P') """
     det_award_01 = DetachedAwardFinancialAssistanceFactory(assistance_type="02", record_type=2, business_types="AbC",
                                                            awardee_or_recipient_uniqu='test', action_date="10/02/2010")
     det_award_02 = DetachedAwardFinancialAssistanceFactory(assistance_type="03", record_type=3, business_types="aBc",
@@ -47,7 +48,8 @@ def test_success(database):
 
 def test_failure(database):
     """ Test failure for AwardeeOrRecipientUniqueIdentifier is required for AssistanceType of 02, 03, 04, or 05 whose
-    ActionDate after October 1, 2010. """
+    ActionDate after October 1, 2010, , unless the record is an aggregate record (RecordType=1) or individual recipient
+    (BusinessTypes includes 'P') """
 
     det_award_1 = DetachedAwardFinancialAssistanceFactory(assistance_type="02", record_type=2, business_types="AbC",
                                                           awardee_or_recipient_uniqu=None, action_date="10/02/2010")

--- a/tests/unit/dataactvalidator/test_d31_detached_award_financial_assistance_2.py
+++ b/tests/unit/dataactvalidator/test_d31_detached_award_financial_assistance_2.py
@@ -5,7 +5,8 @@ _FILE = 'd31_detached_award_financial_assistance_2'
 
 
 def test_column_headers(database):
-    expected_subset = {"row_number", "assistance_type", "action_date", "awardee_or_recipient_uniqu"}
+    expected_subset = {"row_number", "assistance_type", "action_date", "awardee_or_recipient_uniqu", "business_types",\
+                       "record_type"}
     actual = set(query_columns(_FILE, database))
     assert expected_subset == actual
 
@@ -13,30 +14,34 @@ def test_column_headers(database):
 def test_success(database):
     """ Test success for AwardeeOrRecipientUniqueIdentifier is required for AssistanceType of 02, 03, 04, or 05 whose
     ActionDate after October 1, 2010. """
-    det_award_01 = DetachedAwardFinancialAssistanceFactory(assistance_type="02", action_date="10/02/2010",
-                                                           awardee_or_recipient_uniqu='test')
-    det_award_02 = DetachedAwardFinancialAssistanceFactory(assistance_type="03", action_date="10/02/2010",
-                                                           awardee_or_recipient_uniqu='test')
-    det_award_03 = DetachedAwardFinancialAssistanceFactory(assistance_type="04", action_date="10/02/2010",
-                                                           awardee_or_recipient_uniqu='test')
-    det_award_04 = DetachedAwardFinancialAssistanceFactory(assistance_type="05", action_date="10/02/2010",
-                                                           awardee_or_recipient_uniqu='test')
-    det_award_05 = DetachedAwardFinancialAssistanceFactory(assistance_type="02", action_date="09/01/2010",
-                                                           awardee_or_recipient_uniqu=None)
-    det_award_06 = DetachedAwardFinancialAssistanceFactory(assistance_type="03", action_date="09/01/2010",
-                                                           awardee_or_recipient_uniqu='')
-    det_award_07 = DetachedAwardFinancialAssistanceFactory(assistance_type="04", action_date="09/01/2010",
-                                                           awardee_or_recipient_uniqu=None)
-    det_award_08 = DetachedAwardFinancialAssistanceFactory(assistance_type="05", action_date="09/01/2010",
-                                                           awardee_or_recipient_uniqu=None)
-    det_award_09 = DetachedAwardFinancialAssistanceFactory(assistance_type="04", action_date="09/01/2010",
-                                                           awardee_or_recipient_uniqu='test')
-    det_award_10 = DetachedAwardFinancialAssistanceFactory(assistance_type="06", action_date="10/02/2010",
-                                                           awardee_or_recipient_uniqu='')
+    det_award_01 = DetachedAwardFinancialAssistanceFactory(assistance_type="02", record_type=2, business_types="AbC",
+                                                           awardee_or_recipient_uniqu='test', action_date="10/02/2010")
+    det_award_02 = DetachedAwardFinancialAssistanceFactory(assistance_type="03", record_type=3, business_types="aBc",
+                                                           awardee_or_recipient_uniqu='test', action_date="10/02/2010")
+    det_award_03 = DetachedAwardFinancialAssistanceFactory(assistance_type="04", record_type=4, business_types="AbC",
+                                                           awardee_or_recipient_uniqu='test', action_date="10/02/2010")
+    det_award_04 = DetachedAwardFinancialAssistanceFactory(assistance_type="05", record_type=3, business_types="aBc",
+                                                           awardee_or_recipient_uniqu='test', action_date="10/02/2010")
+    det_award_05 = DetachedAwardFinancialAssistanceFactory(assistance_type="02", record_type=2, business_types="AbC",
+                                                           awardee_or_recipient_uniqu=None, action_date="09/01/2010")
+    det_award_06 = DetachedAwardFinancialAssistanceFactory(assistance_type="03", record_type=3, business_types="aBc",
+                                                           awardee_or_recipient_uniqu='', action_date="09/01/2010")
+    det_award_07 = DetachedAwardFinancialAssistanceFactory(assistance_type="04", record_type=4, business_types="AbC",
+                                                           awardee_or_recipient_uniqu=None, action_date="09/01/2010")
+    det_award_08 = DetachedAwardFinancialAssistanceFactory(assistance_type="05", record_type=3, business_types="AbC",
+                                                           awardee_or_recipient_uniqu=None, action_date="09/01/2010")
+    det_award_09 = DetachedAwardFinancialAssistanceFactory(assistance_type="04", record_type=2, business_types="AbC",
+                                                           awardee_or_recipient_uniqu='test', action_date="09/01/2010")
+    det_award_10 = DetachedAwardFinancialAssistanceFactory(assistance_type="02", record_type=3, business_types="aBp",
+                                                           awardee_or_recipient_uniqu=None, action_date="10/02/2010")
+    det_award_11 = DetachedAwardFinancialAssistanceFactory(assistance_type="04", record_type=1, business_types="AbC",
+                                                           awardee_or_recipient_uniqu='', action_date="10/02/2010")
+    det_award_12 = DetachedAwardFinancialAssistanceFactory(assistance_type="06", record_type=4, business_types="aBc",
+                                                           awardee_or_recipient_uniqu='', action_date="10/02/2010")
 
     errors = number_of_errors(_FILE, database, models=[det_award_01, det_award_02, det_award_03, det_award_04,
                                                        det_award_05, det_award_06, det_award_07, det_award_08,
-                                                       det_award_09, det_award_10])
+                                                       det_award_09, det_award_10, det_award_11, det_award_12])
     assert errors == 0
 
 
@@ -44,14 +49,14 @@ def test_failure(database):
     """ Test failure for AwardeeOrRecipientUniqueIdentifier is required for AssistanceType of 02, 03, 04, or 05 whose
     ActionDate after October 1, 2010. """
 
-    det_award_1 = DetachedAwardFinancialAssistanceFactory(assistance_type="02", action_date="10/02/2010",
-                                                          awardee_or_recipient_uniqu=None)
-    det_award_2 = DetachedAwardFinancialAssistanceFactory(assistance_type="03", action_date="10/02/2010",
-                                                          awardee_or_recipient_uniqu='')
-    det_award_3 = DetachedAwardFinancialAssistanceFactory(assistance_type="04", action_date="10/02/2010",
-                                                          awardee_or_recipient_uniqu=None)
-    det_award_4 = DetachedAwardFinancialAssistanceFactory(assistance_type="05", action_date="10/02/2010",
-                                                          awardee_or_recipient_uniqu='')
+    det_award_1 = DetachedAwardFinancialAssistanceFactory(assistance_type="02", record_type=2, business_types="AbC",
+                                                          awardee_or_recipient_uniqu=None, action_date="10/02/2010")
+    det_award_2 = DetachedAwardFinancialAssistanceFactory(assistance_type="03", record_type=3, business_types="aBc",
+                                                          awardee_or_recipient_uniqu='', action_date="10/02/2010")
+    det_award_3 = DetachedAwardFinancialAssistanceFactory(assistance_type="04", record_type=4, business_types="AbC",
+                                                          awardee_or_recipient_uniqu=None, action_date="10/02/2010")
+    det_award_4 = DetachedAwardFinancialAssistanceFactory(assistance_type="05", record_type=3, business_types="aBc",
+                                                          awardee_or_recipient_uniqu='', action_date="10/02/2010")
 
     errors = number_of_errors(_FILE, database, models=[det_award_1, det_award_2, det_award_3, det_award_4])
     assert errors == 4

--- a/tests/unit/dataactvalidator/test_d31_detached_award_financial_assistance_2.py
+++ b/tests/unit/dataactvalidator/test_d31_detached_award_financial_assistance_2.py
@@ -5,7 +5,7 @@ _FILE = 'd31_detached_award_financial_assistance_2'
 
 
 def test_column_headers(database):
-    expected_subset = {"row_number", "assistance_type", "action_date", "awardee_or_recipient_uniqu", "business_types",\
+    expected_subset = {"row_number", "assistance_type", "action_date", "awardee_or_recipient_uniqu", "business_types",
                        "record_type"}
     actual = set(query_columns(_FILE, database))
     assert expected_subset == actual


### PR DESCRIPTION
Acceptance Criteria:
- For rule D31, AwardeeOrRecipientUniqueIdentifier must be blank for aggregate records (i.e. RecordType = 1) and individual recipients (i.e., when BusinessTypes includes "P").


Technical Release Notes:
- Update to a SQL rule