### PR TITLE
Mapping Awarding Agency Code to FRECs if is_frec

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1718,16 +1718,17 @@ def fabs_derivations(obj, sess):
 
     if obj['awarding_sub_tier_agency_c']:
         # deriving awarding agency name and code
-        awarding_agency = sess.query(CGAC).\
-            filter(CGAC.cgac_id == SubTierAgency.cgac_id,
-                   SubTierAgency.sub_tier_agency_code == obj['awarding_sub_tier_agency_c']).one()
-        obj['awarding_agency_code'] = awarding_agency.cgac_code
-        obj['awarding_agency_name'] = awarding_agency.agency_name
-
-        # deriving awarding sub tier agency name
-        awarding_sub_tier_agency_name = sess.query(SubTierAgency).\
+        awarding_sub_tier = sess.query(SubTierAgency).\
             filter_by(sub_tier_agency_code=obj['awarding_sub_tier_agency_c']).one()
-        obj['awarding_sub_tier_agency_n'] = awarding_sub_tier_agency_name.sub_tier_agency_name
+        use_frec = awarding_sub_tier.is_frec
+        awarding_agency = awarding_sub_tier.frec if use_frec else awarding_sub_tier.cgac
+        obj['awarding_agency_code'] = awarding_agency.frec_code if use_frec else awarding_agency.cgac_code
+        obj['awarding_agency_name'] = awarding_agency.agency_name
+        obj['awarding_sub_tier_agency_n'] = awarding_sub_tier.sub_tier_agency_name
+    else:
+        obj['awarding_agency_code'] = None
+        obj['awarding_agency_name'] = None
+        obj['awarding_sub_tier_agency_n'] = None
 
     # deriving funding agency name
     if obj['funding_agency_code']:

--- a/dataactcore/scripts/pullFPDSData.py
+++ b/dataactcore/scripts/pullFPDSData.py
@@ -741,8 +741,10 @@ def calculate_remaining_fields(obj, sub_tier_list):
     """ calculate values that aren't in any feed but can be calculated """
     if obj['awarding_sub_tier_agency_c']:
         try:
-            agency_data = sub_tier_list[obj['awarding_sub_tier_agency_c']].cgac
-            obj['awarding_agency_code'] = agency_data.cgac_code
+            sub_tier_agency = sub_tier_list[obj['awarding_sub_tier_agency_c']]
+            use_frec = sub_tier_agency.is_frec
+            agency_data = sub_tier_agency.frec if use_frec else sub_tier_agency.cgac
+            obj['awarding_agency_code'] = agency_data.frec_code if use_frec else agency_data.cgac_code
             obj['awarding_agency_name'] = agency_data.agency_name
         except KeyError:
             logger.info('WARNING: MissingSubtierCGAC: The awarding sub-tier cgac_code: %s does not exist in cgac table.'
@@ -754,8 +756,10 @@ def calculate_remaining_fields(obj, sub_tier_list):
 
     if obj['funding_sub_tier_agency_co']:
         try:
-            agency_data = sub_tier_list[obj['funding_sub_tier_agency_co']].cgac
-            obj['funding_agency_code'] = agency_data.cgac_code
+            sub_tier_agency = sub_tier_list[obj['funding_sub_tier_agency_co']]
+            use_frec = sub_tier_agency.is_frec
+            agency_data = sub_tier_agency.frec if use_frec else sub_tier_agency.cgac
+            obj['funding_agency_code'] = agency_data.frec_code if use_frec else agency_data.cgac_code
             obj['funding_agency_name'] = agency_data.agency_name
         except KeyError:
             logger.info('WARNING: MissingSubtierCGAC: The funding sub-tier cgac_code: %s does not exist in cgac table. '

--- a/dataactcore/scripts/pullFPDSData.py
+++ b/dataactcore/scripts/pullFPDSData.py
@@ -1834,7 +1834,10 @@ def map_description_manual(row, header, mappings):
 def map_agency_code(row, header, sub_tier_list):
     try:
         code = str(row[header])
-        return sub_tier_list[code].cgac.cgac_code
+        sub_tier_agency = sub_tier_list[code]
+        use_frec = sub_tier_agency.is_frec
+        agency_data = sub_tier_agency.frec if use_frec else sub_tier_agency.cgac
+        return agency_data.frec_code if use_frec else agency_data.cgac_code
     except KeyError:
         return '999'
 
@@ -1842,7 +1845,10 @@ def map_agency_code(row, header, sub_tier_list):
 def map_agency_name(row, header, sub_tier_list):
     try:
         code = str(row[header])
-        return sub_tier_list[code].cgac.agency_name
+        sub_tier_agency = sub_tier_list[code]
+        use_frec = sub_tier_agency.is_frec
+        agency_data = sub_tier_agency.frec if use_frec else sub_tier_agency.cgac
+        return agency_data.agency_name
     except KeyError:
         return None
 


### PR DESCRIPTION
- [x] [DB-2178](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/849) is reviewed and merged
- [x] Code reviewed

Acceptance Criteria:
- `AwardProcurement` and `AwardFinancialAssistance` data's `awarding_agency_code` and `funding_agency_code` columns provide FREC codes when the sub_tier_agency_code is FREC based

Technical Specifications:
- Updating FABS derivations and FPDS script