### PR TITLE
Dev 604 fabs derivation speedup

### DIFF
--- a/dataactbroker/handlers/fabsDerivationsHandler.py
+++ b/dataactbroker/handlers/fabsDerivationsHandler.py
@@ -35,7 +35,7 @@ def get_zip_data(sess, zip_five, zip_four):
 
 def derive_cfda(obj, cfda_dict, job_id, detached_award_financial_assistance_id):
     """ Deriving cfda title from cfda number using cfda program table """
-    obj['cfda_title'] = cfda_dict.get(str(obj['cfda_number']))
+    obj['cfda_title'] = cfda_dict.get(obj['cfda_number'])
     if not obj['cfda_title']:
         logger.error({
             'message': 'CFDA title not found for CFDA number {}'.format(obj['cfda_number']),

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -38,7 +38,8 @@ from dataactcore.models.lookups import (
     FILE_TYPE_DICT, FILE_TYPE_DICT_LETTER, FILE_TYPE_DICT_LETTER_ID, PUBLISH_STATUS_DICT, JOB_STATUS_DICT,
     JOB_TYPE_DICT, RULE_SEVERITY_DICT, FILE_TYPE_DICT_ID, JOB_STATUS_DICT_ID, PUBLISH_STATUS_DICT_ID,
     FILE_TYPE_DICT_LETTER_NAME)
-from dataactcore.models.stagingModels import DetachedAwardFinancialAssistance, PublishedAwardFinancialAssistance
+from dataactcore.models.stagingModels import (DetachedAwardFinancialAssistance, PublishedAwardFinancialAssistance,
+                                              FPDSContractingOffice)
 from dataactcore.models.userModel import User
 from dataactcore.models.views import SubmissionUpdatedView
 
@@ -783,6 +784,14 @@ class FileHandler:
             sub_tier_dict = {}
             cfda_dict = {}
             county_dict = {}
+            fpds_office_dict = {}
+
+            # This table is big enough that we want to only grab 2 columns
+            offices = sess.query(FPDSContractingOffice.contracting_office_code,
+                                 FPDSContractingOffice.contracting_office_name).all()
+            for office in offices:
+                fpds_office_dict[office.contracting_office_code] = office.contracting_office_name
+            del offices
 
             counties = sess.query(CountyCode).all()
             for county in counties:
@@ -834,7 +843,7 @@ class FileHandler:
                 temp_obj.pop('_sa_instance_state', None)
 
                 temp_obj = fabs_derivations(temp_obj, sess, state_dict, country_dict, sub_tier_dict, cfda_dict,
-                                            county_dict)
+                                            county_dict, fpds_office_dict)
 
                 # if it's a correction or deletion row and an old row is active, update the old row to be inactive
                 if row.correction_delete_indicatr is not None:

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -30,7 +30,7 @@ from dataactcore.interfaces.function_bag import (
     create_jobs, get_error_metrics_by_job_jd, get_error_type, get_fabs_meta, mark_job_status, run_job_checks,
     get_last_validated_date, get_lastest_certified_date)
 
-from dataactcore.models.domainModels import CGAC, FREC, SubTierAgency, States, CountryCode
+from dataactcore.models.domainModels import CGAC, FREC, SubTierAgency, States, CountryCode, CFDAProgram
 from dataactcore.models.errorModels import File
 from dataactcore.models.jobModels import (Job, Submission, SubmissionNarrative, SubmissionSubTierAffiliation,
                                           RevalidationThreshold, CertifyHistory, CertifiedFilesHistory, FileRequest)
@@ -780,6 +780,7 @@ class FileHandler:
             state_dict = {}
             country_dict = {}
             sub_tier_dict = {}
+            cfda_dict = {}
 
             states = sess.query(States).all()
             for state in states:
@@ -802,6 +803,11 @@ class FileHandler:
                 }
             del sub_tiers
 
+            cfdas = sess.query(CFDAProgram).all()
+            for cfda in cfdas:
+                cfda_dict[str(cfda.program_number)] = cfda.program_title
+            del cfdas
+
             agency_codes_list = []
             row_count = 1
             log_data['message'] = 'Starting derivations for FABS submission'
@@ -815,7 +821,7 @@ class FileHandler:
                 temp_obj.pop('updated_at', None)
                 temp_obj.pop('_sa_instance_state', None)
 
-                temp_obj = fabs_derivations(temp_obj, sess, state_dict, country_dict, sub_tier_dict)
+                temp_obj = fabs_derivations(temp_obj, sess, state_dict, country_dict, sub_tier_dict, cfda_dict)
 
                 # if it's a correction or deletion row and an old row is active, update the old row to be inactive
                 if row.correction_delete_indicatr is not None:

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -30,7 +30,7 @@ from dataactcore.interfaces.function_bag import (
     create_jobs, get_error_metrics_by_job_jd, get_error_type, get_fabs_meta, mark_job_status, run_job_checks,
     get_last_validated_date, get_lastest_certified_date)
 
-from dataactcore.models.domainModels import CGAC, FREC, SubTierAgency, States
+from dataactcore.models.domainModels import CGAC, FREC, SubTierAgency, States, CountryCode
 from dataactcore.models.errorModels import File
 from dataactcore.models.jobModels import (Job, Submission, SubmissionNarrative, SubmissionSubTierAffiliation,
                                           RevalidationThreshold, CertifyHistory, CertifiedFilesHistory, FileRequest)
@@ -777,11 +777,18 @@ class FileHandler:
                 filter_by(is_valid=True, submission_id=submission_id).all()
 
             # Create lookup dictionaries so we don't have to query the API every time.
-            states = sess.query(States).all()
             state_dict = {}
+            country_dict = {}
+
+            states = sess.query(States).all()
             for state in states:
                 state_dict[state.state_code.upper()] = state.state_name
             del states
+
+            countries = sess.query(CountryCode).all()
+            for country in countries:
+                country_dict[country.country_code.upper()] = country.state_name
+            del countries
 
             agency_codes_list = []
             row_count = 1
@@ -796,7 +803,7 @@ class FileHandler:
                 temp_obj.pop('updated_at', None)
                 temp_obj.pop('_sa_instance_state', None)
 
-                temp_obj = fabs_derivations(temp_obj, sess, state_dict)
+                temp_obj = fabs_derivations(temp_obj, sess, state_dict, country_dict)
 
                 # if it's a correction or deletion row and an old row is active, update the old row to be inactive
                 if row.correction_delete_indicatr is not None:

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -805,7 +805,9 @@ class FileHandler:
 
             cfdas = sess.query(CFDAProgram).all()
             for cfda in cfdas:
-                cfda_dict[str(cfda.program_number)] = cfda.program_title
+                # This is so the key is always "##.###", which is what's required based on the SQL
+                # Could also be "###.###" which this will still pad correctly
+                cfda_dict["%06.3f"%cfda.program_number] = cfda.program_title
             del cfdas
 
             agency_codes_list = []

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -788,7 +788,7 @@ class FileHandler:
 
             countries = sess.query(CountryCode).all()
             for country in countries:
-                country_dict[country.country_code.upper()] = country.state_name
+                country_dict[country.country_code.upper()] = country.country_name
             del countries
 
             sub_tiers = sess.query(SubTierAgency).all()

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -30,7 +30,7 @@ from dataactcore.interfaces.function_bag import (
     create_jobs, get_error_metrics_by_job_jd, get_error_type, get_fabs_meta, mark_job_status, run_job_checks,
     get_last_validated_date, get_lastest_certified_date)
 
-from dataactcore.models.domainModels import CGAC, FREC, SubTierAgency
+from dataactcore.models.domainModels import CGAC, FREC, SubTierAgency, States
 from dataactcore.models.errorModels import File
 from dataactcore.models.jobModels import (Job, Submission, SubmissionNarrative, SubmissionSubTierAffiliation,
                                           RevalidationThreshold, CertifyHistory, CertifiedFilesHistory, FileRequest)
@@ -822,6 +822,13 @@ class FileHandler:
             query = sess.query(DetachedAwardFinancialAssistance).\
                 filter_by(is_valid=True, submission_id=submission_id).all()
 
+            # Create lookup dictionaries so we don't have to query the API every time.
+            states = sess.query(States).all()
+            state_dict = {}
+            for state in states:
+                state_dict[state.state_code.upper()] = state.state_name
+            del states
+
             agency_codes_list = []
             row_count = 1
             log_data['message'] = 'Starting derivations for FABS submission'
@@ -835,7 +842,7 @@ class FileHandler:
                 temp_obj.pop('updated_at', None)
                 temp_obj.pop('_sa_instance_state', None)
 
-                temp_obj = fabs_derivations(temp_obj, sess)
+                temp_obj = fabs_derivations(temp_obj, sess, state_dict)
 
                 # if it's a correction or deletion row and an old row is active, update the old row to be inactive
                 if row.correction_delete_indicatr is not None:

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -779,6 +779,7 @@ class FileHandler:
             # Create lookup dictionaries so we don't have to query the API every time.
             state_dict = {}
             country_dict = {}
+            sub_tier_dict = {}
 
             states = sess.query(States).all()
             for state in states:
@@ -789,6 +790,17 @@ class FileHandler:
             for country in countries:
                 country_dict[country.country_code.upper()] = country.state_name
             del countries
+
+            sub_tiers = sess.query(SubTierAgency).all()
+            for sub_tier in sub_tiers:
+                sub_tier_dict[sub_tier.sub_tier_agency_code] = {
+                    "is_frec": sub_tier.is_frec,
+                    "cgac_code": sub_tier.cgac.cgac_code,
+                    "frec_code": sub_tier.frec.frec_code,
+                    "sub_tier_agency_name": sub_tier.sub_tier_agency_name,
+                    "agency_name": sub_tier.frec.agency_name if sub_tier.is_frec else sub_tier.cgac.agency_name
+                }
+            del sub_tiers
 
             agency_codes_list = []
             row_count = 1
