### PR TITLE
Bugfix updating agengy list changes

### DIFF
--- a/dataactbroker/scripts/update_detached_procurement.py
+++ b/dataactbroker/scripts/update_detached_procurement.py
@@ -1,5 +1,5 @@
 import logging
-import datetime
+import argparse
 
 from dataactcore.logging import configure_logging
 from dataactcore.interfaces.db import GlobalDB
@@ -10,20 +10,19 @@ logger = logging.getLogger(__name__)
 
 # sess: Passing session into the function for modifying db
 # type: will be either 'awarding' or 'funding' to determine which agency type we are checking
-def update_table(sess, type):
-    logger.info('updating ' + type)
-    invalid = sess.execute("select count(*) from detached_award_procurement where " + type + "_agency_code='999'")
-    invalid_count = invalid.fetchone()[0]
-    logger.info("{} invalid {} rows found".format(invalid_count, type))
+def update_table(sess, agency_type, args):
+    logger.info('updating ' + agency_type)
+
     # The name of the column depends on the type because of limited string length
     suffix = 'o' if type == "funding" else ''
 
-    updated_at = datetime.datetime.utcnow().strftime('%Y-%m-%d %I:%M:%S.%f')
+    invalid_count, condition = set_update_condition(agency_type, suffix, sess, args.update_date)
+
     # updates table based off the parent of the sub_tier_agency code
     sess.execute(
-        "UPDATE detached_award_procurement set updated_at = '" + updated_at + "', "
-        + type + "_agency_code = agency.agency_code, " +
-        type + "_agency_name = agency.agency_name from ( " +
+        "UPDATE detached_award_procurement SET" +
+        + agency_type + "_agency_code = agency.agency_code, " +
+        agency_type + "_agency_name = agency.agency_name from ( " +
         "SELECT sub.sub_tier_agency_code, sub.cgac_id, sub.frec_id, sub.is_frec, CASE WHEN sub.is_frec " +
         "THEN (SELECT agency_name from frec WHERE frec.frec_id = sub.frec_id) " +
         "ELSE (SELECT agency_name from cgac where cgac.cgac_id = sub.cgac_id) end agency_name, " +
@@ -33,13 +32,32 @@ def update_table(sess, type):
         "from sub_tier_agency sub " +
         "INNER JOIN cgac ON cgac.cgac_id = sub.cgac_id " +
         "INNER JOIN frec ON frec.frec_id = sub.frec_id ) agency " +
-        "where detached_award_procurement." + type + "_agency_code = '999' " +
-        "and detached_award_procurement." + type + "_sub_tier_agency_c" + suffix +
+        "WHERE " + condition +
+        "and detached_award_procurement." + agency_type + "_sub_tier_agency_c" + suffix +
         " = agency.sub_tier_agency_code "
     )
-    sess.commit()
-    invalid = sess.execute("select count(*) from detached_award_procurement where " + type + "_agency_code='999'")
-    print_report(invalid_count, invalid.fetchone()[0], type)
+    # sess.commit()
+    if args.missing_agency:
+        invalid = sess.execute("select count(*) from" + condition)
+        print_report(invalid_count, invalid.fetchone()[0], type)
+
+
+def set_update_condition(agency_type, suffix, sess, update_date=None):
+
+    if update_date:
+        updated_subtiers = sess.execute(
+            "SELECT sub_tier_agency_code from sub_tier_agency where updated_at::date='{}'::date".format(update_date)
+        )
+        subtier_list = ",".join(["\'{}\'".format(str(x[0])) for x in updated_subtiers.fetchall() if len(x[0]) == 4])
+        sql_statement = "detached_award_procurement."+agency_type+"_sub_tier_agency_c"+suffix+" in ("+subtier_list+")"
+    else:
+        sql_statement = "detached_award_procurement." + agency_type + "_agency_code = '999' "
+
+    invalid = sess.execute("select count(*) from " + sql_statement)
+    invalid_count = invalid.fetchone()[0]
+    logger.info("{} invalid {} rows found".format(invalid_count, agency_type))
+
+    return invalid_count, sql_statement
 
 
 # data logging
@@ -49,11 +67,23 @@ def print_report(initial, final, type):
 
 
 def main():
-    sess = GlobalDB.db().session
+    parser = argparse.ArgumentParser(description='Update contract transaction rows based on updates to the agency list')
+    parser.add_argument('--missing_agency', help='Perform an update on 999 agency codes', action='store_true',
+                        required=False, default=False)
+    parser.add_argument('-d', '--update_date', help='Date subtier were updated at to run updates on the' +
+                                                    'toptier agencies derived in transactions. Format: YYYY/MM/DD',
+                        type=str, required=False)
+    args = parser.parse_args()
 
