### PR TITLE
Db 2054 d43 only applies domestically

### DIFF
--- a/dataactvalidator/config/sqlrules/d43_detached_award_financial_assistance_1.sql
+++ b/dataactvalidator/config/sqlrules/d43_detached_award_financial_assistance_1.sql
@@ -1,9 +1,8 @@
 --  If PrimaryPlaceOfPerformanceCountryCode is not USA, Congressional District must be blank
-
 SELECT
     row_number,
-    place_of_performance_code,
-    place_of_perform_country_c
+    place_of_perform_country_c,
+    place_of_performance_congr
 FROM detached_award_financial_assistance
 WHERE submission_id = {0}
     AND UPPER(place_of_perform_country_c) != 'USA'

--- a/dataactvalidator/config/sqlrules/d43_detached_award_financial_assistance_2.sql
+++ b/dataactvalidator/config/sqlrules/d43_detached_award_financial_assistance_2.sql
@@ -1,8 +1,12 @@
+-- If no PrimaryPlaceOfPerformanceZIP+4 is provided, a PrimaryPlaceOfPerformanceCongressionalDistrict must be provided.
+-- Only applies to domestic PPoP (PPoPCountry Code = USA)
 SELECT
     row_number,
     place_of_performance_congr,
-    place_of_performance_zip4a
+    place_of_performance_zip4a,
+    place_of_perform_country_c
 FROM detached_award_financial_assistance
 WHERE submission_id = {0}
     AND COALESCE(place_of_performance_zip4a, '') = ''
     AND COALESCE(place_of_performance_congr, '') = ''
+    AND UPPER(place_of_perform_country_c) = 'USA'

--- a/tests/unit/dataactvalidator/test_d43_detached_award_financial_assistance_1.py
+++ b/tests/unit/dataactvalidator/test_d43_detached_award_financial_assistance_1.py
@@ -26,8 +26,7 @@ def test_success(database):
 
 
 def test_failure(database):
-    """ Test failure for PrimaryPlaceOfPerformanceCode for aggregate records (i.e., when RecordType = 1)
-        must be in countywide format (XX**###). """
+    """ Test failure for if PrimaryPlaceOfPerformanceCode is not USA, Congressional District must be blank """
 
     det_award_1 = DetachedAwardFinancialAssistanceFactory(place_of_perform_country_c="Nk",
                                                           place_of_performance_congr="12")

--- a/tests/unit/dataactvalidator/test_d43_detached_award_financial_assistance_1.py
+++ b/tests/unit/dataactvalidator/test_d43_detached_award_financial_assistance_1.py
@@ -5,7 +5,7 @@ _FILE = 'd43_detached_award_financial_assistance_1'
 
 
 def test_column_headers(database):
-    expected_subset = {"row_number", "place_of_performance_code", "place_of_perform_country_c"}
+    expected_subset = {"row_number", "place_of_perform_country_c", "place_of_performance_congr"}
     actual = set(query_columns(_FILE, database))
     assert expected_subset == actual
 

--- a/tests/unit/dataactvalidator/test_d43_detached_award_financial_assistance_2.py
+++ b/tests/unit/dataactvalidator/test_d43_detached_award_financial_assistance_2.py
@@ -5,7 +5,8 @@ _FILE = 'd43_detached_award_financial_assistance_2'
 
 
 def test_column_headers(database):
-    expected_subset = {"row_number", "place_of_performance_zip4a", "place_of_performance_congr"}
+    expected_subset = {"row_number", "place_of_performance_zip4a", "place_of_performance_congr",
+                       "place_of_perform_country_c"}
     actual = set(query_columns(_FILE, database))
     print(actual)
     assert expected_subset == actual
@@ -16,17 +17,26 @@ def test_success(database):
         be provided. """
 
     det_award_1 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a="",
-                                                          place_of_performance_congr="01")
+                                                          place_of_performance_congr="01",
+                                                          place_of_perform_country_c="USA")
     det_award_2 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a=None,
-                                                          place_of_performance_congr="01")
+                                                          place_of_performance_congr="01",
+                                                          place_of_perform_country_c="USA")
     det_award_3 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a="12345",
-                                                          place_of_performance_congr="")
+                                                          place_of_performance_congr="",
+                                                          place_of_perform_country_c="usa")
     det_award_4 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a="12345",
-                                                          place_of_performance_congr=None)
+                                                          place_of_performance_congr=None,
+                                                          place_of_perform_country_c="USA")
     det_award_5 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a="12345",
-                                                          place_of_performance_congr="02")
+                                                          place_of_performance_congr="02",
+                                                          place_of_perform_country_c="USA")
+    det_award_6 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a="",
+                                                          place_of_performance_congr="",
+                                                          place_of_perform_country_c="uK")
 
-    errors = number_of_errors(_FILE, database, models=[det_award_1, det_award_2, det_award_3, det_award_4, det_award_5])
+    errors = number_of_errors(_FILE, database, models=[det_award_1, det_award_2, det_award_3, det_award_4, det_award_5,
+                                                       det_award_6])
     assert errors == 0
 
 
@@ -35,12 +45,16 @@ def test_failure(database):
         PrimaryPlaceOfPerformanceCongressionalDistrict must be provided. """
 
     det_award_1 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a="",
-                                                          place_of_performance_congr="")
+                                                          place_of_performance_congr="",
+                                                          place_of_perform_country_c="USA")
     det_award_2 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a=None,
-                                                          place_of_performance_congr="")
+                                                          place_of_performance_congr="",
+                                                          place_of_perform_country_c="UsA")
     det_award_3 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a="",
-                                                          place_of_performance_congr=None)
+                                                          place_of_performance_congr=None,
+                                                          place_of_perform_country_c="USA")
     det_award_4 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a=None,
-                                                          place_of_performance_congr=None)
+                                                          place_of_performance_congr=None,
+                                                          place_of_perform_country_c="USA")
     errors = number_of_errors(_FILE, database, models=[det_award_1, det_award_2, det_award_3, det_award_4])
     assert errors == 4

--- a/tests/unit/dataactvalidator/test_d43_detached_award_financial_assistance_2.py
+++ b/tests/unit/dataactvalidator/test_d43_detached_award_financial_assistance_2.py
@@ -14,7 +14,7 @@ def test_column_headers(database):
 
 def test_success(database):
     """ If no PrimaryPlaceOfPerformanceZIP+4 is provided, a PrimaryPlaceOfPerformanceCongressionalDistrict must
-        be provided. """
+        be provided. Only applies to domestic records. """
 
     det_award_1 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a="",
                                                           place_of_performance_congr="01",
@@ -42,7 +42,7 @@ def test_success(database):
 
 def test_failure(database):
     """ Test failure for if no PrimaryPlaceOfPerformanceZIP+4 is provided, a
-        PrimaryPlaceOfPerformanceCongressionalDistrict must be provided. """
+        PrimaryPlaceOfPerformanceCongressionalDistrict must be provided. Only applies to domestic records. """
 
     det_award_1 = DetachedAwardFinancialAssistanceFactory(place_of_performance_zip4a="",
                                                           place_of_performance_congr="",


### PR DESCRIPTION
+ Fixing what columns are printed for one part of the rule
+ Making zip+4 or CD required only when country code is USA