### PR TITLE
Dev 785 removing submission error warning report paths

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -291,52 +291,6 @@ Example output:
 }
 ```
 
-#### POST "/v1/submission_error_reports/"
-A call to this route should have JSON or form-urlencoded with a key of "submission_id" and value of the submission id received from the submit_files route.  The response object will be JSON with keys of "job_X_error_url" for each job X that is part of the submission, and the value will be the signed URL of the error report on S3. Note that for failed jobs (i.e. file-level errors), no error reports will be created.
-
-Example input:
-
-```json
-{
-   "submission_id":1610
-}
-```
-
-Example output:
-
-```json
-{
-  "job_3012_error_url": "https...",
-  "job_3006_error_url": "https...",
-  "job_3010_error_url": "https...",
-  "job_3008_error_url": "https...",
-  "cross_appropriations-program_activity": "https..."
-}
-```
-
-#### POST "/v1/submission_warning_reports/"
-A call to this route should have JSON or form-urlencoded with a key of "submission_id" and value of the submission id received from the submit_files route.  The response object will be JSON with keys of "job_X_warning_url" for each job X that is part of the submission, and the value will be the signed URL of the error report on S3. Note that for failed jobs (i.e. file-level errors), no error reports will be created.
-
-Example input:
-
-```json
-{
-   "submission_id":1610
-}
-```
-
-Example output:
-
-```json
-{
-  "job_3012_warning_url": "https...",
-  "job_3006_warning_url": "https...",
-  "job_3010_warning_url": "https...",
-  "job_3008_warning_url": "https...",
-  "cross_warning_appropriations-program_activity": "https..."
-}
-```
-
 #### POST "/v1/check_status/"
 A call to this route will provide status information on all jobs associated with the specified submission.
 The request should have JSON or form-urlencoded with a key "submission_id".  The response will contain a list of

--- a/dataactbroker/fileRoutes.py
+++ b/dataactbroker/fileRoutes.py
@@ -100,20 +100,6 @@ def add_file_routes(app, create_credentials, is_local, server_path):
 
         return JsonResponse.create(StatusCode.OK, {"data": data})
 
-    @app.route("/v1/submission_error_reports/", methods=["POST"])
-    @requires_login
-    @use_kwargs({'submission_id': webargs_fields.Int(required=True)})
-    def submission_error_reports(submission_id):
-        file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
-        return file_manager.get_error_report_urls_for_submission(submission_id)
-
-    @app.route("/v1/submission_warning_reports/", methods=["POST"])
-    @requires_login
-    @use_kwargs({'submission_id': webargs_fields.Int(required=True)})
-    def submission_warning_reports(submission_id):
-        file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
-        return file_manager.get_error_report_urls_for_submission(submission_id, is_warning=True)
-
     @app.route("/v1/error_metrics/", methods=["POST"])
     @convert_to_submission_id
     @requires_submission_perms('reader')

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -46,7 +46,7 @@ from dataactcore.models.views import SubmissionUpdatedView
 
 from dataactcore.utils import fileD2
 from dataactcore.utils.jsonResponse import JsonResponse
-from dataactcore.utils.report import get_cross_file_pairs, report_file_name
+from dataactcore.utils.report import report_file_name
 from dataactcore.utils.requestDictionary import RequestDictionary
 from dataactcore.utils.responseException import ResponseException
 from dataactcore.utils.statusCode import StatusCode
@@ -92,52 +92,6 @@ class FileHandler:
         self.isLocal = is_local
         self.serverPath = server_path
         self.s3manager = S3Handler()
-
-    def get_error_report_urls_for_submission(self, submission_id, is_warning=False):
-        """
-        Gets the Signed URLs for download based on the submissionId
-        """
-        sess = GlobalDB.db().session
-        try:
-            self.s3manager = S3Handler()
-            response_dict = {}
-            jobs = sess.query(Job).filter_by(submission_id=submission_id)
-            for job in jobs:
-                if job.job_type.name == 'csv_record_validation':
-                    report_name = report_file_name(
-                        job.submission_id, is_warning, job.file_type.name)
-                    if is_warning:
-                        key = 'job_{}_warning_url'.format(job.job_id)
-                    else:
-                        key = 'job_{}_error_url'.format(job.job_id)
-                    if not self.isLocal:
-                        response_dict[key] = self.s3manager.get_signed_url("errors", report_name, method="GET")
-                    else:
-                        path = os.path.join(self.serverPath, report_name)
-                        response_dict[key] = path
-
-            # For each pair of files, get url for the report
-            for c in get_cross_file_pairs():
-                first_file = c[0]
-                second_file = c[1]
-                report_name = report_file_name(
-                    submission_id, is_warning, first_file.name,
-                    second_file.name
-                )
-                if self.isLocal:
-                    report_path = os.path.join(self.serverPath, report_name)
-                else:
-                    report_path = self.s3manager.get_signed_url("errors", report_name, method="GET")
-                # Assign to key based on source and target
-                response_dict[get_cross_report_key(first_file.name, second_file.name, is_warning)] = report_path
-
-            return JsonResponse.create(StatusCode.OK, response_dict)
-
-        except ResponseException as e:
-            return JsonResponse.error(e, StatusCode.CLIENT_ERROR)
-        except Exception as e:
-            # Unexpected exception, this is a 500 server error
-            return JsonResponse.error(e, StatusCode.INTERNAL_ERROR)
 
     def submit(self, create_credentials):
         """ Builds S3 URLs for a set of files and adds all related jobs to job tracker database
@@ -1560,14 +1514,6 @@ def submission_report_url(submission, warning, file_type, cross_type):
     else:
         url = S3Handler().get_signed_url("errors", file_name, method="GET")
     return JsonResponse.create(StatusCode.OK, {"url": url})
-
-
-def get_cross_report_key(source_type, target_type, is_warning=False):
-    """ Generate a key for cross-file error reports """
-    if is_warning:
-        return "cross_warning_{}-{}".format(source_type, target_type)
-    else:
-        return "cross_{}-{}".format(source_type, target_type)
 
 
 def submission_error(submission_id, file_type):

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -461,26 +461,6 @@ class FileTests(BaseTestAPI):
             bytes_written = key.set_contents_from_filename(full_path)
             return {'bytesWritten': bytes_written, 's3FileName': s3_file_name}
 
-    def test_error_report(self):
-        """Test broker csv_validation error report."""
-        post_json = {"submission_id": self.error_report_submission_id}
-        response = self.app.post_json(
-            "/v1/submission_error_reports/", post_json, headers={"x-session-id": self.session_id})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers.get("Content-Type"), "application/json")
-        self.assertEqual(len(response.json), 14)
-        self.assertIn("cross_appropriations-program_activity", response.json)
-
-    def test_warning_reports(self):
-        """Test broker csv_validation error report."""
-        post_json = {"submission_id": self.error_report_submission_id}
-        response = self.app.post_json(
-            "/v1/submission_warning_reports/", post_json, headers={"x-session-id": self.session_id})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers.get("Content-Type"), "application/json")
-        self.assertEqual(len(response.json), 14)
-        self.assertIn("cross_warning_appropriations-program_activity", response.json)
-
     def check_metrics(self, submission_id, exists, type_file):
         """Get error metrics for specified submission."""
         post_json = {"submission_id": submission_id}


### PR DESCRIPTION
Remove all references to submission_(error/warning)_reports routes

We removed them from everything on the front end so they can get removed here

- [x] Backend review
- [x] https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/854 has been merged (or merged concurrently)