### PR TITLE
Db 2125 prevent duplicate fabs time

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -752,13 +752,15 @@ This route alters a submission's jobs' statuses and then restarts all validation
 
 ```
 {
-  "submission_id": 1
+  "submission_id": 1,
+  "d2_submission": True
 }
 ```
 
 ##### Body Description
 
 * `submission_id` - **required** - an integer corresponding to the ID of the submission for which the validations should be restarted.
+* `d2_submission` - a boolean indicating whether this is a dabs or fabs submission
 
 ##### Response (JSON)
 

--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -457,8 +457,9 @@ def add_file_routes(app, create_credentials, is_local, server_path):
     @app.route("/v1/restart_validation/", methods=['POST'])
     @convert_to_submission_id
     @requires_submission_perms('writer')
-    def restart_validation(submission):
-        return FileHandler.restart_validation(submission)
+    @use_kwargs({'d2_submission': webargs_fields.Bool(missing=False)})
+    def restart_validation(submission, d2_submission):
+        return FileHandler.restart_validation(submission, d2_submission)
 
 
 def convert_to_submission_id(fn):

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -914,11 +914,14 @@ class FileHandler:
             response_dict["bucket_name"] = CONFIG_BROKER["aws_bucket"]
 
     @staticmethod
-    def restart_validation(submission):
+    def restart_validation(submission, fabs):
         # update all validation jobs to "ready"
         sess = GlobalDB.db().session
-        initial_file_types = [FILE_TYPE_DICT['appropriations'], FILE_TYPE_DICT['program_activity'],
-                              FILE_TYPE_DICT['award_financial']]
+        if not fabs:
+            initial_file_types = [FILE_TYPE_DICT['appropriations'], FILE_TYPE_DICT['program_activity'],
+                                  FILE_TYPE_DICT['award_financial']]
+        else:
+            initial_file_types = [FILE_TYPE_DICT['detached_award']]
 
         jobs = sess.query(Job).filter(Job.submission_id == submission.submission_id).all()
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -766,8 +766,11 @@ class FileHandler:
                 join(pafa, and_(dafa.afa_generated_unique == pafa.afa_generated_unique, pafa.is_active.is_(True))).\
                 count()
             if colliding_rows > 0:
-                raise ResponseException("One or more of the new entries in this submission has been published since "
-                                        "validations completed. Please revalidate.", StatusCode.CLIENT_ERROR)
+                raise ResponseException("1 or more rows in this submission were already published (in a separate "
+                                        "submission). This occurred in the time since your validations were completed. "
+                                        "To prevent duplicate records, this submission must be revalidated in order to "
+                                        "publish.",
+                                        StatusCode.CLIENT_ERROR)
 
             # get all valid lines for this submission
             query = sess.query(DetachedAwardFinancialAssistance).\

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -764,6 +764,11 @@ class FileTests(BaseTestAPI):
                                       headers={"x-session-id": self.session_id})
         self.assertEqual(response.json['message'], "Success")
 
+        post_json = {'submission_id': self.test_fabs_submission_id, 'd2_submission': True}
+        response = self.app.post_json("/v1/restart_validation/", post_json,
+                                      headers={"x-session-id": self.session_id})
+        self.assertEqual(response.json['message'], "Success")
+
     @staticmethod
     def insert_submission(sess, submission_user_id, cgac_code=None, start_date=None, end_date=None,
                           is_quarter=False, number_of_errors=0, publish_status_id=1, is_fabs=False):


### PR DESCRIPTION
Prevent duplicate transactions from being published if a different submission with the same new entries is published.

- [ ] Merged concurrently with https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/761
- [ ] Reviewed by backend

Technical Release Notes:
- Updated route `restart_validation` to allow for restarting FABS! validations
- Updated route `submit_detached_file` to check for new rows before continuing