### PR TITLE
Db 2047 cfda number format

### DIFF
--- a/dataactvalidator/config/sqlrules/d37_detached_award_financial_assistance_1.sql
+++ b/dataactvalidator/config/sqlrules/d37_detached_award_financial_assistance_1.sql
@@ -26,7 +26,7 @@ WHERE submission_id = {0}
         SELECT DISTINCT sub_dafa.row_number
         FROM detached_award_financial_assistance_d37_1_{0} AS sub_dafa
             JOIN cfda_program AS cfda
-            ON (CAST(sub_dafa.cfda_number as float) IS NOT DISTINCT FROM CAST(cfda.program_number as float)
+            ON (sub_dafa.cfda_number IS NOT DISTINCT FROM to_char(cfda.program_number, 'FM99D999')
             AND (((cfda.published_date <= sub_dafa.action_date) AND (cfda.archived_date = ''))
                 OR (sub_dafa.action_date <= cfda.archived_date) AND (cfda.archived_date != ''))
             )

--- a/dataactvalidator/config/sqlrules/d37_detached_award_financial_assistance_2.sql
+++ b/dataactvalidator/config/sqlrules/d37_detached_award_financial_assistance_2.sql
@@ -26,7 +26,7 @@ WHERE dafa.action_type IN ('B', 'C', 'D')
         SELECT DISTINCT sub_dafa.row_number
         FROM detached_award_financial_assistance_d37_2_{0} AS sub_dafa
             JOIN cfda_program AS cfda
-            ON (CAST(sub_dafa.cfda_number as float) IS NOT DISTINCT FROM CAST(cfda.program_number as float)
+            ON (sub_dafa.cfda_number IS NOT DISTINCT FROM to_char(cfda.program_number, 'FM99D999')
             AND ((sub_dafa.action_date <= cfda.published_date)
                  OR ((sub_dafa.action_date >= cfda.archived_date)
                      AND (cfda.archived_date != ''))


### PR DESCRIPTION
Stopping the validations from imploding when cfda_number is letters. The format check was correct before it just never got through validations if it wasn't all numbers.
Comparing using the existing string (it should be more accurate this way anyway)

Technical Release Notes:
- Updated sql rule