-    update_table(sess, 'awarding')
-    update_table(sess, 'funding')
-    logger.info("Procurement Update Complete")
+    if not args.update_date and not args.missing_agency:
+        logger.error('Missing either update_date or missing_agency argument')
+    else:
+        sess = GlobalDB.db().session
+
+        update_table(sess, 'awarding', args)
+        update_table(sess, 'funding', args)
+        logger.info("Procurement Update Complete")
+
 
 if __name__ == '__main__':
     configure_logging()

--- a/dataactbroker/scripts/update_detached_procurement.py
+++ b/dataactbroker/scripts/update_detached_procurement.py
@@ -68,12 +68,13 @@ def get_row_count(sql_statement, sess):
 def print_report(initial, final, agency_type, subtier_code, is_updated=False):
     agency_code_type, update_type = ('subtier', subtier_code) if subtier_code else ('cgac', '999')
 
-    logger.info("{} {} {} code {} rows {}".format(initial - final, agency_type,
-                                                  agency_code_type, update_type,
-                                                  'updated' if is_updated else 'to update'
-                                                  ))
+    logger.info("{} {} code {} {}: {} rows".format(agency_type,
+                                                   agency_code_type, update_type,
+                                                   'updated' if is_updated else 'to update',
+                                                   initial - final
+                                                   ))
     if is_updated and update_type == '999':
-        logger.info("{} {} code {} rows remaining".format(final, agency_type, update_type))
+        logger.info("{} {} code remaining: {} rows ".format(agency_type, update_type, final))
 
 
 def main():

--- a/dataactbroker/scripts/update_detached_procurement.py
+++ b/dataactbroker/scripts/update_detached_procurement.py
@@ -14,50 +14,55 @@ def update_table(sess, agency_type, args):
     logger.info('updating ' + agency_type)
 
     # The name of the column depends on the type because of limited string length
-    suffix = 'o' if type == "funding" else ''
+    suffix = 'o' if agency_type == "funding" else ''
 
-    invalid_count, condition = set_update_condition(agency_type, suffix, sess, args.update_date)
+    invalid_count, condition_sql = set_update_condition(agency_type, suffix, sess, args.subtier_code)
 
     # updates table based off the parent of the sub_tier_agency code
     sess.execute(
-        "UPDATE detached_award_procurement SET" +
-        + agency_type + "_agency_code = agency.agency_code, " +
-        agency_type + "_agency_name = agency.agency_name from ( " +
-        "SELECT sub.sub_tier_agency_code, sub.cgac_id, sub.frec_id, sub.is_frec, CASE WHEN sub.is_frec " +
-        "THEN (SELECT agency_name from frec WHERE frec.frec_id = sub.frec_id) " +
-        "ELSE (SELECT agency_name from cgac where cgac.cgac_id = sub.cgac_id) end agency_name, " +
-        "CASE WHEN sub.is_frec " +
-        "THEN (SELECT frec_code from frec WHERE frec.frec_id = sub.frec_id) " +
-        "ELSE (SELECT cgac_code from cgac where cgac.cgac_id = sub.cgac_id) end agency_code " +
-        "from sub_tier_agency sub " +
-        "INNER JOIN cgac ON cgac.cgac_id = sub.cgac_id " +
-        "INNER JOIN frec ON frec.frec_id = sub.frec_id ) agency " +
-        "WHERE " + condition +
-        "and detached_award_procurement." + agency_type + "_sub_tier_agency_c" + suffix +
-        " = agency.sub_tier_agency_code "
+        """
+        UPDATE detached_award_procurement SET
+        {agency_type}_agency_code = agency.agency_code,
+        {agency_type}_agency_name = agency.agency_name FROM (
+        SELECT sub.sub_tier_agency_code, sub.cgac_id, sub.frec_id, sub.is_frec, CASE WHEN sub.is_frec
+        THEN (SELECT agency_name from frec WHERE frec.frec_id = sub.frec_id)
+        ELSE (SELECT agency_name from cgac where cgac.cgac_id = sub.cgac_id) END agency_name,
+        CASE WHEN sub.is_frec
+        THEN (SELECT frec_code from frec WHERE frec.frec_id = sub.frec_id)
+        ELSE (SELECT cgac_code from cgac where cgac.cgac_id = sub.cgac_id) END agency_code
+        FROM sub_tier_agency sub
+        INNER JOIN cgac ON cgac.cgac_id = sub.cgac_id
+        INNER JOIN frec ON frec.frec_id = sub.frec_id ) agency
+        WHERE {condition_sql}
+        AND detached_award_procurement.{agency_type}_sub_tier_agency_c{suffix} = agency.sub_tier_agency_code;
+        """.format(agency_type=agency_type, condition_sql=condition_sql, suffix=suffix)
     )
-    # sess.commit()
+    sess.commit()
     if args.missing_agency:
