### PR TITLE
Db 2136 fsrs generation

### DIFF
--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -93,7 +93,8 @@ def new_client(service_type):
     if config.get('username') and config.get('password'):
         options['transport'] = HttpAuthenticated(
             username=config['username'],
-            password=config['password'])
+            password=config['password'],
+            timeout=300)
 
     return Client(**options)
 

--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -198,8 +198,8 @@ def fetch_and_replace_batch(sess, service_type, min_id=None):
         min_id = model.next_id(sess)
 
     awards = list(retrieve_batch(service_type, min_id))
-    ids = [a.id for a in awards]
-    sess.query(model).filter(model.id.in_(ids)).delete(
+    ids = [a.internal_id for a in awards]
+    sess.query(model).filter(model.internal_id.in_(ids)).delete(
         synchronize_session=False)
     sess.add_all(awards)
     sess.commit()

--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -9,8 +9,7 @@ from suds.transport.https import HttpAuthenticated
 from suds.xsd import doctor
 
 from dataactcore.config import CONFIG_BROKER
-from dataactcore.models.fsrs import (
-    FSRSProcurement, FSRSSubcontract, FSRSGrant, FSRSSubgrant)
+from dataactcore.models.fsrs import FSRSProcurement, FSRSSubcontract, FSRSGrant, FSRSSubgrant
 
 
 logger = logging.getLogger(__name__)
@@ -85,8 +84,8 @@ def new_client(service_type):
     # The WSDL is missing an import; it's so common that suds has a work around
     parsed_wsdl = urlparse(wsdl_url)
     import_fix = doctor.Import('http://schemas.xmlsoap.org/soap/encoding/')
-    import_fix.filter.add(   # Main namespace is the wsdl domain
-        '{}://{}/'.format(parsed_wsdl.scheme, parsed_wsdl.netloc))
+    # Main namespace is the wsdl domain
+    import_fix.filter.add('{}://{}/'.format(parsed_wsdl.scheme, parsed_wsdl.netloc))
 
     options['doctor'] = doctor.ImportDoctor(import_fix)
     options['plugins'] = [ControlFilter(), ZeroDateFilter()]
@@ -109,28 +108,19 @@ def soap_to_dict(soap_obj):
 
 
 # Fields lists to copy
-_common = ('duns', 'dba_name', 'parent_duns', 'funding_agency_id',
-           'funding_agency_name')
-_contract = ('company_name', 'parent_company_name', 'naics',
-             'funding_office_id', 'funding_office_name', 'recovery_model_q1',
-             'recovery_model_q2')
-_grant = ('dunsplus4', 'awardee_name', 'project_description',
-          'compensation_q1', 'compensation_q2')
-_prime = ('internal_id', 'date_submitted', 'report_period_mon',
-          'report_period_year')
+_common = ('duns', 'dba_name', 'parent_duns', 'funding_agency_id', 'funding_agency_name')
+_contract = ('company_name', 'parent_company_name', 'naics', 'funding_office_id', 'funding_office_name',
+             'recovery_model_q1', 'recovery_model_q2')
+_grant = ('dunsplus4', 'awardee_name', 'project_description', 'compensation_q1', 'compensation_q2')
+_prime = ('internal_id', 'date_submitted', 'report_period_mon', 'report_period_year')
 _primeContract = _common + _contract + _prime + (
-    'id', 'contract_number', 'idv_reference_number', 'report_type',
-    'contract_agency_code', 'contract_idv_agency_code',
-    'contracting_office_aid', 'contracting_office_aname',
-    'contracting_office_id', 'contracting_office_name', 'treasury_symbol',
-    'dollar_obligated', 'date_signed', 'transaction_type', 'program_title')
+    'id', 'contract_number', 'idv_reference_number', 'report_type', 'contract_agency_code', 'contract_idv_agency_code',
+    'contracting_office_aid', 'contracting_office_aname', 'contracting_office_id', 'contracting_office_name',
+    'treasury_symbol', 'dollar_obligated', 'date_signed', 'transaction_type', 'program_title')
 _subContract = _common + _contract + (
-    'subcontract_amount', 'subcontract_date', 'subcontract_num',
-    'overall_description', 'recovery_subcontract_amt')
-_primeGrant = _common + _grant + _prime + (
-    'id', 'fain', 'total_fed_funding_amount', 'obligation_date')
-_subGrant = _common + _grant + (
-    'subaward_amount', 'subaward_date', 'subaward_num')
+    'subcontract_amount', 'subcontract_date', 'subcontract_num', 'overall_description', 'recovery_subcontract_amt')
+_primeGrant = _common + _grant + _prime + ('id', 'fain', 'total_fed_funding_amount', 'obligation_date')
+_subGrant = _common + _grant + ('subaward_amount', 'subaward_date', 'subaward_num')
 # Address fields
 _contractAddrs = ('principle_place', 'company_address')
 _grantAddrs = ('principle_place', 'awardee_address')