@@ -803,7 +815,7 @@ class FileHandler:
                 temp_obj.pop('updated_at', None)
                 temp_obj.pop('_sa_instance_state', None)
 
-                temp_obj = fabs_derivations(temp_obj, sess, state_dict, country_dict)
+                temp_obj = fabs_derivations(temp_obj, sess, state_dict, country_dict, sub_tier_dict)
 
                 # if it's a correction or deletion row and an old row is active, update the old row to be inactive
                 if row.correction_delete_indicatr is not None:

--- a/tests/unit/dataactbroker/test_fabs_derivations.py
+++ b/tests/unit/dataactbroker/test_fabs_derivations.py
@@ -3,10 +3,12 @@ from dataactcore.models.lookups import (ACTION_TYPE_DICT, ASSISTANCE_TYPE_DICT, 
                                         RECORD_TYPE_DICT, BUSINESS_TYPE_DICT, BUSINESS_FUNDS_IND_DICT)
 
 from tests.unit.dataactcore.factories.domain import (
-    CGACFactory, FRECFactory, SubTierAgencyFactory, StatesFactory, CountyCodeFactory, CFDAProgramFactory,
-    ZipCityFactory, ZipsFactory, CityCodeFactory, CountryCodeFactory, DunsFactory)
+    CGACFactory, FRECFactory, SubTierAgencyFactory, CountyCodeFactory, CFDAProgramFactory, ZipCityFactory, ZipsFactory,
+    CityCodeFactory, CountryCodeFactory, DunsFactory)
 
 from tests.unit.dataactcore.factories.staging import FPDSContractingOfficeFactory
+
+STATE_DICT = {'NY': "New York"}
 
 
 def initialize_db_values(db, cfda_title=None, cgac_code=None, frec_code=None, use_frec=False):
