### PR TITLE
HOTFIX: account for 'city-wide' as place_of_performance_zip4a during FABS derivations

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1761,7 +1761,7 @@ def fabs_derivations(obj, sess):
     obj['place_of_perform_state_nam'] = ppop_state.state_name
 
     # deriving place of performance values from zip4
-    if obj['place_of_performance_zip4a']:
+    if obj['place_of_performance_zip4a'] and obj['place_of_performance_zip4a'] != 'city-wide':
         zip_five = obj['place_of_performance_zip4a'][:5]
         zip_four = None
 


### PR DESCRIPTION
AC:
- FABS submissions with `city-wide` in their `place_of_performance_zip4a` do not throw a 500 error during derivations


related ticket: https://federal-spending-transparency.atlassian.net/browse/DB-2234