@@ -199,8 +189,7 @@ def fetch_and_replace_batch(sess, service_type, min_id=None):
 
     awards = list(retrieve_batch(service_type, min_id))
     ids = [a.internal_id for a in awards]
-    sess.query(model).filter(model.internal_id.in_(ids)).delete(
-        synchronize_session=False)
+    sess.query(model).filter(model.internal_id.in_(ids)).delete(synchronize_session=False)
     sess.add_all(awards)
     sess.commit()
 

--- a/dataactbroker/scripts/loadFSRS.py
+++ b/dataactbroker/scripts/loadFSRS.py
@@ -22,5 +22,4 @@ if __name__ == '__main__':
             grants = fetch_and_replace_batch(sess, GRANT)
             awards = procs + grants
             numSubAwards = sum(len(a.subawards) for a in awards)
-            logger.info("Inserted/Updated %s awards, %s subawards",
-                        len(awards), numSubAwards)
+            logger.info("Inserted/Updated %s awards, %s subawards", len(awards), numSubAwards)

--- a/dataactbroker/scripts/loadFSRS.py
+++ b/dataactbroker/scripts/loadFSRS.py
@@ -18,8 +18,10 @@ if __name__ == '__main__':
             logger.error("No config for broker/fsrs/[service]/wsdl")
             sys.exit(1)
         else:
-            procs = fetch_and_replace_batch(sess, PROCUREMENT)
-            grants = fetch_and_replace_batch(sess, GRANT)
-            awards = procs + grants
-            numSubAwards = sum(len(a.subawards) for a in awards)
-            logger.info("Inserted/Updated %s awards, %s subawards", len(awards), numSubAwards)
+            awards = ['Starting']
+            while len(awards) > 0:
+                procs = fetch_and_replace_batch(sess, PROCUREMENT)
+                grants = fetch_and_replace_batch(sess, GRANT)
+                awards = procs + grants
+                numSubAwards = sum(len(a.subawards) for a in awards)
+                logger.info("Inserted/Updated %s awards, %s subawards", len(awards), numSubAwards)

--- a/dataactcore/utils/fileF.py
+++ b/dataactcore/utils/fileF.py
@@ -152,7 +152,7 @@ def submission_procurements(submission_id):
 
     results = sess.query(AwardProcurement, FSRSProcurement, FSRSSubcontract).\
         filter(AwardProcurement.submission_id == submission_id).\
-        filter(FSRSProcurement.contract_number.isnot_distinct_from(AwardProcurement.piid)).\
+        filter(FSRSProcurement.contract_number == AwardProcurement.piid).\
         filter(FSRSProcurement.idv_reference_number.isnot_distinct_from(AwardProcurement.parent_award_id)).\
         filter(FSRSSubcontract.parent_id == FSRSProcurement.id)
     for award, proc, sub in results:
