### PR TITLE
Db mk 2246 publish duplicate v2

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -750,7 +750,7 @@ class FileHandler:
         submission_id = submission.submission_id
 
         sess.query(Submission).filter_by(submission_id=submission_id).\
-            update({"publish_status_id": PUBLISH_STATUS_DICT['publishing']},synchronize_session = False)
+            update({"publish_status_id": PUBLISH_STATUS_DICT['publishing']}, synchronize_session=False)
         sess.commit()
 
         try:
@@ -791,7 +791,7 @@ class FileHandler:
             sess.rollback()
 
             sess.query(Submission).filter_by(submission_id=submission_id). \
-                update({"publish_status_id": PUBLISH_STATUS_DICT['unpublished']}, synchronize_session = False)
+                update({"publish_status_id": PUBLISH_STATUS_DICT['unpublished']}, synchronize_session=False)
             sess.commit()
 
             return JsonResponse.error(e, StatusCode.INTERNAL_ERROR)

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -63,7 +63,8 @@ JOB_TYPE_DICT_ID = {item.id: item.name for item in JOB_TYPE}
 PUBLISH_STATUS = [
     LookupType(1, 'unpublished', 'Has not yet been moved to data store'),
     LookupType(2, 'published', 'Has been moved to data store'),
-    LookupType(3, 'updated', 'Submission was updated after being published')
+    LookupType(3, 'updated', 'Submission was updated after being published'),
+    LookupType(4, 'publishing', 'Submission is being published')
 ]
 PUBLISH_STATUS_DICT = {item.name: item.id for item in PUBLISH_STATUS}
 PUBLISH_STATUS_DICT_ID = {item.id: item.name for item in PUBLISH_STATUS}


### PR DESCRIPTION
Technical Release Notes:
- Requires re-initialization of the database
- Updates all submission responses publish state to be either 'published' 'updated' 'unpublished' or 'publishing'