### PR TITLE
Dev 578 adjust c9

### DIFF
--- a/tests/unit/dataactvalidator/test_c9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_c9_award_financial.py
@@ -120,11 +120,21 @@ def test_zero_federal_action_obligation_and_positive_original_loan_subsidy_cost(
 
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=0,
-                                          original_loan_subsidy_cost='1')
+                                          original_loan_subsidy_cost='1', assistance_type='08')
+    afa_2 = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=2,
+                                            original_loan_subsidy_cost='1', assistance_type='07')
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
+
+    errors = number_of_errors(_FILE, database, models=[afa, af, afa_2])
+    assert errors == 2
+
+    # Test that this is ignored if assistance type is 07
+    afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=0,
+                                          original_loan_subsidy_cost='1', assistance_type='07')
     af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
-    assert errors == 1
+    assert errors == 0
 
 
 def test_positive_federal_action_obligation_and_zero_original_loan_subsidy_cost(database):
@@ -133,8 +143,22 @@ def test_positive_federal_action_obligation_and_zero_original_loan_subsidy_cost(
 
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
-                                          original_loan_subsidy_cost='0')
+                                          original_loan_subsidy_cost='0', assistance_type='07')
+    afa_2 = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
+                                            original_loan_subsidy_cost='-2.3', assistance_type='07')
+    afa_3 = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
+                                            original_loan_subsidy_cost='2.3', assistance_type='08')
     af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
 
-    errors = number_of_errors(_FILE, database, models=[afa, af])
-    assert errors == 1
+    errors = number_of_errors(_FILE, database, models=[afa, af, afa_2, afa_3])
+    assert errors == 3
+
+    # Test that this is ignored if assistance type is 08
+    afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
+                                          original_loan_subsidy_cost='0', assistance_type='08')
+    afa_2 = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
+                                            original_loan_subsidy_cost='-2.3', assistance_type='08')
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
+
+    errors = number_of_errors(_FILE, database, models=[afa, af, afa_2])
+    assert errors == 0

--- a/tests/unit/dataactvalidator/test_c9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_c9_award_financial.py
@@ -114,7 +114,7 @@ def test_zero_federal_action_obligation_and_original_loan_subsidy_cost(database)
     assert errors == 0
 
 
-def test_zero_federal_action_obligation_and_positive_original_loan_subsidy_cost(database):
+def test_ignored_and_failed_federal_action_obligation_values(database):
     """ Tests that a single warning is thrown for both a federal action obligation of 0
         and an original loan subsidy cost of 0 """
 
@@ -137,7 +137,7 @@ def test_zero_federal_action_obligation_and_positive_original_loan_subsidy_cost(
     assert errors == 0
 
 
-def test_positive_federal_action_obligation_and_zero_original_loan_subsidy_cost(database):
+def test_ignored_and_failed_original_loan_subsidy_cost_values(database):
     """ Tests that a single warning is thrown for both a federal action obligation of 0
         and an original loan subsidy cost of 0 """
 


### PR DESCRIPTION
Adjusting rule C9 to account for assistance type and changing which lines from D2 are ignored based on assistance type and amount

Technical Release Notes:
- Updated SQL rule