@@ -163,10 +163,11 @@ def submission_procurements(submission_id):
 
 def submission_grants(submission_id):
     """Fetch grants and subgrants"""
+    sess = GlobalDB.db().session
+
     logger.debug('Starting submission grants')
 
-    triplets = GlobalDB.db().session.\
-        query(AwardFinancialAssistance, FSRSGrant, FSRSSubgrant).\
+    triplets = sess.query(AwardFinancialAssistance, FSRSGrant, FSRSSubgrant).\
         filter(AwardFinancialAssistance.submission_id == submission_id).\
         filter(FSRSGrant.fain == AwardFinancialAssistance.fain).\
         filter(FSRSSubgrant.parent_id == FSRSGrant.id)

--- a/dataactcore/utils/fileF.py
+++ b/dataactcore/utils/fileF.py
@@ -32,8 +32,7 @@ class CopyValues:
     # Order to check fields
     MODEL_TYPES = ('subcontract', 'subgrant', 'procurement', 'grant', 'award')
 
-    def __init__(self, subcontract=None, subgrant=None, procurement=None,
-                 grant=None, award=None):
+    def __init__(self, subcontract=None, subgrant=None, procurement=None, grant=None, award=None):
         self.procurement_field = procurement
         self.subcontract_field = subcontract
         self.grant_field = grant
