### PR TITLE
Hotfix: mark D file generation upload job as "running"

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -400,7 +400,9 @@ class FileHandler:
 
         # If this job has already generated a D file that is cached, don't request new job info
         file_request = sess.query(FileRequest).filter_by(job_id=job.job_id).one_or_none()
-        if not file_request or not file_request.is_cached_file:
+        if file_request and file_request.is_cached_file:
+            mark_job_status(job.job_id, "running")
+        else:
             job = self.add_generation_job_info(file_type_name=file_type_name, job=job)
 
         # Generate and upload file to S3


### PR DESCRIPTION
When someone creates a submission that becomes the owner of a cached file, then regenerates the D files within that same submission, it never changes the upload job to `running`. So when we run `mark_job_status`, we miss out because of this `if` statement:

> `    if old_status != 'finished' and status_name == 'finished' and not skip_check:`
> `        check_job_dependencies(job_id)`