### PR TITLE
DB-2100 fix FABS dashboard statuses

### DIFF
--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -366,6 +366,10 @@ class ValidationManager:
             # Update error info for submission
             populate_job_error_info(job)
 
+            if file_type in ["detached_award"]:
+                # set number of errors and warnings for submission.
+                submission = populate_submission_error_info(submission_id)
+
             # Mark validation as finished in job tracker
             mark_job_status(job_id, "finished")
             mark_file_complete(job_id, file_name)

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -367,8 +367,8 @@ class ValidationManager:
             populate_job_error_info(job)
 
             if file_type in ["detached_award"]:
-                # set number of errors and warnings for submission.
-                submission = populate_submission_error_info(submission_id)
+                # set number of errors and warnings for detached submission
+                populate_submission_error_info(submission_id)
 
             # Mark validation as finished in job tracker
             mark_job_status(job_id, "finished")

--- a/dataactvalidator/validation_handlers/validator.py
+++ b/dataactvalidator/validation_handlers/validator.py
@@ -95,9 +95,7 @@ class Validator(object):
                len(current_data.strip()) > current_schema.length:
                 # Length failure, add to failedRules
                 record_failed = True
-                warning_type = "warning"
-                if fabs_record:
-                    warning_type = "fatal"
+                warning_type = "warning" if fabs_record else "fatal"
                 failed_rules.append(Failure(field_name, ValidationError.lengthError, current_data, "", warning_type))
 
         # if all columns are blank (empty row), set it so it doesn't add to the error messages or write the line,

--- a/dataactvalidator/validation_handlers/validator.py
+++ b/dataactvalidator/validation_handlers/validator.py
@@ -95,7 +95,7 @@ class Validator(object):
                len(current_data.strip()) > current_schema.length:
                 # Length failure, add to failedRules
                 record_failed = True
-                warning_type = "warning" if fabs_record else "fatal"
+                warning_type = "fatal" if fabs_record else "warning"
                 failed_rules.append(Failure(field_name, ValidationError.lengthError, current_data, "", warning_type))
 
         # if all columns are blank (empty row), set it so it doesn't add to the error messages or write the line,


### PR DESCRIPTION
AC:
- Files correctly show "has errors" in red when they have critical errors.