@@ -82,33 +81,23 @@ ModelRow.__new__.__defaults__ = (None, None, None, None, None)
 # be placed in a CSV cell), keyed by the CSV column name for that cell. Order
 # matters as it defines the CSV column order
 mappings = OrderedDict([
-    ('SubAwardeeOrRecipientLegalEntityName',
-        CopyValues('company_name', 'awardee_name')),
+    ('SubAwardeeOrRecipientLegalEntityName', CopyValues('company_name', 'awardee_name')),
     ('SubAwardeeOrRecipientUniqueIdentifier', copy_subaward_field('duns')),
-    ('SubAwardeeUltimateParentUniqueIdentifier',
-        copy_subaward_field('parent_duns')),
-    ('SubAwardeeUltimateParentLegalEntityName',
-        CopyValues(subcontract='parent_company_name')),
-    ('LegalEntityAddressLine1',
-        CopyValues('company_address_street', 'awardee_address_street')),
-    ('LegalEntityCityName',
-        CopyValues('company_address_city', 'awardee_address_city')),
-    ('LegalEntityStateCode',
-        CopyValues('company_address_state', 'awardee_address_state')),
+    ('SubAwardeeUltimateParentUniqueIdentifier', copy_subaward_field('parent_duns')),
+    ('SubAwardeeUltimateParentLegalEntityName', CopyValues(subcontract='parent_company_name')),
+    ('LegalEntityAddressLine1', CopyValues('company_address_street', 'awardee_address_street')),
+    ('LegalEntityCityName', CopyValues('company_address_city', 'awardee_address_city')),
+    ('LegalEntityStateCode', CopyValues('company_address_state', 'awardee_address_state')),
     ('LegalEntityZIP+4', SubawardLogic(
-        lambda subcontract:
-            _zipcode_guard(subcontract, 'company_address', True),
+        lambda subcontract: _zipcode_guard(subcontract, 'company_address', True),
         lambda subgrant: _zipcode_guard(subgrant, 'awardee_address', True)
     )),
     ('LegalEntityForeignPostalCode', SubawardLogic(
-        lambda subcontract:
-            _zipcode_guard(subcontract, 'company_address', False),
+        lambda subcontract: _zipcode_guard(subcontract, 'company_address', False),
         lambda subgrant: _zipcode_guard(subgrant, 'awardee_address', False)
     )),
-    ('LegalEntityCongressionalDistrict',
-        CopyValues('company_address_district', 'awardee_address_district')),
-    ('LegalEntityCountryCode',
-        CopyValues('company_address_country', 'awardee_address_country')),
+    ('LegalEntityCongressionalDistrict', CopyValues('company_address_district', 'awardee_address_district')),
+    ('LegalEntityCountryCode', CopyValues('company_address_country', 'awardee_address_country')),
     ('LegalEntityCountryName', SubawardLogic(
         lambda subcontract: _country_name(subcontract.company_address_country),
         lambda subgrant: _country_name(subgrant.awardee_address_country)
@@ -130,29 +119,20 @@ mappings = OrderedDict([
     ('CFDA_NumberAndTitle', CopyValues(subgrant='cfda_numbers')),
     ('AwardingSubTierAgencyName', copy_subaward_field('funding_agency_name')),
     ('AwardingSubTierAgencyCode', copy_subaward_field('funding_agency_id')),
-    ('AwardDescription',
-        CopyValues('overall_description', 'project_description')),
-    ('ActionDate',
-        CopyValues(subcontract='subcontract_date', grant='obligation_date')),
-    ('PrimaryPlaceOfPerformanceCityName',
-        copy_subaward_field('principle_place_city')),
-    ('PrimaryPlaceOfPerformanceAddressLine1',
-        copy_subaward_field('principle_place_street')),
-    ('PrimaryPlaceOfPerformanceStateCode',
-        copy_subaward_field('principle_place_state')),
-    ('PrimaryPlaceOfPerformanceZIP+4',
-        copy_subaward_field('principle_place_zip')),
-    ('PrimaryPlaceOfPerformanceCongressionalDistrict',
-        copy_subaward_field('principle_place_district')),
-    ('PrimaryPlaceOfPerformanceCountryCode',
-        copy_subaward_field('principle_place_country')),
+    ('AwardDescription', CopyValues('overall_description', 'project_description')),
+    ('ActionDate', CopyValues(subcontract='subcontract_date', grant='obligation_date')),
+    ('PrimaryPlaceOfPerformanceCityName', copy_subaward_field('principle_place_city')),
+    ('PrimaryPlaceOfPerformanceAddressLine1', copy_subaward_field('principle_place_street')),
+    ('PrimaryPlaceOfPerformanceStateCode', copy_subaward_field('principle_place_state')),
+    ('PrimaryPlaceOfPerformanceZIP+4', copy_subaward_field('principle_place_zip')),
+    ('PrimaryPlaceOfPerformanceCongressionalDistrict', copy_subaward_field('principle_place_district')),
+    ('PrimaryPlaceOfPerformanceCountryCode', copy_subaward_field('principle_place_country')),
     ('PrimaryPlaceOfPerformanceCountryName', SubawardLogic(
         lambda subcontract: _country_name(subcontract.principle_place_country),
         lambda subgrant: _country_name(subgrant.principle_place_country)
     )),
     ('Vendor Doing As Business Name', copy_subaward_field('dba_name')),
-    ('PrimeAwardReportID',
-        CopyValues(procurement='contract_number', grant='fain')),
+    ('PrimeAwardReportID', CopyValues(procurement='contract_number', grant='fain')),
     ('ParentAwardId', CopyValues(procurement='idv_reference_number')),
     ('AwardReportMonth', copy_prime_field('report_period_mon')),
     ('AwardReportYear', copy_prime_field('report_period_year')),


### PR DESCRIPTION
Updating the FSRS loader and F file generation

- [x] Signed off on by @klrBAH 
- [x] Reviewed by backend

- FSRS loader now deletes based on internal_id rather than the iterating id so it will find duplicates and delete old ones
- FSRS loader loops until there are no records to be updated
- F file generation is now based on distinct fain for grants and piid, awarding sub tier agency code, and parent award id for procurements so even if the D files have multiples, it'll only put one of each in

This isn't as many changes as it looks like, a lot of the lines are formatting/readability updates

Technical Release Notes:
- Updated FSRS loader so if there is local FSRS data it might be prudent to wipe it and start from scratch (if there isn't, nothing for local devs to do)