### PR TITLE
Db 2073 zip code loader edge cases

### DIFF
--- a/dataactvalidator/scripts/readZips.py
+++ b/dataactvalidator/scripts/readZips.py
@@ -71,7 +71,7 @@ def parse_zip4_file(f, sess):
             # ignore state codes AA, AE, and AP because they're just for military routing
             if state not in ['AA', 'AE', 'AP']:
                 zip5 = curr_row[1:6]
-
+                # zip of 96898 is a special case
                 if zip5 == "96898":
                     congressional_district = "99"
                     state = "UM"
@@ -79,6 +79,14 @@ def parse_zip4_file(f, sess):
                 else:
                     county = curr_row[159:162]
                     congressional_district = curr_row[162:164]
+
+                # certain states require specific CDs
+                if state in ["AK", "DE", "MT", "ND", "SD", "VT", "WY"]:
+                    congressional_district = "00"
+                elif state in ["AS", "DC", "GU", "MP", "PR", "VI"]:
+                    congressional_district = "98"
+                elif state in ["FM", "MH", "PW", "UM"]:
+                    congressional_district = "99"
 
                 try:
                     zip4_low = int(curr_row[140:144])
@@ -151,6 +159,7 @@ def parse_citystate_file(f, sess):
                 # ignore state codes AA, AE, and AP because they're just for military routing
                 if state not in ['AA', 'AE', 'AP']:
                     zip5 = curr_row[1:6]
+                    # zip of 96898 is a special case
                     if zip5 == "96898":
                         congressional_district = "99"
                         state = "UM"
@@ -158,6 +167,15 @@ def parse_citystate_file(f, sess):
                     else:
                         congressional_district = None
                         county = curr_row[101:104]
+
+                    # certain states require specific CDs
+                    if state in ["AK", "DE", "MT", "ND", "SD", "VT", "WY"]:
+                        congressional_district = "00"
+                    elif state in ["AS", "DC", "GU", "MP", "PR", "VI"]:
+                        congressional_district = "98"
+                    elif state in ["FM", "MH", "PW", "UM"]:
+                        congressional_district = "99"
+
                     data_array[zip5] = {"zip5": zip5, "zip_last4": None, "state_abbreviation": state,
                                         "county_number": county, "congressional_district_no": congressional_district}
 


### PR DESCRIPTION
Hardcoding a couple of cases for the zip loader. Also slid in a little speedup, approximately 1/6 faster than before.

- [x] Below SQL has been run on all DBs that have zip data loaded
- [x] Reviewed by backend
```
DELETE FROM zips
WHERE state_abbreviation IN ('AA', 'AE', 'AP');

UPDATE zips
SET state_abbreviation = 'UM', congressional_district_no = '99', county_number = '450'
WHERE zip5 = '96898';

UPDATE zips
SET congressional_district_no = '00'
WHERE state_abbreviation IN ('AK', 'DE', 'MT', 'ND', 'SD', 'VT', 'WY');

UPDATE zips
SET congressional_district_no = '98'
WHERE state_abbreviation IN ('AS', 'DC', 'GU', 'MP', 'PR', 'VI');

UPDATE zips
SET congressional_district_no = '99'
WHERE state_abbreviation IN ('FM', 'MH', 'PW', 'UM');
```

Technical release notes:
- Updated zip loader, might want to rerun initialize (at least with a -z flag)