### PR TITLE
adding retries in get_data to log statements, expanding exception scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DATA Act Broker Backend
 
-The DATA Act broker backend is a collection of services that power the DATA Act's central data submission platform. 
+The DATA Act broker backend is a collection of services that power the DATA Act's central data submission platform.
 
 The website that runs on these services is here: [https://broker.usaspending.gov/](https://broker.usaspending.gov/ "DATA Act Broker website").
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DATA Act Broker Backend
 
-The DATA Act broker backend is a collection of services that power the DATA Act's central data submission platform.
+The DATA Act broker backend is a collection of services that power the DATA Act's central data submission platform. 
 
 The website that runs on these services is here: [https://broker.usaspending.gov/](https://broker.usaspending.gov/ "DATA Act Broker website").
 

--- a/dataactcore/scripts/pullFPDSData.py
+++ b/dataactcore/scripts/pullFPDSData.py
@@ -1275,7 +1275,7 @@ def get_data(contract_type, award_type, now, sess, sub_tier_list, county_by_name
             except (ConnectionResetError, ReadTimeoutError, requests.exceptions.ConnectionError) as e:
                 exception_retries += 1
                 if exception_retries < len(retry_sleep_times):
-                    logger.info('ConnectionReset/ReadTimeout caught. Sleeping {}s and then retrying...'.format(
+                    logger.info('Connection exception caught. Sleeping {}s and then retrying...'.format(
                         retry_sleep_times[exception_retries]))
                     time.sleep(retry_sleep_times[exception_retries])
                 else:

--- a/dataactcore/scripts/pullFPDSData.py
+++ b/dataactcore/scripts/pullFPDSData.py
@@ -20,6 +20,8 @@ from sqlalchemy import func
 
 from dateutil.relativedelta import relativedelta
 
+from requests.packages.urllib3.exceptions import ReadTimeoutError
+
 from dataactcore.logging import configure_logging
 from dataactcore.config import CONFIG_BROKER
 
@@ -1270,11 +1272,10 @@ def get_data(contract_type, award_type, now, sess, sub_tier_list, county_by_name
                                             namespaces={'http://www.fpdsng.com/FPDS': None,
                                                         'http://www.w3.org/2005/Atom': None})
                 break
-            except ConnectionResetError:
+            except (ConnectionResetError, ReadTimeoutError):
                 exception_retries += 1
-                # retry up to 3 times before raising an error
                 if exception_retries < len(retry_sleep_times):
-                    logger.info('ConnectionResetError caught. Sleeping {}s and then retrying...'.format(
+                    logger.info('ConnectionReset/ReadTimeout caught. Sleeping {}s and then retrying...'.format(
                         retry_sleep_times[exception_retries]))
                     time.sleep(retry_sleep_times[exception_retries])
                 else:

--- a/dataactcore/scripts/pullFPDSData.py
+++ b/dataactcore/scripts/pullFPDSData.py
@@ -1272,16 +1272,15 @@ def get_data(contract_type, award_type, now, sess, sub_tier_list, county_by_name
                                             namespaces={'http://www.fpdsng.com/FPDS': None,
                                                         'http://www.w3.org/2005/Atom': None})
                 break
-            except (ConnectionResetError, ReadTimeoutError):
+            except (ConnectionResetError, ReadTimeoutError, requests.exceptions.ConnectionError) as e:
                 exception_retries += 1
                 if exception_retries < len(retry_sleep_times):
                     logger.info('ConnectionReset/ReadTimeout caught. Sleeping {}s and then retrying...'.format(
                         retry_sleep_times[exception_retries]))
                     time.sleep(retry_sleep_times[exception_retries])
                 else:
-                    raise ResponseException(
-                        "Connection to FPDS feed lost, maximum retry attempts exceeded.", StatusCode.INTERNAL_ERROR
-                    )
+                    logger.info('Connection to FPDS feed lost, maximum retry attempts exceeded.')
+                    raise e
 
         # only list the data if there's data to list
         try:

--- a/dataactcore/scripts/pullFPDSData.py
+++ b/dataactcore/scripts/pullFPDSData.py
@@ -29,8 +29,6 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 
 from dataactcore.interfaces.db import GlobalDB
-from dataactcore.utils.statusCode import StatusCode
-from dataactcore.utils.responseException import ResponseException
 from dataactcore.models.domainModels import SubTierAgency, CountryCode, States, CountyCode, Zips
 from dataactcore.models.stagingModels import DetachedAwardProcurement
 from dataactcore.models.jobModels import FPDSUpdate
@@ -1361,7 +1359,7 @@ def get_delete_data(contract_type, now, sess, last_run, start_date=None, end_dat
             else:
                 logger.info('Connection to FPDS feed lost, maximum retry attempts exceeded.')
                 raise e
-            
+
         # only list the data if there's data to list
         try:
             listed_data = list_data(resp_data['feed']['entry'])

--- a/dataactcore/scripts/pullFPDSData.py
+++ b/dataactcore/scripts/pullFPDSData.py
@@ -1274,6 +1274,8 @@ def get_data(contract_type, award_type, now, sess, sub_tier_list, county_by_name
                 exception_retries += 1
                 # retry up to 3 times before raising an error
                 if exception_retries < len(retry_sleep_times):
+                    logger.info('ConnectionResetError caught. Sleeping {}s and then retrying...'.format(
+                        retry_sleep_times[exception_retries]))
                     time.sleep(retry_sleep_times[exception_retries])
                 else:
                     raise ResponseException(


### PR DESCRIPTION
This PR adds ReadTimeoutError and ConnectionError to the FPDS retries. Currently we were only checking for ConnectionResetError. The error I've been seeing during the nightly job for this is requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer')), which would not be caught (or retried) and therefore immediately fail in the current version of the script.