### PR TITLE
DEV-49 Update B9 (B10) to check for 2016-2018

### DIFF
--- a/dataactvalidator/config/sqlrules/b9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/b9_award_financial.sql
@@ -26,8 +26,8 @@ WHERE af.program_activity_code <> '0000'
             AND af.main_account_code = pa.account_number
             AND UPPER(COALESCE(af.program_activity_name, '')) = UPPER(pa.program_activity_name)
             AND COALESCE(af.program_activity_code, '') = pa.program_activity_code
-            AND CAST(pa.budget_year AS INTEGER) IN (2016, (SELECT reporting_fiscal_year
-                                                           FROM submission
-                                                           WHERE submission_id = {0})
-                                                   )
+            AND CAST(pa.budget_year AS INTEGER) IN (2016, 2017, 2018)  -- temporarily hardcoded to 2016-2018
+                                                   -- (SELECT reporting_fiscal_year
+                                                   --  FROM submission
+                                                   --  WHERE submission_id = {0})
     );

--- a/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
@@ -36,10 +36,10 @@ WHERE op.program_activity_code <> '0000'
                 AND op.main_account_code = pa.account_number
                 AND UPPER(COALESCE(op.program_activity_name, '')) = UPPER(pa.program_activity_name)
                 AND COALESCE(op.program_activity_code, '') = pa.program_activity_code
-                AND CAST(pa.budget_year AS INTEGER) IN (2016, (SELECT reporting_fiscal_year
-                                                               FROM submission
-                                                               WHERE submission_id = {0})
-                                                       )
+                AND CAST(pa.budget_year AS INTEGER) IN (2016, 2017, 2018)  -- temporarily hardcoded to 2016-2018
+                                                       -- (SELECT reporting_fiscal_year
+                                                       --  FROM submission
+                                                       --  WHERE submission_id = {0})
     )
     -- when there's no program activity name, return sum of true/false statements of whether all numerical values
     -- are zero or not (1 = not zero) (see if there are any non-zero values basically)

--- a/tests/unit/dataactvalidator/test_b9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_b9_award_financial.py
@@ -79,9 +79,12 @@ def test_failure_fiscal_year(database):
     pa_3 = ProgramActivityFactory(budget_year=2018, agency_id='test3', allocation_transfer_id='test3',
                                   account_number='test3', program_activity_name='test3', program_activity_code='test3')
 
+    pa_4 = ProgramActivityFactory(budget_year=2019, agency_id='test4', allocation_transfer_id='test4',
+                                  account_number='test4', program_activity_name='test4', program_activity_code='test4')
+
     submission = SubmissionFactory(submission_id='1', reporting_fiscal_year='2017')
 
-    assert number_of_errors(_FILE, database, models=[af, pa_1, pa_2, pa_3], submission=submission) == 1
+    assert number_of_errors(_FILE, database, models=[af, pa_1, pa_2, pa_3, pa_4], submission=submission) == 1
 
 
 def test_success_ignore_case(database):

--- a/tests/unit/dataactvalidator/test_b9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_b9_award_financial.py
@@ -66,9 +66,9 @@ def test_success_fiscal_year(database):
 def test_failure_fiscal_year(database):
     """ Testing invalid name for FY, not matches with budget_year"""
 
-    af = AwardFinancialFactory(row_number=1, submission_id='1', agency_identifier='test3',
-                               main_account_code='test3', program_activity_name='test3',
-                               program_activity_code='test3')
+    af = AwardFinancialFactory(row_number=1, submission_id='1', agency_identifier='test4',
+                               main_account_code='test4', program_activity_name='test4',
+                               program_activity_code='test4')
 
     pa_1 = ProgramActivityFactory(budget_year=2016, agency_id='test', allocation_transfer_id='test',
                                   account_number='test', program_activity_name='test', program_activity_code='test')

--- a/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
@@ -51,9 +51,9 @@ def test_success_fiscal_year(database):
 def test_failure_fiscal_year(database):
     """ Testing invalid name for FY, not matches with budget_year"""
 
-    op = ObjectClassProgramActivityFactory(row_number=1, submission_id='1', agency_identifier='test3',
-                                           main_account_code='test3', program_activity_name='test3',
-                                           program_activity_code='test3')
+    op = ObjectClassProgramActivityFactory(row_number=1, submission_id='1', agency_identifier='test4',
+                                           main_account_code='test4', program_activity_name='test4',
+                                           program_activity_code='test4')
 
     pa_1 = ProgramActivityFactory(budget_year=2016, agency_id='test', allocation_transfer_id='test',
                                   account_number='test', program_activity_name='test', program_activity_code='test')
@@ -64,9 +64,12 @@ def test_failure_fiscal_year(database):
     pa_3 = ProgramActivityFactory(budget_year=2018, agency_id='test3', allocation_transfer_id='test3',
                                   account_number='test3', program_activity_name='test3', program_activity_code='test3')
 
+    pa_4 = ProgramActivityFactory(budget_year=2019, agency_id='test4', allocation_transfer_id='test4',
+                                  account_number='test4', program_activity_name='test4', program_activity_code='test4')
+
     submission = SubmissionFactory(submission_id='1', reporting_fiscal_year='2017')
 
-    assert number_of_errors(_FILE, database, models=[op, pa_1, pa_2, pa_3], submission=submission) == 1
+    assert number_of_errors(_FILE, database, models=[op, pa_1, pa_2, pa_3, pa_4], submission=submission) == 1
 
 
 def test_success_unknown_value(database):


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-49

A/C:
- Update B9 execution to accept PA name/code per AID/ATA/MAC combo in authoritative OMB list for FY 2018
- Until we get official OMB policy, make it year agnostic. In other words, validation checks FY16,17, and 18 list.

Technical Release Notes:
- SQL rule updates