@@ -25,29 +27,28 @@ def initialize_db_values(db, cfda_title=None, cgac_code=None, frec_code=None, us
     cfda_number = CFDAProgramFactory(program_number=12.345, program_title=cfda_title)
     sub_tier = SubTierAgencyFactory(sub_tier_agency_code="1234", cgac=cgac, frec=frec, is_frec=use_frec,
                                     sub_tier_agency_name="Test Subtier Agency")
-    state = StatesFactory(state_code="NY", state_name="New York")
-    zip_code_1 = ZipsFactory(zip5="12345", zip_last4="6789", state_abbreviation=state.state_code, county_number="001",
+    zip_code_1 = ZipsFactory(zip5="12345", zip_last4="6789", state_abbreviation="NY", county_number="001",
                              congressional_district_no="01")
-    zip_code_2 = ZipsFactory(zip5="12345", zip_last4="4321", state_abbreviation=state.state_code, county_number="001",
+    zip_code_2 = ZipsFactory(zip5="12345", zip_last4="4321", state_abbreviation="NY", county_number="001",
                              congressional_district_no="02")
-    zip_code_3 = ZipsFactory(zip5="54321", zip_last4="4321", state_abbreviation=state.state_code, county_number="001",
+    zip_code_3 = ZipsFactory(zip5="54321", zip_last4="4321", state_abbreviation="NY", county_number="001",
                              congressional_district_no="05")
-    zip_code_4 = ZipsFactory(zip5="98765", zip_last4="4321", state_abbreviation=state.state_code, county_number="001",
+    zip_code_4 = ZipsFactory(zip5="98765", zip_last4="4321", state_abbreviation="NY", county_number="001",
                              congressional_district_no=None)
     zip_city = ZipCityFactory(zip_code=zip_code_1.zip5, city_name="Test Zip City")
     zip_city_2 = ZipCityFactory(zip_code=zip_code_3.zip5, city_name="Test Zip City 2")
     zip_city_3 = ZipCityFactory(zip_code=zip_code_4.zip5, city_name="Test Zip City 3")
-    county_code = CountyCodeFactory(state_code=state.state_code, county_number=zip_code_1.county_number,
+    county_code = CountyCodeFactory(state_code="NY", county_number=zip_code_1.county_number,
                                     county_name="Test County")
-    city_code = CityCodeFactory(feature_name="Test City", city_code="00001", state_code=state.state_code,
+    city_code = CityCodeFactory(feature_name="Test City", city_code="00001", state_code="NY",
                                 county_number=zip_code_1.county_number, county_name="Test City County")
     contracting_office = FPDSContractingOfficeFactory(contracting_office_code='033103',
                                                       contracting_office_name='Office')
     country_code = CountryCodeFactory(country_code='USA', country_name='United States of America')
     duns = DunsFactory(awardee_or_recipient_uniqu='123456789', ultimate_parent_unique_ide='234567890',
                        ultimate_parent_legal_enti='Parent 1')
-    db.session.add_all([sub_tier, state, cfda_number, zip_code_1, zip_code_2, zip_code_3, zip_code_4, zip_city,
-                        zip_city_2, zip_city_3, county_code, city_code, contracting_office, country_code, duns])
+    db.session.add_all([sub_tier, cfda_number, zip_code_1, zip_code_2, zip_code_3, zip_code_4, zip_city, zip_city_2,
+                        zip_city_3, county_code, city_code, contracting_office, country_code, duns])
     db.session.commit()
 
 
@@ -100,17 +101,17 @@ def test_total_funding_amount(database):
 
     # when fao and nffa are empty
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['total_funding_amount'] == 0
 
     # when one of fao and nffa is empty and the other isn't
     obj = initialize_test_obj(fao=5.3)
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['total_funding_amount'] == 5.3
 
     # when fao and nffa aren't empty
     obj = initialize_test_obj(fao=-10.6, nffa=123)
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['total_funding_amount'] == 112.4
 
 
@@ -119,12 +120,12 @@ def test_cfda_title(database):
 
     # when cfda_number isn't in the database
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['cfda_title'] is None
 
     # when cfda_number is in the database
     obj = initialize_test_obj(cfda_num="12.345")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['cfda_title'] == "Test Title"
 
 
@@ -132,7 +133,7 @@ def test_awarding_agency_cgac(database):
     initialize_db_values(database, cgac_code="000", frec_code="1111")
 
     obj = initialize_test_obj(sub_tier_code="1234")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['awarding_agency_code'] == "000"
     assert obj['awarding_agency_name'] == "Test CGAC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Subtier Agency"
@@ -142,7 +143,7 @@ def test_awarding_agency_frec(database):
     initialize_db_values(database, cgac_code="000", frec_code="1111", use_frec=True)
 
     obj = initialize_test_obj(sub_tier_code="1234")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['awarding_agency_code'] == "1111"
     assert obj['awarding_agency_name'] == "Test FREC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Subtier Agency"
@@ -153,14 +154,14 @@ def test_funding_sub_tier_agency_na(database):
 
     # when funding_sub_tier_agency_co is not provided
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['funding_sub_tier_agency_na'] is None
     assert obj['funding_agency_code'] is None
     assert obj['funding_agency_name'] is None
 
     # when funding_sub_tier_agency_co is provided
     obj = initialize_test_obj(sub_fund_agency_code="1234")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['funding_sub_tier_agency_na'] == "Test Subtier Agency"
     assert obj['funding_agency_code'] == '5678'
     assert obj['funding_agency_name'] == 'Test CGAC Agency'
@@ -170,17 +171,17 @@ def test_ppop_state(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_perfor_state_code'] == 'NY'
     assert obj['place_of_perform_state_nam'] == "New York"
 
     obj = initialize_test_obj(ppop_code="00*****")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] == "Multi-state"
 
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] is None
 
@@ -190,7 +191,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and no congressional district
     obj = initialize_test_obj(ppop_zip4a="123454321")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_performance_congr'] == '02'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -198,12 +199,12 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and has congressional district
     obj = initialize_test_obj(ppop_zip4a="12345-4321", ppop_cd="03")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_performance_congr'] == '03'
 
     # when ppop_zip4a is 5 digits
     obj = initialize_test_obj(ppop_zip4a="12345")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     # cd should be 90 if there's more than one option
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
@@ -212,7 +213,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits but last 4 are invalid (one cd available)
     obj = initialize_test_obj(ppop_zip4a="543210000")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_performance_congr'] == '05'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -220,7 +221,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits (no cd available)
     obj = initialize_test_obj(ppop_zip4a="987654321")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -228,7 +229,7 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX**### format
     obj = initialize_test_obj(ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
     assert obj['place_of_performance_city'] is None
@@ -236,7 +237,7 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX##### format
     obj = initialize_test_obj(ppop_code="NY00001")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test City County"
     assert obj['place_of_performance_city'] == "Test City"
@@ -244,7 +245,7 @@ def test_ppop_derivations(database):
 
     # when we don't have a ppop_code at all
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_perform_county_co'] is None
     assert obj['place_of_perform_county_na'] is None
     assert obj['place_of_performance_city'] is None
@@ -257,7 +258,7 @@ def test_legal_entity_derivations(database):
     # if there is a legal_entity_zip5, record_type is always 2 or 3
     # when we have legal_entity_zip5 and zip4
     obj = initialize_test_obj(le_zip5="12345", le_zip4="6789")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     assert obj['legal_entity_congressional'] == "01"
     assert obj['legal_entity_county_code'] == "001"
@@ -267,7 +268,7 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 but no zip4
     obj = initialize_test_obj(le_zip5="12345")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     # there are multiple options so this should be 90
     assert obj['legal_entity_congressional'] == "90"
@@ -278,12 +279,12 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 and congressional but no zip4
     obj = initialize_test_obj(le_zip5="12345", legal_congr="95")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['legal_entity_congressional'] == "95"
 
     # if there is no legal_entity_zip5 and record_type is 1, ppop_code is always in format XX**###
     obj = initialize_test_obj(record_type=1, ppop_cd="03", ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] == "03"
     assert obj['legal_entity_county_code'] == "001"
@@ -293,7 +294,7 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format XX*****
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="NY*****")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -303,7 +304,7 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format 00FORGN
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="00FORGN")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -317,11 +318,11 @@ def test_primary_place_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(primary_place_country='USA')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_perform_country_n'] == 'United States of America'
 
     obj = initialize_test_obj(primary_place_country='NK')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_perform_country_n'] is None
 
 
@@ -330,11 +331,11 @@ def test_awarding_office_codes(database):
 
     # if awarding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['awarding_office_name'] == 'Office'
 
     obj = initialize_test_obj(awarding_office='111111')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['awarding_office_name'] is None
 
 
@@ -343,11 +344,11 @@ def test_funding_office_codes(database):
 
     # if funding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['funding_office_name'] == 'Office'
 
     obj = initialize_test_obj(funding_office='111111')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['funding_office_name'] is None
 
 
@@ -356,11 +357,11 @@ def test_legal_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(legal_country='USA')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['legal_entity_country_name'] == 'United States of America'
 
     obj = initialize_test_obj(legal_country='NK')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['legal_entity_country_name'] is None
 
 
@@ -369,31 +370,31 @@ def test_split_zip(database):
 
     # testing with 5-digit
     obj = initialize_test_obj(ppop_zip4a='12345')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing with 9-digit
     obj = initialize_test_obj(ppop_zip4a='123456789')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with 9-digit and dash
     obj = initialize_test_obj(ppop_zip4a='12345-6789')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with city-wide
     obj = initialize_test_obj(ppop_zip4a='city-wide')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing without ppop_zip4
     obj = initialize_test_obj(ppop_zip4a='')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
@@ -402,7 +403,7 @@ def test_derive_parent_duns(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456789')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
 
     assert obj['ultimate_parent_legal_enti'] == 'Parent 1'
     assert obj['ultimate_parent_unique_ide'] == '234567890'
@@ -412,7 +413,7 @@ def test_derive_parent_duns_return_none(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
 
     assert not obj['ultimate_parent_legal_enti']
     assert not obj['ultimate_parent_unique_ide']
@@ -423,7 +424,7 @@ def test_derive_labels(database):
 
     # Testing when these values are blank
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -432,7 +433,7 @@ def test_derive_labels(database):
 
     # Testing for valid values of each
     obj = initialize_test_obj(cdi='c', action_type='a', assist_type='02', busi_type='d', busi_fund='non')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['action_type_description'] == ACTION_TYPE_DICT['A']
     assert obj['assistance_type_desc'] == ASSISTANCE_TYPE_DICT['02']
     assert obj['correction_delete_ind_desc'] == CORRECTION_DELETE_IND_DICT['C']
@@ -442,7 +443,7 @@ def test_derive_labels(database):
 
     # Testing for invalid values of each
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='Z', busi_fund='ab')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -452,7 +453,7 @@ def test_derive_labels(database):
 
     # Test multiple business types (2 valid, one invalid)
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='azb')
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['business_types_desc'] == BUSINESS_TYPE_DICT['A'] + ';' + BUSINESS_TYPE_DICT['B']
 
 
@@ -461,15 +462,15 @@ def test_is_active(database):
 
     # Testing with none values
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['is_active'] is True
 
     # Testing with value other than D
     obj = initialize_test_obj(cdi="c")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['is_active'] is True
 
     # Testing with D
     obj = initialize_test_obj(cdi="D")
-    obj = fabs_derivations(obj, database.session)
+    obj = fabs_derivations(obj, database.session, STATE_DICT)
     assert obj['is_active'] is False

--- a/tests/unit/dataactbroker/test_fabs_derivations.py
+++ b/tests/unit/dataactbroker/test_fabs_derivations.py
@@ -4,8 +4,6 @@ from dataactcore.models.lookups import (ACTION_TYPE_DICT, ASSISTANCE_TYPE_DICT, 
 
 from tests.unit.dataactcore.factories.domain import ZipCityFactory, ZipsFactory, CityCodeFactory, DunsFactory
 
-from tests.unit.dataactcore.factories.staging import FPDSContractingOfficeFactory
-
 STATE_DICT = {"NY": "New York"}
 COUNTRY_DICT = {"USA": "United States of America"}
 SUB_TIER_DICT = {
@@ -26,6 +24,7 @@ SUB_TIER_DICT = {
 }
 CFDA_DICT = {"12.345": "CFDA Title"}
 COUNTY_DICT = {"NY001": "Test County"}
+FPDS_OFFICE_DICT = {"033103": "Office"}
 
 
 def initialize_db_values(db):
@@ -43,12 +42,10 @@ def initialize_db_values(db):
     zip_city_3 = ZipCityFactory(zip_code=zip_code_4.zip5, city_name="Test Zip City 3")
     city_code = CityCodeFactory(feature_name="Test City", city_code="00001", state_code="NY",
                                 county_number=zip_code_1.county_number, county_name="Test City County")
-    contracting_office = FPDSContractingOfficeFactory(contracting_office_code='033103',
-                                                      contracting_office_name='Office')
     duns = DunsFactory(awardee_or_recipient_uniqu='123456789', ultimate_parent_unique_ide='234567890',
                        ultimate_parent_legal_enti='Parent 1')
     db.session.add_all([zip_code_1, zip_code_2, zip_code_3, zip_code_4, zip_city, zip_city_2, zip_city_3, city_code,
-                        contracting_office, duns])
+                        duns])
     db.session.commit()
 
 
@@ -99,17 +96,20 @@ def test_total_funding_amount(database):
 
     # when fao and nffa are empty
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['total_funding_amount'] == 0
 
     # when one of fao and nffa is empty and the other isn't
     obj = initialize_test_obj(fao=5.3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['total_funding_amount'] == 5.3
 
     # when fao and nffa aren't empty
     obj = initialize_test_obj(fao=-10.6, nffa=123)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['total_funding_amount'] == 112.4
 
 
@@ -118,12 +118,14 @@ def test_cfda_title(database):
 
     # when cfda_number isn't in the database
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['cfda_title'] is None
 
     # when cfda_number is in the database
     obj = initialize_test_obj(cfda_num="12.345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['cfda_title'] == "CFDA Title"
 
 
@@ -131,7 +133,8 @@ def test_awarding_agency_cgac(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj(sub_tier_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['awarding_agency_code'] == "000"
     assert obj['awarding_agency_name'] == "Test CGAC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Subtier Agency"
@@ -141,7 +144,8 @@ def test_awarding_agency_frec(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj(sub_tier_code="4321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['awarding_agency_code'] == "1111"
     assert obj['awarding_agency_name'] == "Test FREC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Frec Subtier Agency"
@@ -152,14 +156,16 @@ def test_funding_sub_tier_agency_na(database):
 
     # when funding_sub_tier_agency_co is not provided
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['funding_sub_tier_agency_na'] is None
     assert obj['funding_agency_code'] is None
     assert obj['funding_agency_name'] is None
 
     # when funding_sub_tier_agency_co is provided
     obj = initialize_test_obj(sub_fund_agency_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['funding_sub_tier_agency_na'] == "Test Subtier Agency"
     assert obj['funding_agency_code'] == '000'
     assert obj['funding_agency_name'] == 'Test CGAC Agency'
@@ -169,17 +175,20 @@ def test_ppop_state(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_perfor_state_code'] == 'NY'
     assert obj['place_of_perform_state_nam'] == "New York"
 
     obj = initialize_test_obj(ppop_code="00*****")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] == "Multi-state"
 
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] is None
 
@@ -189,7 +198,8 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and no congressional district
     obj = initialize_test_obj(ppop_zip4a="123454321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_performance_congr'] == '02'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -197,12 +207,14 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and has congressional district
     obj = initialize_test_obj(ppop_zip4a="12345-4321", ppop_cd="03")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_performance_congr'] == '03'
 
     # when ppop_zip4a is 5 digits
     obj = initialize_test_obj(ppop_zip4a="12345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     # cd should be 90 if there's more than one option
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
@@ -211,7 +223,8 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits but last 4 are invalid (one cd available)
     obj = initialize_test_obj(ppop_zip4a="543210000")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_performance_congr'] == '05'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -219,7 +232,8 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits (no cd available)
     obj = initialize_test_obj(ppop_zip4a="987654321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -227,7 +241,8 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX**### format
     obj = initialize_test_obj(ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
     assert obj['place_of_performance_city'] is None
@@ -235,7 +250,8 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX##### format
     obj = initialize_test_obj(ppop_code="NY00001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test City County"
     assert obj['place_of_performance_city'] == "Test City"
@@ -243,7 +259,8 @@ def test_ppop_derivations(database):
 
     # when we don't have a ppop_code at all
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_perform_county_co'] is None
     assert obj['place_of_perform_county_na'] is None
     assert obj['place_of_performance_city'] is None
@@ -256,7 +273,8 @@ def test_legal_entity_derivations(database):
     # if there is a legal_entity_zip5, record_type is always 2 or 3
     # when we have legal_entity_zip5 and zip4
     obj = initialize_test_obj(le_zip5="12345", le_zip4="6789")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     assert obj['legal_entity_congressional'] == "01"
     assert obj['legal_entity_county_code'] == "001"
@@ -266,7 +284,8 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 but no zip4
     obj = initialize_test_obj(le_zip5="12345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     # there are multiple options so this should be 90
     assert obj['legal_entity_congressional'] == "90"
@@ -277,12 +296,14 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 and congressional but no zip4
     obj = initialize_test_obj(le_zip5="12345", legal_congr="95")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['legal_entity_congressional'] == "95"
 
     # if there is no legal_entity_zip5 and record_type is 1, ppop_code is always in format XX**###
     obj = initialize_test_obj(record_type=1, ppop_cd="03", ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] == "03"
     assert obj['legal_entity_county_code'] == "001"
@@ -292,7 +313,8 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format XX*****
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="NY*****")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -302,7 +324,8 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format 00FORGN
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="00FORGN")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -316,11 +339,13 @@ def test_primary_place_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(primary_place_country='USA')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_perform_country_n'] == 'United States of America'
 
     obj = initialize_test_obj(primary_place_country='NK')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_perform_country_n'] is None
 
 
@@ -329,11 +354,13 @@ def test_awarding_office_codes(database):
 
     # if awarding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['awarding_office_name'] == 'Office'
 
     obj = initialize_test_obj(awarding_office='111111')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['awarding_office_name'] is None
 
 
@@ -342,11 +369,13 @@ def test_funding_office_codes(database):
 
     # if funding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['funding_office_name'] == 'Office'
 
     obj = initialize_test_obj(funding_office='111111')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['funding_office_name'] is None
 
 
@@ -355,11 +384,13 @@ def test_legal_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(legal_country='USA')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['legal_entity_country_name'] == 'United States of America'
 
     obj = initialize_test_obj(legal_country='NK')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['legal_entity_country_name'] is None
 
 
@@ -368,31 +399,36 @@ def test_split_zip(database):
 
     # testing with 5-digit
     obj = initialize_test_obj(ppop_zip4a='12345')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing with 9-digit
     obj = initialize_test_obj(ppop_zip4a='123456789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with 9-digit and dash
     obj = initialize_test_obj(ppop_zip4a='12345-6789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with city-wide
     obj = initialize_test_obj(ppop_zip4a='city-wide')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing without ppop_zip4
     obj = initialize_test_obj(ppop_zip4a='')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
@@ -401,7 +437,8 @@ def test_derive_parent_duns(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
 
     assert obj['ultimate_parent_legal_enti'] == 'Parent 1'
     assert obj['ultimate_parent_unique_ide'] == '234567890'
@@ -411,7 +448,8 @@ def test_derive_parent_duns_return_none(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
 
     assert not obj['ultimate_parent_legal_enti']
     assert not obj['ultimate_parent_unique_ide']
@@ -422,7 +460,8 @@ def test_derive_labels(database):
 
     # Testing when these values are blank
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -431,7 +470,8 @@ def test_derive_labels(database):
 
     # Testing for valid values of each
     obj = initialize_test_obj(cdi='c', action_type='a', assist_type='02', busi_type='d', busi_fund='non')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['action_type_description'] == ACTION_TYPE_DICT['A']
     assert obj['assistance_type_desc'] == ASSISTANCE_TYPE_DICT['02']
     assert obj['correction_delete_ind_desc'] == CORRECTION_DELETE_IND_DICT['C']
@@ -441,7 +481,8 @@ def test_derive_labels(database):
 
     # Testing for invalid values of each
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='Z', busi_fund='ab')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -451,7 +492,8 @@ def test_derive_labels(database):
 
     # Test multiple business types (2 valid, one invalid)
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='azb')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['business_types_desc'] == BUSINESS_TYPE_DICT['A'] + ';' + BUSINESS_TYPE_DICT['B']
 
 
@@ -460,15 +502,18 @@ def test_is_active(database):
 
     # Testing with none values
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['is_active'] is True
 
     # Testing with value other than D
     obj = initialize_test_obj(cdi="c")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['is_active'] is True
 
     # Testing with D
     obj = initialize_test_obj(cdi="D")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT,
+                           FPDS_OFFICE_DICT)
     assert obj['is_active'] is False

--- a/tests/unit/dataactbroker/test_fabs_derivations.py
+++ b/tests/unit/dataactbroker/test_fabs_derivations.py
@@ -4,11 +4,12 @@ from dataactcore.models.lookups import (ACTION_TYPE_DICT, ASSISTANCE_TYPE_DICT, 
 
 from tests.unit.dataactcore.factories.domain import (
     CGACFactory, FRECFactory, SubTierAgencyFactory, CountyCodeFactory, CFDAProgramFactory, ZipCityFactory, ZipsFactory,
-    CityCodeFactory, CountryCodeFactory, DunsFactory)
+    CityCodeFactory, DunsFactory)
 
 from tests.unit.dataactcore.factories.staging import FPDSContractingOfficeFactory
 
-STATE_DICT = {'NY': "New York"}
+STATE_DICT = {"NY": "New York"}
+COUNTRY_DICT = {"USA": "United States of America"}
 
 
 def initialize_db_values(db, cfda_title=None, cgac_code=None, frec_code=None, use_frec=False):
@@ -44,11 +45,10 @@ def initialize_db_values(db, cfda_title=None, cgac_code=None, frec_code=None, us
                                 county_number=zip_code_1.county_number, county_name="Test City County")
     contracting_office = FPDSContractingOfficeFactory(contracting_office_code='033103',
                                                       contracting_office_name='Office')
-    country_code = CountryCodeFactory(country_code='USA', country_name='United States of America')
     duns = DunsFactory(awardee_or_recipient_uniqu='123456789', ultimate_parent_unique_ide='234567890',
                        ultimate_parent_legal_enti='Parent 1')
     db.session.add_all([sub_tier, cfda_number, zip_code_1, zip_code_2, zip_code_3, zip_code_4, zip_city, zip_city_2,
-                        zip_city_3, county_code, city_code, contracting_office, country_code, duns])
+                        zip_city_3, county_code, city_code, contracting_office, duns])
     db.session.commit()
 
 
@@ -101,17 +101,17 @@ def test_total_funding_amount(database):
 
     # when fao and nffa are empty
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['total_funding_amount'] == 0
 
     # when one of fao and nffa is empty and the other isn't
     obj = initialize_test_obj(fao=5.3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['total_funding_amount'] == 5.3
 
     # when fao and nffa aren't empty
     obj = initialize_test_obj(fao=-10.6, nffa=123)
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['total_funding_amount'] == 112.4
 
 
@@ -120,12 +120,12 @@ def test_cfda_title(database):
 
     # when cfda_number isn't in the database
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['cfda_title'] is None
 
     # when cfda_number is in the database
     obj = initialize_test_obj(cfda_num="12.345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['cfda_title'] == "Test Title"
 
 
@@ -133,7 +133,7 @@ def test_awarding_agency_cgac(database):
     initialize_db_values(database, cgac_code="000", frec_code="1111")
 
     obj = initialize_test_obj(sub_tier_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['awarding_agency_code'] == "000"
     assert obj['awarding_agency_name'] == "Test CGAC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Subtier Agency"
@@ -143,7 +143,7 @@ def test_awarding_agency_frec(database):
     initialize_db_values(database, cgac_code="000", frec_code="1111", use_frec=True)
 
     obj = initialize_test_obj(sub_tier_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['awarding_agency_code'] == "1111"
     assert obj['awarding_agency_name'] == "Test FREC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Subtier Agency"
@@ -154,14 +154,14 @@ def test_funding_sub_tier_agency_na(database):
 
     # when funding_sub_tier_agency_co is not provided
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['funding_sub_tier_agency_na'] is None
     assert obj['funding_agency_code'] is None
     assert obj['funding_agency_name'] is None
 
     # when funding_sub_tier_agency_co is provided
     obj = initialize_test_obj(sub_fund_agency_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['funding_sub_tier_agency_na'] == "Test Subtier Agency"
     assert obj['funding_agency_code'] == '5678'
     assert obj['funding_agency_name'] == 'Test CGAC Agency'
@@ -171,17 +171,17 @@ def test_ppop_state(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_perfor_state_code'] == 'NY'
     assert obj['place_of_perform_state_nam'] == "New York"
 
     obj = initialize_test_obj(ppop_code="00*****")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] == "Multi-state"
 
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] is None
 
@@ -191,7 +191,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and no congressional district
     obj = initialize_test_obj(ppop_zip4a="123454321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_performance_congr'] == '02'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -199,12 +199,12 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and has congressional district
     obj = initialize_test_obj(ppop_zip4a="12345-4321", ppop_cd="03")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_performance_congr'] == '03'
 
     # when ppop_zip4a is 5 digits
     obj = initialize_test_obj(ppop_zip4a="12345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     # cd should be 90 if there's more than one option
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
@@ -213,7 +213,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits but last 4 are invalid (one cd available)
     obj = initialize_test_obj(ppop_zip4a="543210000")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_performance_congr'] == '05'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -221,7 +221,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits (no cd available)
     obj = initialize_test_obj(ppop_zip4a="987654321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -229,7 +229,7 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX**### format
     obj = initialize_test_obj(ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
     assert obj['place_of_performance_city'] is None
@@ -237,7 +237,7 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX##### format
     obj = initialize_test_obj(ppop_code="NY00001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test City County"
     assert obj['place_of_performance_city'] == "Test City"
@@ -245,7 +245,7 @@ def test_ppop_derivations(database):
 
     # when we don't have a ppop_code at all
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_perform_county_co'] is None
     assert obj['place_of_perform_county_na'] is None
     assert obj['place_of_performance_city'] is None
@@ -258,7 +258,7 @@ def test_legal_entity_derivations(database):
     # if there is a legal_entity_zip5, record_type is always 2 or 3
     # when we have legal_entity_zip5 and zip4
     obj = initialize_test_obj(le_zip5="12345", le_zip4="6789")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     assert obj['legal_entity_congressional'] == "01"
     assert obj['legal_entity_county_code'] == "001"
@@ -268,7 +268,7 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 but no zip4
     obj = initialize_test_obj(le_zip5="12345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     # there are multiple options so this should be 90
     assert obj['legal_entity_congressional'] == "90"
@@ -279,12 +279,12 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 and congressional but no zip4
     obj = initialize_test_obj(le_zip5="12345", legal_congr="95")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['legal_entity_congressional'] == "95"
 
     # if there is no legal_entity_zip5 and record_type is 1, ppop_code is always in format XX**###
     obj = initialize_test_obj(record_type=1, ppop_cd="03", ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] == "03"
     assert obj['legal_entity_county_code'] == "001"
@@ -294,7 +294,7 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format XX*****
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="NY*****")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -304,7 +304,7 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format 00FORGN
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="00FORGN")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -318,11 +318,11 @@ def test_primary_place_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(primary_place_country='USA')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_perform_country_n'] == 'United States of America'
 
     obj = initialize_test_obj(primary_place_country='NK')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_perform_country_n'] is None
 
 
@@ -331,11 +331,11 @@ def test_awarding_office_codes(database):
 
     # if awarding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['awarding_office_name'] == 'Office'
 
     obj = initialize_test_obj(awarding_office='111111')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['awarding_office_name'] is None
 
 
@@ -344,11 +344,11 @@ def test_funding_office_codes(database):
 
     # if funding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['funding_office_name'] == 'Office'
 
     obj = initialize_test_obj(funding_office='111111')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['funding_office_name'] is None
 
 
@@ -357,11 +357,11 @@ def test_legal_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(legal_country='USA')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['legal_entity_country_name'] == 'United States of America'
 
     obj = initialize_test_obj(legal_country='NK')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['legal_entity_country_name'] is None
 
 
@@ -370,31 +370,31 @@ def test_split_zip(database):
 
     # testing with 5-digit
     obj = initialize_test_obj(ppop_zip4a='12345')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing with 9-digit
     obj = initialize_test_obj(ppop_zip4a='123456789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with 9-digit and dash
     obj = initialize_test_obj(ppop_zip4a='12345-6789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with city-wide
     obj = initialize_test_obj(ppop_zip4a='city-wide')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing without ppop_zip4
     obj = initialize_test_obj(ppop_zip4a='')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
@@ -403,7 +403,7 @@ def test_derive_parent_duns(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
 
     assert obj['ultimate_parent_legal_enti'] == 'Parent 1'
     assert obj['ultimate_parent_unique_ide'] == '234567890'
@@ -413,7 +413,7 @@ def test_derive_parent_duns_return_none(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
 
     assert not obj['ultimate_parent_legal_enti']
     assert not obj['ultimate_parent_unique_ide']
@@ -424,7 +424,7 @@ def test_derive_labels(database):
 
     # Testing when these values are blank
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -433,7 +433,7 @@ def test_derive_labels(database):
 
     # Testing for valid values of each
     obj = initialize_test_obj(cdi='c', action_type='a', assist_type='02', busi_type='d', busi_fund='non')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['action_type_description'] == ACTION_TYPE_DICT['A']
     assert obj['assistance_type_desc'] == ASSISTANCE_TYPE_DICT['02']
     assert obj['correction_delete_ind_desc'] == CORRECTION_DELETE_IND_DICT['C']
@@ -443,7 +443,7 @@ def test_derive_labels(database):
 
     # Testing for invalid values of each
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='Z', busi_fund='ab')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -453,7 +453,7 @@ def test_derive_labels(database):
 
     # Test multiple business types (2 valid, one invalid)
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='azb')
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['business_types_desc'] == BUSINESS_TYPE_DICT['A'] + ';' + BUSINESS_TYPE_DICT['B']
 
 
@@ -462,15 +462,15 @@ def test_is_active(database):
 
     # Testing with none values
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['is_active'] is True
 
     # Testing with value other than D
     obj = initialize_test_obj(cdi="c")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['is_active'] is True
 
     # Testing with D
     obj = initialize_test_obj(cdi="D")
-    obj = fabs_derivations(obj, database.session, STATE_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
     assert obj['is_active'] is False

--- a/tests/unit/dataactbroker/test_fabs_derivations.py
+++ b/tests/unit/dataactbroker/test_fabs_derivations.py
@@ -2,32 +2,34 @@ from dataactbroker.handlers.fabsDerivationsHandler import fabs_derivations
 from dataactcore.models.lookups import (ACTION_TYPE_DICT, ASSISTANCE_TYPE_DICT, CORRECTION_DELETE_IND_DICT,
                                         RECORD_TYPE_DICT, BUSINESS_TYPE_DICT, BUSINESS_FUNDS_IND_DICT)
 
-from tests.unit.dataactcore.factories.domain import (
-    CGACFactory, FRECFactory, SubTierAgencyFactory, CountyCodeFactory, CFDAProgramFactory, ZipCityFactory, ZipsFactory,
-    CityCodeFactory, DunsFactory)
+from tests.unit.dataactcore.factories.domain import (CountyCodeFactory, CFDAProgramFactory, ZipCityFactory, ZipsFactory,
+                                                     CityCodeFactory, DunsFactory)
 
 from tests.unit.dataactcore.factories.staging import FPDSContractingOfficeFactory
 
 STATE_DICT = {"NY": "New York"}
 COUNTRY_DICT = {"USA": "United States of America"}
+SUB_TIER_DICT = {
+    "1234": {
+        "is_frec": False,
+        "cgac_code": "000",
+        "frec_code": "0000",
+        "sub_tier_agency_name": "Test Subtier Agency",
+        "agency_name": "Test CGAC Agency"
+    },
+    "4321": {
+        "is_frec": True,
+        "cgac_code": "111",
+        "frec_code": "1111",
+        "sub_tier_agency_name": "Test Frec Subtier Agency",
+        "agency_name": "Test FREC Agency"
+    }
+}
 
 
-def initialize_db_values(db, cfda_title=None, cgac_code=None, frec_code=None, use_frec=False):
+def initialize_db_values(db, cfda_title=None):
     """ Initialize the values in the DB that can be used throughout the tests """
-    if cgac_code:
-        cgac = CGACFactory(cgac_code=cgac_code, agency_name="Test CGAC Agency")
-    else:
-        cgac = CGACFactory()
-    if frec_code:
-        frec = FRECFactory(frec_code=frec_code, agency_name="Test FREC Agency", cgac=cgac)
-    else:
-        frec = FRECFactory(cgac=cgac)
-    db.session.add_all([cgac, frec])
-    db.session.commit()
-
     cfda_number = CFDAProgramFactory(program_number=12.345, program_title=cfda_title)
-    sub_tier = SubTierAgencyFactory(sub_tier_agency_code="1234", cgac=cgac, frec=frec, is_frec=use_frec,
-                                    sub_tier_agency_name="Test Subtier Agency")
     zip_code_1 = ZipsFactory(zip5="12345", zip_last4="6789", state_abbreviation="NY", county_number="001",
                              congressional_district_no="01")
     zip_code_2 = ZipsFactory(zip5="12345", zip_last4="4321", state_abbreviation="NY", county_number="001",
@@ -47,7 +49,7 @@ def initialize_db_values(db, cfda_title=None, cgac_code=None, frec_code=None, us
                                                       contracting_office_name='Office')
     duns = DunsFactory(awardee_or_recipient_uniqu='123456789', ultimate_parent_unique_ide='234567890',
                        ultimate_parent_legal_enti='Parent 1')
-    db.session.add_all([sub_tier, cfda_number, zip_code_1, zip_code_2, zip_code_3, zip_code_4, zip_city, zip_city_2,
+    db.session.add_all([cfda_number, zip_code_1, zip_code_2, zip_code_3, zip_code_4, zip_city, zip_city_2,
                         zip_city_3, county_code, city_code, contracting_office, duns])
     db.session.commit()
 
@@ -58,9 +60,7 @@ def initialize_test_obj(fao=None, nffa=None, cfda_num="00.000", sub_tier_code="1
                         funding_office='033103', legal_congr=None, legal_city="WASHINGTON", legal_state="DC",
                         primary_place_country='USA', legal_country='USA', detached_award_financial_assistance_id=None,
                         job_id=None, action_type=None, assist_type=None, busi_type=None, busi_fund=None,
-                        awardee_or_recipient_uniqu=None
-                        ):
-
+                        awardee_or_recipient_uniqu=None):
     """ Initialize the values in the object being run through the fabs_derivations function """
     obj = {
         'federal_action_obligation': fao,
@@ -101,17 +101,17 @@ def test_total_funding_amount(database):
 
     # when fao and nffa are empty
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['total_funding_amount'] == 0
 
     # when one of fao and nffa is empty and the other isn't
     obj = initialize_test_obj(fao=5.3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['total_funding_amount'] == 5.3
 
     # when fao and nffa aren't empty
     obj = initialize_test_obj(fao=-10.6, nffa=123)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['total_funding_amount'] == 112.4
 
 
@@ -120,50 +120,50 @@ def test_cfda_title(database):
 
     # when cfda_number isn't in the database
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['cfda_title'] is None
 
     # when cfda_number is in the database
     obj = initialize_test_obj(cfda_num="12.345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['cfda_title'] == "Test Title"
 
 
 def test_awarding_agency_cgac(database):
-    initialize_db_values(database, cgac_code="000", frec_code="1111")
+    initialize_db_values(database)
 
     obj = initialize_test_obj(sub_tier_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['awarding_agency_code'] == "000"
     assert obj['awarding_agency_name'] == "Test CGAC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Subtier Agency"
 
 
 def test_awarding_agency_frec(database):
-    initialize_db_values(database, cgac_code="000", frec_code="1111", use_frec=True)
+    initialize_db_values(database)
 
-    obj = initialize_test_obj(sub_tier_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = initialize_test_obj(sub_tier_code="4321")
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['awarding_agency_code'] == "1111"
     assert obj['awarding_agency_name'] == "Test FREC Agency"
-    assert obj['awarding_sub_tier_agency_n'] == "Test Subtier Agency"
+    assert obj['awarding_sub_tier_agency_n'] == "Test Frec Subtier Agency"
 
 
 def test_funding_sub_tier_agency_na(database):
-    initialize_db_values(database, cgac_code="5678")
+    initialize_db_values(database)
 
     # when funding_sub_tier_agency_co is not provided
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['funding_sub_tier_agency_na'] is None
     assert obj['funding_agency_code'] is None
     assert obj['funding_agency_name'] is None
 
     # when funding_sub_tier_agency_co is provided
     obj = initialize_test_obj(sub_fund_agency_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['funding_sub_tier_agency_na'] == "Test Subtier Agency"
-    assert obj['funding_agency_code'] == '5678'
+    assert obj['funding_agency_code'] == '000'
     assert obj['funding_agency_name'] == 'Test CGAC Agency'
 
 
@@ -171,17 +171,17 @@ def test_ppop_state(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_perfor_state_code'] == 'NY'
     assert obj['place_of_perform_state_nam'] == "New York"
 
     obj = initialize_test_obj(ppop_code="00*****")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] == "Multi-state"
 
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] is None
 
@@ -191,7 +191,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and no congressional district
     obj = initialize_test_obj(ppop_zip4a="123454321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_performance_congr'] == '02'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -199,12 +199,12 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and has congressional district
     obj = initialize_test_obj(ppop_zip4a="12345-4321", ppop_cd="03")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_performance_congr'] == '03'
 
     # when ppop_zip4a is 5 digits
     obj = initialize_test_obj(ppop_zip4a="12345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     # cd should be 90 if there's more than one option
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
@@ -213,7 +213,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits but last 4 are invalid (one cd available)
     obj = initialize_test_obj(ppop_zip4a="543210000")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_performance_congr'] == '05'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -221,7 +221,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits (no cd available)
     obj = initialize_test_obj(ppop_zip4a="987654321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -229,7 +229,7 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX**### format
     obj = initialize_test_obj(ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
     assert obj['place_of_performance_city'] is None
@@ -237,7 +237,7 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX##### format
     obj = initialize_test_obj(ppop_code="NY00001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test City County"
     assert obj['place_of_performance_city'] == "Test City"
@@ -245,7 +245,7 @@ def test_ppop_derivations(database):
 
     # when we don't have a ppop_code at all
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_perform_county_co'] is None
     assert obj['place_of_perform_county_na'] is None
     assert obj['place_of_performance_city'] is None
@@ -258,7 +258,7 @@ def test_legal_entity_derivations(database):
     # if there is a legal_entity_zip5, record_type is always 2 or 3
     # when we have legal_entity_zip5 and zip4
     obj = initialize_test_obj(le_zip5="12345", le_zip4="6789")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     assert obj['legal_entity_congressional'] == "01"
     assert obj['legal_entity_county_code'] == "001"
@@ -268,7 +268,7 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 but no zip4
     obj = initialize_test_obj(le_zip5="12345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     # there are multiple options so this should be 90
     assert obj['legal_entity_congressional'] == "90"
@@ -279,12 +279,12 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 and congressional but no zip4
     obj = initialize_test_obj(le_zip5="12345", legal_congr="95")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['legal_entity_congressional'] == "95"
 
     # if there is no legal_entity_zip5 and record_type is 1, ppop_code is always in format XX**###
     obj = initialize_test_obj(record_type=1, ppop_cd="03", ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] == "03"
     assert obj['legal_entity_county_code'] == "001"
@@ -294,7 +294,7 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format XX*****
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="NY*****")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -304,7 +304,7 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format 00FORGN
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="00FORGN")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -318,11 +318,11 @@ def test_primary_place_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(primary_place_country='USA')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_perform_country_n'] == 'United States of America'
 
     obj = initialize_test_obj(primary_place_country='NK')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_perform_country_n'] is None
 
 
@@ -331,11 +331,11 @@ def test_awarding_office_codes(database):
 
     # if awarding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['awarding_office_name'] == 'Office'
 
     obj = initialize_test_obj(awarding_office='111111')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['awarding_office_name'] is None
 
 
@@ -344,11 +344,11 @@ def test_funding_office_codes(database):
 
     # if funding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['funding_office_name'] == 'Office'
 
     obj = initialize_test_obj(funding_office='111111')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['funding_office_name'] is None
 
 
@@ -357,11 +357,11 @@ def test_legal_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(legal_country='USA')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['legal_entity_country_name'] == 'United States of America'
 
     obj = initialize_test_obj(legal_country='NK')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['legal_entity_country_name'] is None
 
 
@@ -370,31 +370,31 @@ def test_split_zip(database):
 
     # testing with 5-digit
     obj = initialize_test_obj(ppop_zip4a='12345')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing with 9-digit
     obj = initialize_test_obj(ppop_zip4a='123456789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with 9-digit and dash
     obj = initialize_test_obj(ppop_zip4a='12345-6789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with city-wide
     obj = initialize_test_obj(ppop_zip4a='city-wide')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing without ppop_zip4
     obj = initialize_test_obj(ppop_zip4a='')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
@@ -403,7 +403,7 @@ def test_derive_parent_duns(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
 
     assert obj['ultimate_parent_legal_enti'] == 'Parent 1'
     assert obj['ultimate_parent_unique_ide'] == '234567890'
@@ -413,7 +413,7 @@ def test_derive_parent_duns_return_none(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
 
     assert not obj['ultimate_parent_legal_enti']
     assert not obj['ultimate_parent_unique_ide']
@@ -424,7 +424,7 @@ def test_derive_labels(database):
 
     # Testing when these values are blank
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -433,7 +433,7 @@ def test_derive_labels(database):
 
     # Testing for valid values of each
     obj = initialize_test_obj(cdi='c', action_type='a', assist_type='02', busi_type='d', busi_fund='non')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['action_type_description'] == ACTION_TYPE_DICT['A']
     assert obj['assistance_type_desc'] == ASSISTANCE_TYPE_DICT['02']
     assert obj['correction_delete_ind_desc'] == CORRECTION_DELETE_IND_DICT['C']
@@ -443,7 +443,7 @@ def test_derive_labels(database):
 
     # Testing for invalid values of each
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='Z', busi_fund='ab')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -453,7 +453,7 @@ def test_derive_labels(database):
 
     # Test multiple business types (2 valid, one invalid)
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='azb')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['business_types_desc'] == BUSINESS_TYPE_DICT['A'] + ';' + BUSINESS_TYPE_DICT['B']
 
 
@@ -462,15 +462,15 @@ def test_is_active(database):
 
     # Testing with none values
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['is_active'] is True
 
     # Testing with value other than D
     obj = initialize_test_obj(cdi="c")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['is_active'] is True
 
     # Testing with D
     obj = initialize_test_obj(cdi="D")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
     assert obj['is_active'] is False

--- a/tests/unit/dataactbroker/test_fabs_derivations.py
+++ b/tests/unit/dataactbroker/test_fabs_derivations.py
@@ -2,8 +2,8 @@ from dataactbroker.handlers.fabsDerivationsHandler import fabs_derivations
 from dataactcore.models.lookups import (ACTION_TYPE_DICT, ASSISTANCE_TYPE_DICT, CORRECTION_DELETE_IND_DICT,
                                         RECORD_TYPE_DICT, BUSINESS_TYPE_DICT, BUSINESS_FUNDS_IND_DICT)
 
-from tests.unit.dataactcore.factories.domain import (CountyCodeFactory, CFDAProgramFactory, ZipCityFactory, ZipsFactory,
-                                                     CityCodeFactory, DunsFactory)
+from tests.unit.dataactcore.factories.domain import (CountyCodeFactory, ZipCityFactory, ZipsFactory, CityCodeFactory,
+                                                     DunsFactory)
 
 from tests.unit.dataactcore.factories.staging import FPDSContractingOfficeFactory
 
@@ -25,11 +25,11 @@ SUB_TIER_DICT = {
         "agency_name": "Test FREC Agency"
     }
 }
+CFDA_DICT = {"12.345": "CFDA Title"}
 
 
-def initialize_db_values(db, cfda_title=None):
+def initialize_db_values(db):
     """ Initialize the values in the DB that can be used throughout the tests """
-    cfda_number = CFDAProgramFactory(program_number=12.345, program_title=cfda_title)
     zip_code_1 = ZipsFactory(zip5="12345", zip_last4="6789", state_abbreviation="NY", county_number="001",
                              congressional_district_no="01")
     zip_code_2 = ZipsFactory(zip5="12345", zip_last4="4321", state_abbreviation="NY", county_number="001",
@@ -49,8 +49,8 @@ def initialize_db_values(db, cfda_title=None):
                                                       contracting_office_name='Office')
     duns = DunsFactory(awardee_or_recipient_uniqu='123456789', ultimate_parent_unique_ide='234567890',
                        ultimate_parent_legal_enti='Parent 1')
-    db.session.add_all([cfda_number, zip_code_1, zip_code_2, zip_code_3, zip_code_4, zip_city, zip_city_2,
-                        zip_city_3, county_code, city_code, contracting_office, duns])
+    db.session.add_all([zip_code_1, zip_code_2, zip_code_3, zip_code_4, zip_city, zip_city_2, zip_city_3, county_code,
+                        city_code, contracting_office, duns])
     db.session.commit()
 
 
@@ -101,39 +101,39 @@ def test_total_funding_amount(database):
 
     # when fao and nffa are empty
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['total_funding_amount'] == 0
 
     # when one of fao and nffa is empty and the other isn't
     obj = initialize_test_obj(fao=5.3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['total_funding_amount'] == 5.3
 
     # when fao and nffa aren't empty
     obj = initialize_test_obj(fao=-10.6, nffa=123)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['total_funding_amount'] == 112.4
 
 
 def test_cfda_title(database):
-    initialize_db_values(database, cfda_title="Test Title")
+    initialize_db_values(database)
 
     # when cfda_number isn't in the database
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['cfda_title'] is None
 
     # when cfda_number is in the database
     obj = initialize_test_obj(cfda_num="12.345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
-    assert obj['cfda_title'] == "Test Title"
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    assert obj['cfda_title'] == "CFDA Title"
 
 
 def test_awarding_agency_cgac(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj(sub_tier_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['awarding_agency_code'] == "000"
     assert obj['awarding_agency_name'] == "Test CGAC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Subtier Agency"
@@ -143,7 +143,7 @@ def test_awarding_agency_frec(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj(sub_tier_code="4321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['awarding_agency_code'] == "1111"
     assert obj['awarding_agency_name'] == "Test FREC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Frec Subtier Agency"
@@ -154,14 +154,14 @@ def test_funding_sub_tier_agency_na(database):
 
     # when funding_sub_tier_agency_co is not provided
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['funding_sub_tier_agency_na'] is None
     assert obj['funding_agency_code'] is None
     assert obj['funding_agency_name'] is None
 
     # when funding_sub_tier_agency_co is provided
     obj = initialize_test_obj(sub_fund_agency_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['funding_sub_tier_agency_na'] == "Test Subtier Agency"
     assert obj['funding_agency_code'] == '000'
     assert obj['funding_agency_name'] == 'Test CGAC Agency'
@@ -171,17 +171,17 @@ def test_ppop_state(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_perfor_state_code'] == 'NY'
     assert obj['place_of_perform_state_nam'] == "New York"
 
     obj = initialize_test_obj(ppop_code="00*****")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] == "Multi-state"
 
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] is None
 
@@ -191,7 +191,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and no congressional district
     obj = initialize_test_obj(ppop_zip4a="123454321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_performance_congr'] == '02'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -199,12 +199,12 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and has congressional district
     obj = initialize_test_obj(ppop_zip4a="12345-4321", ppop_cd="03")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_performance_congr'] == '03'
 
     # when ppop_zip4a is 5 digits
     obj = initialize_test_obj(ppop_zip4a="12345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     # cd should be 90 if there's more than one option
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
@@ -213,7 +213,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits but last 4 are invalid (one cd available)
     obj = initialize_test_obj(ppop_zip4a="543210000")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_performance_congr'] == '05'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -221,7 +221,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits (no cd available)
     obj = initialize_test_obj(ppop_zip4a="987654321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -229,7 +229,7 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX**### format
     obj = initialize_test_obj(ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
     assert obj['place_of_performance_city'] is None
@@ -237,7 +237,7 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX##### format
     obj = initialize_test_obj(ppop_code="NY00001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test City County"
     assert obj['place_of_performance_city'] == "Test City"
@@ -245,7 +245,7 @@ def test_ppop_derivations(database):
 
     # when we don't have a ppop_code at all
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_perform_county_co'] is None
     assert obj['place_of_perform_county_na'] is None
     assert obj['place_of_performance_city'] is None
@@ -258,7 +258,7 @@ def test_legal_entity_derivations(database):
     # if there is a legal_entity_zip5, record_type is always 2 or 3
     # when we have legal_entity_zip5 and zip4
     obj = initialize_test_obj(le_zip5="12345", le_zip4="6789")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     assert obj['legal_entity_congressional'] == "01"
     assert obj['legal_entity_county_code'] == "001"
@@ -268,7 +268,7 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 but no zip4
     obj = initialize_test_obj(le_zip5="12345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     # there are multiple options so this should be 90
     assert obj['legal_entity_congressional'] == "90"
@@ -279,12 +279,12 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 and congressional but no zip4
     obj = initialize_test_obj(le_zip5="12345", legal_congr="95")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['legal_entity_congressional'] == "95"
 
     # if there is no legal_entity_zip5 and record_type is 1, ppop_code is always in format XX**###
     obj = initialize_test_obj(record_type=1, ppop_cd="03", ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] == "03"
     assert obj['legal_entity_county_code'] == "001"
@@ -294,7 +294,7 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format XX*****
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="NY*****")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -304,7 +304,7 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format 00FORGN
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="00FORGN")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -318,11 +318,11 @@ def test_primary_place_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(primary_place_country='USA')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_perform_country_n'] == 'United States of America'
 
     obj = initialize_test_obj(primary_place_country='NK')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_perform_country_n'] is None
 
 
@@ -331,11 +331,11 @@ def test_awarding_office_codes(database):
 
     # if awarding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['awarding_office_name'] == 'Office'
 
     obj = initialize_test_obj(awarding_office='111111')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['awarding_office_name'] is None
 
 
@@ -344,11 +344,11 @@ def test_funding_office_codes(database):
 
     # if funding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['funding_office_name'] == 'Office'
 
     obj = initialize_test_obj(funding_office='111111')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['funding_office_name'] is None
 
 
@@ -357,11 +357,11 @@ def test_legal_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(legal_country='USA')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['legal_entity_country_name'] == 'United States of America'
 
     obj = initialize_test_obj(legal_country='NK')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['legal_entity_country_name'] is None
 
 
@@ -370,31 +370,31 @@ def test_split_zip(database):
 
     # testing with 5-digit
     obj = initialize_test_obj(ppop_zip4a='12345')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing with 9-digit
     obj = initialize_test_obj(ppop_zip4a='123456789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with 9-digit and dash
     obj = initialize_test_obj(ppop_zip4a='12345-6789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with city-wide
     obj = initialize_test_obj(ppop_zip4a='city-wide')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing without ppop_zip4
     obj = initialize_test_obj(ppop_zip4a='')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
@@ -403,7 +403,7 @@ def test_derive_parent_duns(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
 
     assert obj['ultimate_parent_legal_enti'] == 'Parent 1'
     assert obj['ultimate_parent_unique_ide'] == '234567890'
@@ -413,7 +413,7 @@ def test_derive_parent_duns_return_none(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
 
     assert not obj['ultimate_parent_legal_enti']
     assert not obj['ultimate_parent_unique_ide']
@@ -424,7 +424,7 @@ def test_derive_labels(database):
 
     # Testing when these values are blank
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -433,7 +433,7 @@ def test_derive_labels(database):
 
     # Testing for valid values of each
     obj = initialize_test_obj(cdi='c', action_type='a', assist_type='02', busi_type='d', busi_fund='non')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['action_type_description'] == ACTION_TYPE_DICT['A']
     assert obj['assistance_type_desc'] == ASSISTANCE_TYPE_DICT['02']
     assert obj['correction_delete_ind_desc'] == CORRECTION_DELETE_IND_DICT['C']
@@ -443,7 +443,7 @@ def test_derive_labels(database):
 
     # Testing for invalid values of each
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='Z', busi_fund='ab')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -453,7 +453,7 @@ def test_derive_labels(database):
 
     # Test multiple business types (2 valid, one invalid)
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='azb')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['business_types_desc'] == BUSINESS_TYPE_DICT['A'] + ';' + BUSINESS_TYPE_DICT['B']
 
 
@@ -462,15 +462,15 @@ def test_is_active(database):
 
     # Testing with none values
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['is_active'] is True
 
     # Testing with value other than D
     obj = initialize_test_obj(cdi="c")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['is_active'] is True
 
     # Testing with D
     obj = initialize_test_obj(cdi="D")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
     assert obj['is_active'] is False

--- a/tests/unit/dataactbroker/test_fabs_derivations.py
+++ b/tests/unit/dataactbroker/test_fabs_derivations.py
@@ -2,8 +2,7 @@ from dataactbroker.handlers.fabsDerivationsHandler import fabs_derivations
 from dataactcore.models.lookups import (ACTION_TYPE_DICT, ASSISTANCE_TYPE_DICT, CORRECTION_DELETE_IND_DICT,
                                         RECORD_TYPE_DICT, BUSINESS_TYPE_DICT, BUSINESS_FUNDS_IND_DICT)
 
-from tests.unit.dataactcore.factories.domain import (CountyCodeFactory, ZipCityFactory, ZipsFactory, CityCodeFactory,
-                                                     DunsFactory)
+from tests.unit.dataactcore.factories.domain import ZipCityFactory, ZipsFactory, CityCodeFactory, DunsFactory
 
 from tests.unit.dataactcore.factories.staging import FPDSContractingOfficeFactory
 
@@ -26,6 +25,7 @@ SUB_TIER_DICT = {
     }
 }
 CFDA_DICT = {"12.345": "CFDA Title"}
+COUNTY_DICT = {"NY001": "Test County"}
 
 
 def initialize_db_values(db):
@@ -41,16 +41,14 @@ def initialize_db_values(db):
     zip_city = ZipCityFactory(zip_code=zip_code_1.zip5, city_name="Test Zip City")
     zip_city_2 = ZipCityFactory(zip_code=zip_code_3.zip5, city_name="Test Zip City 2")
     zip_city_3 = ZipCityFactory(zip_code=zip_code_4.zip5, city_name="Test Zip City 3")
-    county_code = CountyCodeFactory(state_code="NY", county_number=zip_code_1.county_number,
-                                    county_name="Test County")
     city_code = CityCodeFactory(feature_name="Test City", city_code="00001", state_code="NY",
                                 county_number=zip_code_1.county_number, county_name="Test City County")
     contracting_office = FPDSContractingOfficeFactory(contracting_office_code='033103',
                                                       contracting_office_name='Office')
     duns = DunsFactory(awardee_or_recipient_uniqu='123456789', ultimate_parent_unique_ide='234567890',
                        ultimate_parent_legal_enti='Parent 1')
-    db.session.add_all([zip_code_1, zip_code_2, zip_code_3, zip_code_4, zip_city, zip_city_2, zip_city_3, county_code,
-                        city_code, contracting_office, duns])
+    db.session.add_all([zip_code_1, zip_code_2, zip_code_3, zip_code_4, zip_city, zip_city_2, zip_city_3, city_code,
+                        contracting_office, duns])
     db.session.commit()
 
 
@@ -101,17 +99,17 @@ def test_total_funding_amount(database):
 
     # when fao and nffa are empty
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['total_funding_amount'] == 0
 
     # when one of fao and nffa is empty and the other isn't
     obj = initialize_test_obj(fao=5.3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['total_funding_amount'] == 5.3
 
     # when fao and nffa aren't empty
     obj = initialize_test_obj(fao=-10.6, nffa=123)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['total_funding_amount'] == 112.4
 
 
@@ -120,12 +118,12 @@ def test_cfda_title(database):
 
     # when cfda_number isn't in the database
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['cfda_title'] is None
 
     # when cfda_number is in the database
     obj = initialize_test_obj(cfda_num="12.345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['cfda_title'] == "CFDA Title"
 
 
@@ -133,7 +131,7 @@ def test_awarding_agency_cgac(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj(sub_tier_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['awarding_agency_code'] == "000"
     assert obj['awarding_agency_name'] == "Test CGAC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Subtier Agency"
@@ -143,7 +141,7 @@ def test_awarding_agency_frec(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj(sub_tier_code="4321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['awarding_agency_code'] == "1111"
     assert obj['awarding_agency_name'] == "Test FREC Agency"
     assert obj['awarding_sub_tier_agency_n'] == "Test Frec Subtier Agency"
@@ -154,14 +152,14 @@ def test_funding_sub_tier_agency_na(database):
 
     # when funding_sub_tier_agency_co is not provided
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['funding_sub_tier_agency_na'] is None
     assert obj['funding_agency_code'] is None
     assert obj['funding_agency_name'] is None
 
     # when funding_sub_tier_agency_co is provided
     obj = initialize_test_obj(sub_fund_agency_code="1234")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['funding_sub_tier_agency_na'] == "Test Subtier Agency"
     assert obj['funding_agency_code'] == '000'
     assert obj['funding_agency_name'] == 'Test CGAC Agency'
@@ -171,17 +169,17 @@ def test_ppop_state(database):
     initialize_db_values(database)
 
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_perfor_state_code'] == 'NY'
     assert obj['place_of_perform_state_nam'] == "New York"
 
     obj = initialize_test_obj(ppop_code="00*****")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] == "Multi-state"
 
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_perfor_state_code'] is None
     assert obj['place_of_perform_state_nam'] is None
 
@@ -191,7 +189,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and no congressional district
     obj = initialize_test_obj(ppop_zip4a="123454321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_performance_congr'] == '02'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -199,12 +197,12 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4a is 5 digits and has congressional district
     obj = initialize_test_obj(ppop_zip4a="12345-4321", ppop_cd="03")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_performance_congr'] == '03'
 
     # when ppop_zip4a is 5 digits
     obj = initialize_test_obj(ppop_zip4a="12345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     # cd should be 90 if there's more than one option
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
@@ -213,7 +211,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits but last 4 are invalid (one cd available)
     obj = initialize_test_obj(ppop_zip4a="543210000")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_performance_congr'] == '05'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -221,7 +219,7 @@ def test_ppop_derivations(database):
 
     # when ppop_zip4 is 9 digits (no cd available)
     obj = initialize_test_obj(ppop_zip4a="987654321")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_performance_congr'] == '90'
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
@@ -229,7 +227,7 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX**### format
     obj = initialize_test_obj(ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test County"
     assert obj['place_of_performance_city'] is None
@@ -237,7 +235,7 @@ def test_ppop_derivations(database):
 
     # when we don't have ppop_zip4a and ppop_code is in XX##### format
     obj = initialize_test_obj(ppop_code="NY00001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_perform_county_co'] == "001"
     assert obj['place_of_perform_county_na'] == "Test City County"
     assert obj['place_of_performance_city'] == "Test City"
@@ -245,7 +243,7 @@ def test_ppop_derivations(database):
 
     # when we don't have a ppop_code at all
     obj = initialize_test_obj(ppop_code="", record_type=3)
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_perform_county_co'] is None
     assert obj['place_of_perform_county_na'] is None
     assert obj['place_of_performance_city'] is None
@@ -258,7 +256,7 @@ def test_legal_entity_derivations(database):
     # if there is a legal_entity_zip5, record_type is always 2 or 3
     # when we have legal_entity_zip5 and zip4
     obj = initialize_test_obj(le_zip5="12345", le_zip4="6789")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     assert obj['legal_entity_congressional'] == "01"
     assert obj['legal_entity_county_code'] == "001"
@@ -268,7 +266,7 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 but no zip4
     obj = initialize_test_obj(le_zip5="12345")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['legal_entity_city_name'] == "Test Zip City"
     # there are multiple options so this should be 90
     assert obj['legal_entity_congressional'] == "90"
@@ -279,12 +277,12 @@ def test_legal_entity_derivations(database):
 
     # when we have legal_entity_zip5 and congressional but no zip4
     obj = initialize_test_obj(le_zip5="12345", legal_congr="95")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['legal_entity_congressional'] == "95"
 
     # if there is no legal_entity_zip5 and record_type is 1, ppop_code is always in format XX**###
     obj = initialize_test_obj(record_type=1, ppop_cd="03", ppop_code="NY**001")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] == "03"
     assert obj['legal_entity_county_code'] == "001"
@@ -294,7 +292,7 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format XX*****
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="NY*****")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -304,7 +302,7 @@ def test_legal_entity_derivations(database):
 
     # if there is no legal_entity_zip5, record_type is always 1 and ppop_code can be format 00FORGN
     obj = initialize_test_obj(record_type=1, ppop_cd=None, ppop_code="00FORGN")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['legal_entity_city_name'] is None
     assert obj['legal_entity_congressional'] is None
     assert obj['legal_entity_county_code'] is None
@@ -318,11 +316,11 @@ def test_primary_place_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(primary_place_country='USA')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_perform_country_n'] == 'United States of America'
 
     obj = initialize_test_obj(primary_place_country='NK')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_perform_country_n'] is None
 
 
@@ -331,11 +329,11 @@ def test_awarding_office_codes(database):
 
     # if awarding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['awarding_office_name'] == 'Office'
 
     obj = initialize_test_obj(awarding_office='111111')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['awarding_office_name'] is None
 
 
@@ -344,11 +342,11 @@ def test_funding_office_codes(database):
 
     # if funding office_code is present, get office name
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['funding_office_name'] == 'Office'
 
     obj = initialize_test_obj(funding_office='111111')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['funding_office_name'] is None
 
 
@@ -357,11 +355,11 @@ def test_legal_country(database):
 
     # if primary_plce_of_performance_country_code is present get country name
     obj = initialize_test_obj(legal_country='USA')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['legal_entity_country_name'] == 'United States of America'
 
     obj = initialize_test_obj(legal_country='NK')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['legal_entity_country_name'] is None
 
 
@@ -370,31 +368,31 @@ def test_split_zip(database):
 
     # testing with 5-digit
     obj = initialize_test_obj(ppop_zip4a='12345')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing with 9-digit
     obj = initialize_test_obj(ppop_zip4a='123456789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with 9-digit and dash
     obj = initialize_test_obj(ppop_zip4a='12345-6789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_performance_zip5'] == '12345'
     assert obj['place_of_perform_zip_last4'] == '6789'
 
     # testing with city-wide
     obj = initialize_test_obj(ppop_zip4a='city-wide')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
     # testing without ppop_zip4
     obj = initialize_test_obj(ppop_zip4a='')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['place_of_performance_zip5'] is None
     assert obj['place_of_perform_zip_last4'] is None
 
@@ -403,7 +401,7 @@ def test_derive_parent_duns(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456789')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
 
     assert obj['ultimate_parent_legal_enti'] == 'Parent 1'
     assert obj['ultimate_parent_unique_ide'] == '234567890'
@@ -413,7 +411,7 @@ def test_derive_parent_duns_return_none(database, monkeypatch):
     initialize_db_values(database)
 
     obj = initialize_test_obj(awardee_or_recipient_uniqu='123456')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
 
     assert not obj['ultimate_parent_legal_enti']
     assert not obj['ultimate_parent_unique_ide']
@@ -424,7 +422,7 @@ def test_derive_labels(database):
 
     # Testing when these values are blank
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -433,7 +431,7 @@ def test_derive_labels(database):
 
     # Testing for valid values of each
     obj = initialize_test_obj(cdi='c', action_type='a', assist_type='02', busi_type='d', busi_fund='non')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['action_type_description'] == ACTION_TYPE_DICT['A']
     assert obj['assistance_type_desc'] == ASSISTANCE_TYPE_DICT['02']
     assert obj['correction_delete_ind_desc'] == CORRECTION_DELETE_IND_DICT['C']
@@ -443,7 +441,7 @@ def test_derive_labels(database):
 
     # Testing for invalid values of each
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='Z', busi_fund='ab')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['action_type_description'] is None
     assert obj['assistance_type_desc'] is None
     assert obj['correction_delete_ind_desc'] is None
@@ -453,7 +451,7 @@ def test_derive_labels(database):
 
     # Test multiple business types (2 valid, one invalid)
     obj = initialize_test_obj(cdi='f', action_type='z', assist_type='01', record_type=5, busi_type='azb')
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['business_types_desc'] == BUSINESS_TYPE_DICT['A'] + ';' + BUSINESS_TYPE_DICT['B']
 
 
@@ -462,15 +460,15 @@ def test_is_active(database):
 
     # Testing with none values
     obj = initialize_test_obj()
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['is_active'] is True
 
     # Testing with value other than D
     obj = initialize_test_obj(cdi="c")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['is_active'] is True
 
     # Testing with D
     obj = initialize_test_obj(cdi="D")
-    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT)
+    obj = fabs_derivations(obj, database.session, STATE_DICT, COUNTRY_DICT, SUB_TIER_DICT, CFDA_DICT, COUNTY_DICT)
     assert obj['is_active'] is False


### PR DESCRIPTION
Attempting to speed up FABS derivations as much as we can. Turning some of the DB queries into lookups to reduce strain on the DB and to speed up the process as much as possible.

On average sped up the process by 10-15 seconds per 1k rows, which isn't a ton but it's better than nothing.