### PR TITLE
Db 2068 updating wrong type error text

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -375,7 +375,7 @@ status objects for each job under the key "jobs", and other submission-level dat
     * error_data: Holds a list of errors, each error is a dict with keys:
         - field_name: What field the error occurred on
         - error_name: Type of error that occurred, values are:
-            * type_error: Value was of the wrong type
+            * type_error: Value was of the wrong type. Note that all type errors in a line must be fixed before the rest of the validation logic is applied to that line.
             * required_error: A required value was missing
             * read_error: Could not parse this value from the file
             * write_error: This was a problem writing the value to the staging table
@@ -443,7 +443,7 @@ Example output:
         {
           "field_name": "allocationtransferagencyid",
           "error_name": "type_error",
-          "error_description": "The value provided was of the wrong type",
+          "error_description": "The value provided was of the wrong type. Note that all type errors in a line must be fixed before the rest of the validation logic is applied to that line.",
           "occurrences": 27,
           "rule_failed": "",
           "original_label":""

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -26,7 +26,8 @@ FILE_STATUS_DICT = {item.name: item.id for item in FILE_STATUS}
 FILE_STATUS_DICT_ID = {item.id: item.name for item in FILE_STATUS}
 
 ERROR_TYPE = [
-    LookupType(1, 'type_error', 'The value provided was of the wrong type'),
+    LookupType(1, 'type_error', 'The value provided was of the wrong type. Note that all type errors in a line'
+                                ' must be fixed before the rest of the validation logic is applied to that line.'),
     LookupType(2, 'required_error', 'A required value was not provided'),
     LookupType(3, 'value_error', 'The value provided was invalid'),
     LookupType(4, 'read_error', 'Could not parse this record correctly'),

--- a/dataactvalidator/validation_handlers/validationError.py
+++ b/dataactvalidator/validation_handlers/validationError.py
@@ -1,7 +1,8 @@
 class ValidationError:
     """ This class holds errors that can occur during validation, for use in the error report and database """
 
-    typeErrorMsg = "The value provided was of the wrong type"
+    typeErrorMsg = "The value provided was of the wrong type. Note that all type errors in a line" \
+                   " must be fixed before the rest of the validation logic is applied to that line."
     typeError = 0
     requiredErrorMsg = "A required value was not provided"
     requiredError = 1


### PR DESCRIPTION
Changing text in "type_error" so it's more clear that other validations didn't run.

Technical Release Notes:
- Updating error text, will have to reinitialize your DB