### PR TITLE
DEV-338 Update fsrs loader to load missing submissions

### DIFF
--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -187,7 +187,6 @@ def retrieve_batch(service_type, min_id, return_single_id):
             pass
 
 
-
 def fetch_and_replace_batch(sess, service_type, min_id=None):
     """Hit one of the FSRS APIs and replace any local records that match.
     Returns the award models"""

--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -183,8 +183,6 @@ def retrieve_batch(service_type, min_id, return_single_id):
                 yield to_prime_contract(as_dict)
             else:
                 yield to_prime_grant(as_dict)
-        else:
-            pass
 
 
 def fetch_and_replace_batch(sess, service_type, min_id=None):

--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -130,7 +130,7 @@ _grantAddrs = ('principle_place', 'awardee_address')
 def flatten_soap_dict(simple_fields, address_fields, comma_field, soap_dict):
     """For all four FSRS models, we need to copy over values, flatten address
     data, flatten topPaid, convert comma fields"""
-    logger.debug(soap_dict['id'])
+    logger.debug(soap_dict)
     model_attrs = {}
     for field in simple_fields:
         model_attrs[field] = soap_dict.get(field)
@@ -173,6 +173,9 @@ def retrieve_batch(service_type, min_id, return_single_id):
     """The FSRS web service returns records in batches (500 at a time).
     Retrieve one such batch, converting each result (and sub-results) into
     dicts"""
+
+    # Subtracting 1 from min_id since FSRS API starts one after value
+    # If the last id is 50 for example the min_id is 51, the API will retrieve 52 and greater
     for report in new_client(service_type).service.getData(id=min_id-1)['reports']:
         if (report['id'] == min_id and return_single_id) or not return_single_id:
             as_dict = soap_to_dict(report)

--- a/dataactbroker/scripts/loadFSRS.py
+++ b/dataactbroker/scripts/loadFSRS.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import argparse
 
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.logging import configure_logging
@@ -12,16 +13,43 @@ logger = logging.getLogger(__name__)
 
 if __name__ == '__main__':
     configure_logging()
+    parser = argparse.ArgumentParser(description='Pull data from FSRS Feed')
+    parser.add_argument('-p', '--procurement',action='store_true', help="Load just procurement awards")
+    parser.add_argument('-g', '--grants', action='store_true', help="Load just grant awards")
+    parser.add_argument('-i', '--ids', type=int, nargs='+',
+                        help="Single or list of FSRS ids to pull from the FSRS API ")
+
     with create_app().app_context():
         sess = GlobalDB.db().session
         if not config_valid():
             logger.error("No config for broker/fsrs/[service]/wsdl")
             sys.exit(1)
         else:
-            awards = ['Starting']
-            while len(awards) > 0:
-                procs = fetch_and_replace_batch(sess, PROCUREMENT)
-                grants = fetch_and_replace_batch(sess, GRANT)
-                awards = procs + grants
-                numSubAwards = sum(len(a.subawards) for a in awards)
-                logger.info("Inserted/Updated %s awards, %s subawards", len(awards), numSubAwards)
+            args = parser.parse_args()
+
+            # Regular FSRS data load, starts where last load left off
+            if len(sys.argv) <= 1:
+                awards = ['Starting']
+                while len(awards) > 0:
+                    procs = fetch_and_replace_batch(sess, PROCUREMENT)
+                    grants = fetch_and_replace_batch(sess, GRANT)
+                    awards = procs + grants
+                    numSubAwards = sum(len(a.subawards) for a in awards)
+                    logger.info("Inserted/Updated %s awards, %s subawards", len(awards), numSubAwards)
+
+            elif args.procurement and args.ids:
+                for procurement_id in args.ids:
+                    procs = fetch_and_replace_batch(sess, PROCUREMENT, procurement_id)
+                    numSubAwards = sum(len(a.subawards) for a in procs)
+                    logger.info("Inserted/Updated %s awards, %s subawards", len(procs), numSubAwards)
+            elif args.grants and args.ids:
+                for grant_id in args.ids:
+                    grants = fetch_and_replace_batch(sess, GRANT, grant_id)
+                    numSubAwards = sum(len(a.subawards) for a in grants)
+                    logger.info("Inserted/Updated %s awards, %s subawards", len(grants), numSubAwards)
+            else:
+                if not args.ids:
+                    logger.error('Missing --ids argument when loading just procurment or grants awards')
+                else:
+                    logger.error('Missing --procurement or --grants argument when loading specific award ids')
+

--- a/dataactbroker/scripts/loadFSRS.py
+++ b/dataactbroker/scripts/loadFSRS.py
@@ -19,7 +19,7 @@ def log_fsrs_counts(total_awards):
 if __name__ == '__main__':
     configure_logging()
     parser = argparse.ArgumentParser(description='Pull data from FSRS Feed')
-    parser.add_argument('-p', '--procurement',action='store_true', help="Load just procurement awards")
+    parser.add_argument('-p', '--procurement', action='store_true', help="Load just procurement awards")
     parser.add_argument('-g', '--grants', action='store_true', help="Load just grant awards")
     parser.add_argument('-i', '--ids', type=int, nargs='+',
                         help="Single or list of FSRS ids to pull from the FSRS API ")
@@ -59,4 +59,3 @@ if __name__ == '__main__':
                     logger.error('Missing --ids argument when loading just procurment or grants awards')
                 else:
                     logger.error('Missing --procurement or --grants argument when loading specific award ids')
-

--- a/dataactbroker/scripts/loadFSRS.py
+++ b/dataactbroker/scripts/loadFSRS.py
@@ -56,6 +56,6 @@ if __name__ == '__main__':
                     log_fsrs_counts(grants)
             else:
                 if not args.ids:
-                    logger.error('Missing --ids argument when loading just procurment or grants awards')
+                    logger.error('Missing --ids argument when loading just procurement or grants awards')
                 else:
                     logger.error('Missing --procurement or --grants argument when loading specific award ids')


### PR DESCRIPTION
[Bug Link](https://federal-spending-transparency.atlassian.net/browse/DEV-338)

Updated `loadFSRS.py`, adding arguments in order to specify which ids to load that are missing in broker.  Also fixed issue where regular load was skipping initial id. 

We need to load 2 FSRS report ids (492178, 515853) should taking no more than 10 mins based on the bug ticket. 

Command:
```
python dataactbroker/scripts/loadFSRS.py -g -i 492178 515853
```

Average time to load per id is 3 mins. 