### PR TITLE
Updating A33 based on DEV-357 bug

### DIFF
--- a/dataactvalidator/config/sqlrules/a33_appropriations_1.sql
+++ b/dataactvalidator/config/sqlrules/a33_appropriations_1.sql
@@ -20,7 +20,7 @@ FROM sf_133 AS sf
             OR sf.allocation_transfer_agency = sub.cgac_code
         )
     LEFT JOIN tas_lookup
-        ON tas_lookup.tas_id = sf.tas_id
+        ON tas_lookup.account_num = sf.tas_id
 WHERE sub.submission_id = {0}
     AND NOT EXISTS (
         SELECT 1

--- a/dataactvalidator/config/sqlrules/a33_appropriations_1.sql
+++ b/dataactvalidator/config/sqlrules/a33_appropriations_1.sql
@@ -28,4 +28,4 @@ WHERE sub.submission_id = {0}
         WHERE sf.tas IS NOT DISTINCT FROM approp.tas
             AND approp.submission_id = {0}
     )
-    AND tas_lookup.financial_indicator2 IS DISTINCT FROM 'F';
+    AND COALESCE(UPPER(tas_lookup.financial_indicator2), '') <> 'F';

--- a/dataactvalidator/config/sqlrules/a33_appropriations_2.sql
+++ b/dataactvalidator/config/sqlrules/a33_appropriations_2.sql
@@ -29,7 +29,7 @@ WITH appropriation_a33_2_{0} AS
         ON tas_lookup.account_num = approp.tas_id
     WHERE submission_id = {0}
         -- In case a file a submission contains a financial account
-        AND tas_lookup.financial_indicator2 IS DISTINCT FROM 'F')
+        AND COALESCE(UPPER(tas_lookup.financial_indicator2), '') <> 'F')
 SELECT DISTINCT
     approp.row_number,
     approp.allocation_transfer_agency,

--- a/dataactvalidator/config/sqlrules/a33_appropriations_2.sql
+++ b/dataactvalidator/config/sqlrules/a33_appropriations_2.sql
@@ -3,29 +3,33 @@
 -- when all monetary amounts are zero for the TAS.
 WITH appropriation_a33_2_{0} AS 
     (SELECT row_number,
-        allocation_transfer_agency,
-        agency_identifier,
-        beginning_period_of_availa,
-        ending_period_of_availabil,
-        availability_type_code,
-        main_account_code,
-        sub_account_code,
-        submission_id,
-        tas,
-        adjustments_to_unobligated_cpe,
-        budget_authority_appropria_cpe,
-        borrowing_authority_amount_cpe,
-        contract_authority_amount_cpe,
-        spending_authority_from_of_cpe,
-        other_budgetary_resources_cpe,
-        budget_authority_available_cpe,
-        gross_outlay_amount_by_tas_cpe,
-        obligations_incurred_total_cpe,
-        deobligations_recoveries_r_cpe,
-        unobligated_balance_cpe,
-        status_of_budgetary_resour_cpe
-    FROM appropriation
-    WHERE submission_id = {0})
+        approp.allocation_transfer_agency,
+        approp.agency_identifier,
+        approp.beginning_period_of_availa,
+        approp.ending_period_of_availabil,
+        approp.availability_type_code,
+        approp.main_account_code,
+        approp.sub_account_code,
+        approp.submission_id,
+        approp.tas,
+        approp.adjustments_to_unobligated_cpe,
+        approp.budget_authority_appropria_cpe,
+        approp.borrowing_authority_amount_cpe,
+        approp.contract_authority_amount_cpe,
+        approp.spending_authority_from_of_cpe,
+        approp.other_budgetary_resources_cpe,
+        approp.budget_authority_available_cpe,
+        approp.gross_outlay_amount_by_tas_cpe,
+        approp.obligations_incurred_total_cpe,
+        approp.deobligations_recoveries_r_cpe,
+        approp.unobligated_balance_cpe,
+        approp.status_of_budgetary_resour_cpe
+    FROM appropriation as approp
+    LEFT JOIN tas_lookup
+        ON tas_lookup.account_num = approp.tas_id
+    WHERE submission_id = {0}
+        -- In case a file a submission contains a financial account
+        AND tas_lookup.financial_indicator2 IS DISTINCT FROM 'F')
 SELECT DISTINCT
     approp.row_number,
     approp.allocation_transfer_agency,

--- a/tests/unit/dataactvalidator/test_a33_appropriations_1.py
+++ b/tests/unit/dataactvalidator/test_a33_appropriations_1.py
@@ -83,7 +83,7 @@ def test_financing_tas(database):
     cars = TASFactory()
     database.session.add(cars)
     database.session.commit()