-        invalid = sess.execute("select count(*) from" + condition)
-        print_report(invalid_count, invalid.fetchone()[0], type)
+        final_invalid_count = get_invalid_count(condition_sql, sess)
+        print(final_invalid_count)
+        print_report(invalid_count, final_invalid_count, agency_type)
 
 
-def set_update_condition(agency_type, suffix, sess, update_date=None):
+def set_update_condition(agency_type, suffix, sess, subtier_code=None):
 
-    if update_date:
-        updated_subtiers = sess.execute(
-            "SELECT sub_tier_agency_code from sub_tier_agency where updated_at::date='{}'::date".format(update_date)
-        )
-        subtier_list = ",".join(["\'{}\'".format(str(x[0])) for x in updated_subtiers.fetchall() if len(x[0]) == 4])
-        sql_statement = "detached_award_procurement."+agency_type+"_sub_tier_agency_c"+suffix+" in ("+subtier_list+")"
+    if subtier_code:
+        sql_statement = "detached_award_procurement.{}_sub_tier_agency_c{} = '{}' ".format(agency_type,
+                                                                                           suffix, subtier_code)
     else:
         sql_statement = "detached_award_procurement." + agency_type + "_agency_code = '999' "
 
-    invalid = sess.execute("select count(*) from " + sql_statement)
-    invalid_count = invalid.fetchone()[0]
+    invalid_count = get_invalid_count(sql_statement, sess)
     logger.info("{} invalid {} rows found".format(invalid_count, agency_type))
 
     return invalid_count, sql_statement
+
+
+def get_invalid_count(sql_statement, sess):
+    invalid = sess.execute("select count(*) from detached_award_procurement where " + sql_statement + ";")
+    invalid_count = invalid.fetchone()[0]
+
+    return invalid_count
 
 
 # data logging
@@ -68,15 +73,16 @@ def print_report(initial, final, type):
 
 def main():
     parser = argparse.ArgumentParser(description='Update contract transaction rows based on updates to the agency list')
-    parser.add_argument('--missing_agency', help='Perform an update on 999 agency codes', action='store_true',
+    parser.add_argument('-a', '--missing_agency', help='Perform an update on 999 agency codes', action='store_true',
                         required=False, default=False)
-    parser.add_argument('-d', '--update_date', help='Date subtier were updated at to run updates on the' +
-                                                    'toptier agencies derived in transactions. Format: YYYY/MM/DD',
+    parser.add_argument('-s', '--subtier_code', help='Select specific subtier to update. Must be a 4-digit code',
                         type=str, required=False)
     args = parser.parse_args()
 
-    if not args.update_date and not args.missing_agency:
+    if not args.subtier_code and not args.missing_agency:
         logger.error('Missing either update_date or missing_agency argument')
+    elif args.subtier_code and len(args.subtier_code) != 4:
+        logger.error('Subtier not a correct format, must be 4 digits')
     else:
         sess = GlobalDB.db().session
 


### PR DESCRIPTION
Updating the detached procurement update script to fix additional agency list changes.

- Removed setting of updated_at 
- Added argument to run update on a specific subtier agency (for the case of USAID agency 1152)
- Updated logging

Relates to bugs: [231](https://federal-spending-transparency.atlassian.net/browse/DEV-231), [410](https://federal-spending-transparency.atlassian.net/browse/DEV-410), [423](https://federal-spending-transparency.atlassian.net/browse/DEV-423)
There are only FPDS transactions with the following subtiers: 1152, 5300, 9576

Run locally:
Run the following commands on the test environment. You can view the updated `agency_code_list.csv` in the sf133-dev bucket. 
```
python dataactcore/scripts/initialize.py -c . # updates agency tables base on new agency_codes_list
python dataactbroker/scripts/update_detached_procurement.py -a  # updates agency codes with 999 (pertains to IMLS 5300)
python dataactbroker/scripts/update_detached_procurement.py -s 1152 . # updates USAID sub 1152 transactions
```

Testing:

Timing:
1. Agency update: 8 seconds
2. 999 fix:  2 hours
    - < 1 min to update 758 awarding agency transaction rows
    -  Almost an hour to get a count of 999 funding agency transaction rows (9 million rows)
    -  1 hour to update 568 funding cgac  transaction code
3. 1152 fix: 12 seconds
    - Updated 28 awarding agency transaction rows
    -  Updated 7707 funding agency transaction rows

_Future fix would be to remove funding agency code 999 from  historical transactions where funding subtier agency code is null. The daily loader does not do this already_

Agency Changes:
Changes to the agency list
- IMLS (474) has 2 subtiers instead of 1
- VEF (519) now has 2 subtiers  instead of 1
- USAID (072) now has 2 subtiers  instead of 1
- EOP (1100) now had 42 subtiers  instead of 43

- [x] Approve changes to `agency_codes_list.csv`
- [x]  Backend Review

Relates to: fedspendingtransparency/usaspending-api#948