### PR TITLE
Update dev 249 job type

### DIFF
--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -93,7 +93,6 @@ def get_submission_status(submission, jobs):
         string containing the status of the submission"""
     status_names = JOB_STATUS_DICT.keys()
     statuses = {name: 0 for name in status_names}
-    skip_count = 0
 
     for job in jobs:
         job_status = job.job_status.name
@@ -111,7 +110,7 @@ def get_submission_status(submission, jobs):
         status = "waiting"
     elif statuses["ready"] != 0:
         status = "ready"
-    elif statuses["finished"] == jobs.count() - skip_count:  # need to account for the jobs that were skipped above
+    elif statuses["finished"] == jobs.count():
         status = "validation_successful"
         if submission.number_of_warnings is not None and submission.number_of_warnings > 0:
             status = "validation_successful_warnings"

--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -96,11 +96,8 @@ def get_submission_status(submission, jobs):
     skip_count = 0
 
     for job in jobs:
-        if job.job_type.name not in ["external_validation", None]:
-            job_status = job.job_status.name
-            statuses[job_status] += 1
-        else:
-            skip_count += 1
+        job_status = job.job_status.name
+        statuses[job_status] += 1
 
     status = "unknown"
 

--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -377,14 +377,13 @@ def create_jobs(upload_files, submission, existing_submission=False):
     if existing_submission and not submission.d2_submission:
         # find cross-file jobs and mark them as waiting
         # (note: job_type of 'validation' is a cross-file job)
-        val_job = sess.query(Job). \
+        val_job = sess.query(Job).\
             filter_by(
-            submission_id=submission_id,
-            job_type_id=JOB_TYPE_DICT["validation"]). \
+                submission_id=submission_id,
+                job_type_id=JOB_TYPE_DICT["validation"]).\
             one()
         val_job.job_status_id = JOB_STATUS_DICT["waiting"]
         submission.updated_at = time.strftime("%c")
-
     # todo: add these back in for detached_d2 when we have actual validations
     elif not submission.d2_submission:
         # create cross-file validation job

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -53,9 +53,7 @@ JOB_STATUS_DICT_ID = {item.id: item.name for item in JOB_STATUS}
 JOB_TYPE = [
     LookupType(1, 'file_upload', 'file must be uploaded to S3'),
     LookupType(2, 'csv_record_validation', 'do record level validation and add to staging table'),
-    LookupType(3, 'db_transfer', 'information must be moved from production DB to staging table'),
-    LookupType(4, 'validation', 'new information must be validated'),
-    LookupType(5, 'external_validation', 'new information must be validated against external sources')
+    LookupType(4, 'validation', 'new information must be validated')
 ]
 JOB_TYPE_DICT = {item.name: item.id for item in JOB_TYPE}
 JOB_TYPE_DICT_ID = {item.id: item.name for item in JOB_TYPE}

--- a/dataactcore/scripts/setupJobTrackerDB.py
+++ b/dataactcore/scripts/setupJobTrackerDB.py
@@ -1,3 +1,5 @@
+from sqlalchemy import or_
+
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.logging import configure_logging
 from dataactcore.models import lookups
@@ -10,6 +12,7 @@ def setup_job_tracker_db():
     with create_app().app_context():
         sess = GlobalDB.db().session
         insert_codes(sess)
+        delete_unused_job_types(sess)
         sess.commit()
 
 
@@ -42,6 +45,41 @@ def insert_codes(sess):
             file_order=ft.order
         )
         sess.merge(file_type)
+
+
+def delete_unused_job_types(sess):
+    """
+    Deletes the job_type and jobs associated with db_transfer and external_validation that are not used
+    """
+
+    # Using raw sql to delete jobs to avoid sqlalchemy cascading that deletes the entire submission
+
+    # Delete related jobs from job_dependency table
+    delete_job_dependency_statement = """
+     DELETE FROM job_dependency
+     USING job, job_type
+     WHERE job_dependency.job_id = job.job_id
+        AND job.job_type_id = job_type.job_type_id
+        AND (job_type.name = 'db_transfer' OR job_type.name = 'external_validation');
+     """
+
+    # Delete related jobs from job table
+    delete_job_statement = """
+    DELETE FROM job
+    USING job_type
+    WHERE job.job_type_id = job_type.job_type_id
+        AND (job_type.name = 'db_transfer' OR job_type.name = 'external_validation');
+    """
+
+    sess.execute(delete_job_dependency_statement)
+    sess.execute(delete_job_statement)
+
+    # Delete unused job types from job_type table
+    job_type_query = sess.query(JobType).filter(or_(JobType.name == 'db_transfer',
+                                                    JobType.name == 'external_validation'))
+
+    for job_type in job_type_query:
+        sess.delete(job_type)
 
 
 if __name__ == '__main__':

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -977,8 +977,6 @@ class FileTests(BaseTestAPI):
                                JOB_TYPE_DICT['file_upload'], None, None, None],
             'recordRunning': [FILE_TYPE_DICT['award'], JOB_STATUS_DICT['running'],
                               JOB_TYPE_DICT['csv_record_validation'], None, None, None],
-            'externalWaiting': [FILE_TYPE_DICT['award'], JOB_STATUS_DICT['waiting'],
-                                JOB_TYPE_DICT['external_validation'], None, None, None],
             'awardFin': [FILE_TYPE_DICT['award_financial'], JOB_STATUS_DICT['ready'],
                          JOB_TYPE_DICT['csv_record_validation'], "awardFin.csv", 100, 100],
             'appropriations': [FILE_TYPE_DICT['appropriations'], JOB_STATUS_DICT['ready'],


### PR DESCRIPTION
Removing `db_transfer` and `external_validation` from broker.
- Removed from job types lookup
- Added functionality to `initialize.py --db` to remove job types and related jobs and job dependencies
- Removed `external_validation` job creation from submission process 

[Story Link](https://federal-spending-transparency.atlassian.net/browse/DEV-249)

