### PR TITLE
Hotfix only split valid zips

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1895,7 +1895,7 @@ def fabs_derivations(obj, sess):
             obj['legal_entity_country_name'] = None
 
     # splitting ppop zip code into 5 and 4 digit codes for ease of website access
-    if obj['place_of_performance_zip4a']:
+    if obj['place_of_performance_zip4a'] and re.match('^\d{5}(-?\d{4})?$', obj['place_of_performance_zip4a']):
         if len(obj['place_of_performance_zip4a']) == 5:
             obj['place_of_performance_zip5'] = obj['place_of_performance_zip4a'][:5]
             obj['place_of_perform_zip_last4'] = None

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1676,6 +1676,8 @@ def fabs_derivations(obj, sess):
     # initializing a few of the derivations so the keys exist
     obj['legal_entity_state_code'] = None
     obj['legal_entity_city_name'] = None
+    obj['place_of_performance_zip5'] = None
+    obj['place_of_perform_zip_last4'] = None
 
     # deriving total_funding_amount
     federal_action_obligation = obj['federal_action_obligation'] or 0

--- a/tests/unit/dataactbroker/test_fabs_derivations.py
+++ b/tests/unit/dataactbroker/test_fabs_derivations.py
@@ -332,6 +332,12 @@ def test_split_zip(database):
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
+    # testing with city-wide
+    obj = initialize_test_obj(ppop_zip4a='city-wide')
+    obj = fabs_derivations(obj, database.session)
+    assert obj['place_of_performance_zip5'] is None
+    assert obj['place_of_perform_zip_last4'] is None
+
 
 def test_is_active(database):
     initialize_db_values(database)


### PR DESCRIPTION
We don't want to split the zip4 when it's `city-wide`