### PR TITLE
Updating alembic functionality to clean up automigrations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alembic==0.8.5
+alembic==0.9.2
 amqp==1.4.9
 anyjson==0.3.3
 awscli==1.10.10


### PR DESCRIPTION
[Story Link](https://federal-spending-transparency.atlassian.net/browse/DEV-244)

- Alembic version [9.2.0](http://alembic.zzzcomputing.com/en/latest/changelog.html#change-0.9.2) fixes renaming of long index names in Postgres [Details on bugfix](https://bitbucket.org/zzzeek/alembic/issues/421)
- Add functionality to skip dropping indexes  `ix_detached_award_procurement_updated_at` and `ix_published_award_financial_assistance_created_at` since columns are created by timestamp mixin