### PR TITLE
DEV-48 Trim whitespace from city_names

### DIFF
--- a/dataactvalidator/scripts/loadLocationData.py
+++ b/dataactvalidator/scripts/loadLocationData.py
@@ -136,7 +136,7 @@ def parse_zip_city_file(f, sess):
             curr_row = curr_chunk[:line_size]
             if curr_row[0] == "D":
                 zip_code = curr_row[1:6]
-                city_name = curr_row[62:90]
+                city_name = curr_row[62:90].strip()
                 data_array[zip_code] = {"zip_code": zip_code, "city_name": city_name}
 
             # cut the current line out of the chunk we're processing


### PR DESCRIPTION
https://federal-spending-transparency.atlassian.net/browse/DEV-48

- readZips.py strings are trimmed before being inserted into DB
- loadLocationData.py load_zip_city_data strings are trimmed before being inserted into DB

(_dev note: bullet one is not needed, because all records pulled from ctystate.txt in the readZips.py functions are codes_)