### PR TITLE
Updating FABS15.1 to include record type 2 and 3

### DIFF
--- a/dataactvalidator/config/sqlrules/fabs15_detached_award_financial_assistance_1.sql
+++ b/dataactvalidator/config/sqlrules/fabs15_detached_award_financial_assistance_1.sql
@@ -1,11 +1,14 @@
 -- LegalEntityForeignCityName is required for foreign recipients (i.e., when LegalEntityCountryCode <> USA)
+-- for non-aggregate and PII-redacted non-aggregate records (RecordType = 2 or 3).
 SELECT
     row_number,
     legal_entity_country_code,
+    record_type,
     legal_entity_foreign_city
 FROM detached_award_financial_assistance
 WHERE submission_id = {0}
     AND UPPER(legal_entity_country_code) <> 'USA'
+    AND record_type IN (2, 3)
     AND (legal_entity_foreign_city IS NULL
         OR legal_entity_foreign_city = ''
     );

--- a/dataactvalidator/config/sqlrules/sqlRules.csv
+++ b/dataactvalidator/config/sqlrules/sqlRules.csv
@@ -104,7 +104,7 @@ FABS13.3,"LegalEntityZIP5 is required for domestic recipients (i.e., when LegalE
 FABS14.1,"LegalEntityZIPLast4 must be blank for aggregate and PII-redacted non-aggregate records (i.e., when RecordType = 1 or 3)",n,fabs,fatal,,fabs14_detached_award_financial_assistance_1
 FABS14.2,"LegalEntityZIPLast4 must be blank for foreign recipients (i.e., when LegalEntityCountryCode is not USA)",n,fabs,fatal,,fabs14_detached_award_financial_assistance_2
 FABS14.3,"When it exists, LegalEntityZIPLast4 should be provided for domestic recipients (i.e., when LegalEntityCountryCode = USA) for non-aggregate records (i.e., when RecordType = 2). A warning will be triggered when it is not provided.",n,fabs,warning,,fabs14_detached_award_financial_assistance_3
-FABS15.1,"LegalEntityForeignCityName is required for foreign recipients (i.e., when LegalEntityCountryCode is not USA)",n,fabs,fatal,,fabs15_detached_award_financial_assistance_1
+FABS15.1,"LegalEntityForeignCityName is required for foreign recipients (i.e., when LegalEntityCountryCode is not USA) for non-aggregate and PII-redacted non-aggregate records (RecordType = 2 or 3).",n,fabs,fatal,,fabs15_detached_award_financial_assistance_1
 FABS15.2,"LegalEntityForeignCityName must be blank for domestic recipients (i.e., when LegalEntityCountryCode = USA)",n,fabs,fatal,,fabs15_detached_award_financial_assistance_2
 FABS16,"LegalEntityForeignProvinceName must be blank for domestic recipients (i.e., when LegalEntityCountryCode = USA)",n,fabs,fatal,,fabs16_detached_award_financial_assistance
 FABS17,"LegalEntityForeignPostalCode must be blank for domestic recipients (i.e., when LegalEntityCountryCode = USA)",n,fabs,fatal,,fabs17_detached_award_financial_assistance

--- a/tests/unit/dataactvalidator/test_fabs15_detached_award_financial_assistance_1.py
+++ b/tests/unit/dataactvalidator/test_fabs15_detached_award_financial_assistance_1.py
@@ -5,36 +5,51 @@ _FILE = 'fabs15_detached_award_financial_assistance_1'
 
 
 def test_column_headers(database):
-    expected_subset = {"row_number", "legal_entity_country_code", "legal_entity_foreign_city"}
+    expected_subset = {"row_number", "legal_entity_country_code", "legal_entity_foreign_city", "record_type"}
     actual = set(query_columns(_FILE, database))
     assert expected_subset == actual
 
 
 def test_success(database):
     """ Test success LegalEntityForeignCityName is required for foreign recipients
-    (i.e., when LegalEntityCountryCode != USA) """
+    (i.e., when LegalEntityCountryCode != USA) for non-aggregate
+    and PII-redacted non-aggregate records (RecordType = 2 or 3)"""
 
     det_award_1 = DetachedAwardFinancialAssistanceFactory(legal_entity_country_code="Japan",
-                                                          legal_entity_foreign_city="Tokyo")
+                                                          legal_entity_foreign_city="Tokyo",
+                                                          record_type=2)
     det_award_2 = DetachedAwardFinancialAssistanceFactory(legal_entity_country_code="UK",
-                                                          legal_entity_foreign_city="Manchester")
+                                                          legal_entity_foreign_city="Manchester",
+                                                          record_type=3)
     det_award_3 = DetachedAwardFinancialAssistanceFactory(legal_entity_country_code="USA",
-                                                          legal_entity_foreign_city=None)
+                                                          legal_entity_foreign_city=None,
+                                                          record_type=2)
     det_award_4 = DetachedAwardFinancialAssistanceFactory(legal_entity_country_code="USA",
-                                                          legal_entity_foreign_city="")
+                                                          legal_entity_foreign_city="",
+                                                          record_type=3)
+    det_award_5 = DetachedAwardFinancialAssistanceFactory(legal_entity_country_code="UK",
+                                                          legal_entity_foreign_city="",
+                                                          record_type=1)
+    det_award_6 = DetachedAwardFinancialAssistanceFactory(legal_entity_country_code="CAN",
+                                                          legal_entity_foreign_city=None,
+                                                          record_type=1)
 
-    errors = number_of_errors(_FILE, database, models=[det_award_1, det_award_2, det_award_3, det_award_4])
+    errors = number_of_errors(_FILE, database, models=[det_award_1, det_award_2, det_award_3, det_award_4, det_award_5,
+                                                       det_award_6])
     assert errors == 0
 
 
 def test_failure(database):
     """ Test failure LegalEntityForeignCityName is required for foreign recipients
-    (i.e., when LegalEntityCountryCode != USA) """
+    (i.e., when LegalEntityCountryCode != USA) for non-aggregate
+    and PII-redacted non-aggregate records (RecordType = 2 or 3)"""
 
     det_award = DetachedAwardFinancialAssistanceFactory(legal_entity_country_code="Japan",
-                                                        legal_entity_foreign_city=None)
+                                                        legal_entity_foreign_city=None,
+                                                        record_type=2)
     det_award_2 = DetachedAwardFinancialAssistanceFactory(legal_entity_country_code="Canada",
-                                                          legal_entity_foreign_city="")
+                                                          legal_entity_foreign_city="",
+                                                          record_type=3)
 
     errors = number_of_errors(_FILE, database, models=[det_award, det_award_2])
     assert errors == 2


### PR DESCRIPTION
FABS15.1 is updated to prevent legitimate foreign aggregate records from being validated. Adding a check for record type 2 and 3  and updating rule text given by Schema.

[Story Link](https://federal-spending-transparency.atlassian.net/browse/DEV-886)

- [ ] Reviewed by backend
- [ ]  Merged concurrently with https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/864

Technical Release Notes:
- Updated SQL rule
