### PR TITLE
Update fabs 42.1 rule

### DIFF
--- a/dataactvalidator/config/sqlrules/fabs42_detached_award_financial_assistance_1.sql
+++ b/dataactvalidator/config/sqlrules/fabs42_detached_award_financial_assistance_1.sql
@@ -2,9 +2,11 @@
 -- (i.e., when PrimaryPlaceOfPerformanceCountryCode does not equal USA).
 SELECT
     row_number,
+    record_type,
     place_of_performance_forei,
     place_of_perform_country_c
 FROM detached_award_financial_assistance
 WHERE submission_id = {0}
     AND COALESCE(place_of_performance_forei, '') = ''
-    AND UPPER(place_of_perform_country_c) <> 'USA';
+    AND UPPER(place_of_perform_country_c) <> 'USA'
+    AND record_type = 2;

--- a/tests/unit/dataactvalidator/test_fabs42_detached_award_financial_assistance_1.py
+++ b/tests/unit/dataactvalidator/test_fabs42_detached_award_financial_assistance_1.py
@@ -5,37 +5,51 @@ _FILE = 'fabs42_detached_award_financial_assistance_1'
 
 
 def test_column_headers(database):
-    expected_subset = {"row_number", "place_of_performance_forei", "place_of_perform_country_c"}
+    expected_subset = {"row_number", "place_of_performance_forei", "place_of_perform_country_c", "record_type"}
     actual = set(query_columns(_FILE, database))
     assert expected_subset == actual
 
 
 def test_success(database):
     """ Test PrimaryPlaceOfPerformanceForeignLocationDescription is required for foreign places of performance
-        (i.e., when PrimaryPlaceOfPerformanceCountryCode does not equal USA). This test shouldn't care about
-        content when country_code is USA (that is for another validation). """
+        (i.e., when PrimaryPlaceOfPerformanceCountryCode does not equal USA) for record type 2. This test shouldn't
+       care about content when country_code is USA (that is for another validation). """
 
     det_award_1 = DetachedAwardFinancialAssistanceFactory(place_of_performance_forei="description",
-                                                          place_of_perform_country_c="UK")
+                                                          place_of_perform_country_c="UK",
+                                                          record_type=2)
     det_award_2 = DetachedAwardFinancialAssistanceFactory(place_of_performance_forei="description",
-                                                          place_of_perform_country_c="USA")
+                                                          place_of_perform_country_c="USA",
+                                                          record_type=2
+                                                          )
     det_award_3 = DetachedAwardFinancialAssistanceFactory(place_of_performance_forei=None,
-                                                          place_of_perform_country_c="USA")
+                                                          place_of_perform_country_c="USA",
+                                                          record_type=2)
     det_award_4 = DetachedAwardFinancialAssistanceFactory(place_of_performance_forei="",
-                                                          place_of_perform_country_c="UsA")
+                                                          place_of_perform_country_c="UsA",
+                                                          record_type=2)
+    det_award_5 = DetachedAwardFinancialAssistanceFactory(place_of_performance_forei="",
+                                                          place_of_perform_country_c="UK",
+                                                          record_type=1)
+    det_award_6 = DetachedAwardFinancialAssistanceFactory(place_of_performance_forei=None,
+                                                          place_of_perform_country_c="UK",
+                                                          record_type=1)
 
-    errors = number_of_errors(_FILE, database, models=[det_award_1, det_award_2, det_award_3, det_award_4])
+    errors = number_of_errors(_FILE, database, models=[det_award_1, det_award_2, det_award_3, det_award_4,
+                                                       det_award_5, det_award_6])
     assert errors == 0
 
 
 def test_failure(database):
     """ Test failure PrimaryPlaceOfPerformanceForeignLocationDescription is required for foreign places of performance
-        (i.e., when PrimaryPlaceOfPerformanceCountryCode does not equal USA). """
+        (i.e., when PrimaryPlaceOfPerformanceCountryCode does not equal USA) for record type 2. """
 
     det_award_1 = DetachedAwardFinancialAssistanceFactory(place_of_performance_forei="",
-                                                          place_of_perform_country_c="UK")
+                                                          place_of_perform_country_c="UK",
+                                                          record_type=2)
     det_award_2 = DetachedAwardFinancialAssistanceFactory(place_of_performance_forei=None,
-                                                          place_of_perform_country_c="UK")
+                                                          place_of_perform_country_c="UK",
+                                                          record_type=2)
 
     errors = number_of_errors(_FILE, database, models=[det_award_1, det_award_2])
     assert errors == 2


### PR DESCRIPTION
[Feature Link](https://federal-spending-transparency.atlassian.net/browse/DEV-449)

Rule 42.1 where `PrimaryPlaceOfPerformanceForeignLocationDescription` is required for foreign places of performance for record type 2.