### PR TITLE
Update DEV 424

### DIFF
--- a/dataactvalidator/filestreaming/csvReader.py
+++ b/dataactvalidator/filestreaming/csvReader.py
@@ -254,6 +254,8 @@ def normalize_headers(header_row, long_headers, long_to_short_dict):
             header = 'deobligationsrecoveriesrefundsdofprioryearbyprogramobjectclass_cpe'
         if header == 'facevalueloanguarantee':
             header = 'facevalueofdirectloanorloanguarantee'
+        if header == 'totalbudgetaryresources_cpe':
+            header = 'budgetauthorityavailableamounttotal_cpe'
         if long_headers and header in long_to_short_dict:
             yield FieldCleaner.clean_string(long_to_short_dict[header])
         else:


### PR DESCRIPTION
Allows the user to use the field `BudgetAuthorityAvailableAmountTotal_CPE` or `TotalBudgetaryResources_CPE` for file A submissions by renaming `TotalBudgetaryResources_CPE` to `BudgetAuthorityAvailableAmountTotal_CPE`. Keeps rules as is. 

[Story Link](https://federal-spending-transparency.atlassian.net/browse/DEV-424)

