### PR TITLE
Allow all users to upload fabs

### DIFF
--- a/dataactbroker/domainRoutes.py
+++ b/dataactbroker/domainRoutes.py
@@ -45,10 +45,11 @@ def add_domain_routes(app):
         """
         sess = GlobalDB.db().session
 
-        cgac_ids = [cgac.cgac_id for cgac in cgacs]
+        # cgac_ids = [cgac.cgac_id for cgac in cgacs]
         sub_tier_agencies = []
-        for cgac_id in cgac_ids:
-            sub_tier_agencies.extend(sess.query(SubTierAgency).filter_by(cgac_id=cgac_id))
+        sub_tier_agencies.extend(sess.query(SubTierAgency))
+        # for cgac_id in cgac_ids:
+        #     sub_tier_agencies.extend(sess.query(SubTierAgency).filter_by(cgac_id=cgac_id))
 
         sub_tier_agency_list = [
             {'agency_name': '{}: {}'.format(sub_tier_agency.cgac.agency_name, sub_tier_agency.sub_tier_agency_name),

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -748,9 +748,10 @@ class FileHandler:
                         job_data.get('reporting_start_date'), job_data.get('reporting_end_date')),
                         StatusCode.CLIENT_ERROR)
 
-            if not current_user_can('writer', job_data["cgac_code"]):
-                raise ResponseException("User does not have permission to create jobs for this agency",
-                                        StatusCode.PERMISSION_DENIED)
+            ### Commented out to temporarily allow all users to upload FABS data for all agencies during testing
+            # if not current_user_can('writer', job_data["cgac_code"]):
+            #     raise ResponseException("User does not have permission to create jobs for this agency",
+            #                             StatusCode.PERMISSION_DENIED)
 
             submission = create_submission(g.user.user_id, job_data, existing_submission_obj)
             sess.add(submission)

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -748,7 +748,10 @@ class FileHandler:
                         job_data.get('reporting_start_date'), job_data.get('reporting_end_date')),
                         StatusCode.CLIENT_ERROR)
 
-            ### Commented out to temporarily allow all users to upload FABS data for all agencies during testing
+            '''
+            Below lines commented out to temporarily allow all users
+            to upload FABS data for all agencies during testing
+            '''
             # if not current_user_can('writer', job_data["cgac_code"]):
             #     raise ResponseException("User does not have permission to create jobs for this agency",
             #                             StatusCode.PERMISSION_DENIED)


### PR DESCRIPTION
Temporarily allowing all users to see all agencies in the FABS upload page.

This will need to be changed back at a later date but is needed for testing.