-    gtas = SF133Factory(tas_id=cars.tas_id)
+    gtas = SF133Factory(tas_id=cars.account_num)
     submission = SubmissionFactory(
         reporting_fiscal_period=gtas.period,
         reporting_fiscal_year=gtas.fiscal_year,

--- a/tests/unit/dataactvalidator/test_a33_appropriations_1.py
+++ b/tests/unit/dataactvalidator/test_a33_appropriations_1.py
@@ -80,17 +80,36 @@ def test_failure_null_ata(database):
 def test_financing_tas(database):
     """GTAS entries associated with a CARS with a "financing" financial
     indicator should be ignored"""
-    cars = TASFactory()
-    database.session.add(cars)
-    database.session.commit()
-    gtas = SF133Factory(tas_id=cars.account_num)
-    submission = SubmissionFactory(
-        reporting_fiscal_period=gtas.period,
-        reporting_fiscal_year=gtas.fiscal_year,
-        cgac_code=gtas.allocation_transfer_agency
-    )
-    errors = number_of_errors(_FILE, database, models=[gtas, cars], submission=submission)
-    assert errors == 1
+    cars_1 = TASFactory(financial_indicator2='other indicator')
+    cars_2 = TASFactory(financial_indicator2=None)
 
-    cars.financial_indicator2 = 'F'
-    assert error_rows(_FILE, database, models=[gtas, cars], submission=submission) == []
+    gtas_1 = SF133Factory(tas_id=cars_1.account_num, allocation_transfer_agency=None)
+
+    gtas_2 = SF133Factory(tas_id=cars_2.account_num, period=gtas_1.period, fiscal_year=gtas_1.fiscal_year,
+                          agency_identifier=gtas_1.agency_identifier, allocation_transfer_agency=None)
+
+    submission_1 = SubmissionFactory(
+        reporting_fiscal_period=gtas_1.period,
+        reporting_fiscal_year=gtas_1.fiscal_year,
+        cgac_code=gtas_1.agency_identifier
+    )
+
+    errors = number_of_errors(_FILE, database, models=[gtas_1, gtas_2, cars_1, cars_2], submission=submission_1)
+    assert errors == 2
+
+    cars_3 = TASFactory(financial_indicator2='f')
+    cars_4 = TASFactory(financial_indicator2='F')
+
+    gtas_3 = SF133Factory(tas_id=cars_3.account_num, allocation_transfer_agency=None)
+
+    gtas_4 = SF133Factory(tas_id=cars_4.account_num, period=gtas_3.period, fiscal_year=gtas_3.fiscal_year,
+                          agency_identifier=gtas_3.agency_identifier, allocation_transfer_agency=None)
+
+    submission_2 = SubmissionFactory(
+        reporting_fiscal_period=gtas_3.period,
+        reporting_fiscal_year=gtas_3.fiscal_year,
+        cgac_code=gtas_3.agency_identifier
+    )
+
+    errors = number_of_errors(_FILE, database, models=[gtas_3, gtas_4, cars_3, cars_4], submission=submission_2)
+    assert errors == 0

--- a/tests/unit/dataactvalidator/test_a33_appropriations_2.py
+++ b/tests/unit/dataactvalidator/test_a33_appropriations_2.py
@@ -52,11 +52,18 @@ def test_failure_with_rule_exception(database):
 def test_financial_tas_approp(database):
     """ Tests that TAS for File A are not present in SF-133
     except when a financial account (financial indicator type F)"""
-    tas_1 = TASFactory()
+    tas_1 = TASFactory(financial_indicator2='other indicator')
+    tas_2 = TASFactory(financial_indicator2=None)
 
-    ap = AppropriationFactory(tas_id=tas_1.account_num)
+    ap_1 = AppropriationFactory(tas_id=tas_1.account_num)
+    ap_2 = AppropriationFactory(tas_id=tas_2.account_num)
 
-    assert number_of_errors(_FILE, database, models=[tas_1, ap]) == 1
+    assert number_of_errors(_FILE, database, models=[tas_1, tas_2, ap_1, ap_2]) == 2
 
-    tas_1.financial_indicator2 = 'F'
-    assert number_of_errors(_FILE, database, models=[tas_1, ap]) == 0
+    tas_3 = TASFactory(financial_indicator2='F')
+    tas_4 = TASFactory(financial_indicator2='f')
+
+    ap_3 = AppropriationFactory(tas_id=tas_3.account_num)
+    ap_4 = AppropriationFactory(tas_id=tas_4.account_num)
+
+    assert number_of_errors(_FILE, database, models=[tas_3, tas_4, ap_3, ap_4]) == 0

--- a/tests/unit/dataactvalidator/test_a33_appropriations_2.py
+++ b/tests/unit/dataactvalidator/test_a33_appropriations_2.py
@@ -1,5 +1,5 @@
 from tests.unit.dataactcore.factories.staging import AppropriationFactory
-from tests.unit.dataactcore.factories.domain import SF133Factory
+from tests.unit.dataactcore.factories.domain import SF133Factory, TASFactory
 from tests.unit.dataactvalidator.utils import number_of_errors, query_columns
 
 
@@ -47,3 +47,16 @@ def test_failure_with_rule_exception(database):
                       main_account_code="000", sub_account_code="000")
 
     assert number_of_errors(_FILE, database, models=[ap1, ap2, ap3, sf]) == 2
+
+
+def test_financial_tas_approp(database):
+    """ Tests that TAS for File A are not present in SF-133
+    except when a financial account (financial indicator type F)"""
+    tas_1 = TASFactory()
+
+    ap = AppropriationFactory(tas_id=tas_1.account_num)
+
+    assert number_of_errors(_FILE, database, models=[tas_1, ap]) == 1
+
+    tas_1.financial_indicator2 = 'F'
+    assert number_of_errors(_FILE, database, models=[tas_1, ap]) == 0


### PR DESCRIPTION
[Story Link](https://federal-spending-transparency.atlassian.net/browse/DEV-357)
- Joins to the `tas_lookup table` should happen  on `account_num` field
- Add a check to make sure File A submission with financial indicator 'F' (financial accounts) are ignored
- Updated tests to include these changes