### PR TITLE
Hotfix - Existing Dabs Submission Check Bug

### DIFF
--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -47,6 +47,7 @@ def add_file_routes(app, create_credentials, is_local, server_path):
                 Submission.reporting_start_date == formatted_start_date,
                 Submission.reporting_end_date == formatted_end_date,
                 Submission.is_quarter_format == request.json.get('is_quarter'),
+                Submission.d2_submission == False, # noqa
                 Submission.publish_status_id != PUBLISH_STATUS_DICT['unpublished'])
 
             if 'existing_submission_id' in request.json:


### PR DESCRIPTION
This route is specific for dabs submissions and dabs submissions are the only one that needs to check for a submission with an existing period. FABS route does not care if there are published submissions with existing periods

using == with # noqa because checking 'is False' will break sqlAlchemy and this will throw a flake warning