### PR TITLE
Dev-1132: Update user name during login

### DIFF
--- a/dataactbroker/handlers/accountHandler.py
+++ b/dataactbroker/handlers/accountHandler.py
@@ -135,19 +135,9 @@ class AccountHandler:
                 # past the above group membership checks
                 if user is None:
                     user = User()
-
-                    first_name = cas_attrs['maxAttribute:First-Name']
-                    middle_name = cas_attrs['maxAttribute:Middle-Name']
-                    last_name = cas_attrs['maxAttribute:Last-Name']
-
                     user.email = email
 
-                    # Check for None first so the condition can short-circuit without
-                    # having to worry about calling strip() on a None object
-                    if middle_name is None or middle_name.strip() == '':
-                        user.name = first_name + " " + last_name
-                    else:
-                        user.name = first_name + " " + middle_name[0] + ". " + last_name
+                set_user_name(user, cas_attrs)
 
                 set_max_perms(user, cas_attrs['maxAttribute:GroupList'])
 
@@ -347,6 +337,25 @@ def best_affiliation(affiliations):
 
     all_affils = list(dabs_affils.values()) + list(fabs_affils.values())
     return all_affils
+
+
+def set_user_name(user, cas_attrs):
+    """ Update the name for the user based on the MAX attributes.
+
+        Args:
+            user: the User object
+            cas_attrs: a dictionary of the max attributes for a user who has successfully logedin
+    """
+    first_name = cas_attrs['maxAttribute:First-Name']
+    middle_name = cas_attrs['maxAttribute:Middle-Name']
+    last_name = cas_attrs['maxAttribute:Last-Name']
+
+    # Check for None first so the condition can short-circuit without
+    # having to worry about calling strip() on a None object
+    if middle_name is None or middle_name.strip() == '':
+        user.name = first_name + " " + last_name
+    else:
+        user.name = first_name + " " + middle_name[0] + ". " + last_name
 
 
 def set_max_perms(user, max_group_list):

--- a/dataactbroker/handlers/accountHandler.py
+++ b/dataactbroker/handlers/accountHandler.py
@@ -344,7 +344,7 @@ def set_user_name(user, cas_attrs):
 
         Args:
             user: the User object
-            cas_attrs: a dictionary of the max attributes for a user who has successfully logedin
+            cas_attrs: a dictionary of the max attributes (includes first, middle, last names) for a logged in user
     """
     first_name = cas_attrs['maxAttribute:First-Name']
     middle_name = cas_attrs['maxAttribute:Middle-Name']

--- a/tests/unit/dataactbroker/test_account_handler.py
+++ b/tests/unit/dataactbroker/test_account_handler.py
@@ -80,6 +80,51 @@ def test_max_login_failure(monkeypatch):
 
 
 @pytest.mark.usefixtures("user_constants")
+def test_set_user_name_middle_name(database, monkeypatch):
+    user = UserFactory()
+
+    mock_cas_attrs = {
+                    'maxAttribute:First-Name': 'Test',
+                    'maxAttribute:Middle-Name': 'Abc',
+                    'maxAttribute:Last-Name': 'User'
+                    }
+
+    accountHandler.set_user_name(user, mock_cas_attrs)
+
+    assert user.name == 'Test A. User'
+
+
+@pytest.mark.usefixtures("user_constants")
+def test_set_user_name_empty_middle_name(database, monkeypatch):
+    user = UserFactory()
+
+    mock_cas_attrs = {
+                    'maxAttribute:First-Name': 'Test',
+                    'maxAttribute:Middle-Name': ' ',
+                    'maxAttribute:Last-Name': 'User'
+                }
+
+    accountHandler.set_user_name(user, mock_cas_attrs)
+
+    assert user.name == 'Test User'
+
+
+@pytest.mark.usefixtures("user_constants")
+def test_set_user_name_none_middle_name(database, monkeypatch):
+    user = UserFactory()
+
+    mock_cas_attrs = {
+                    'maxAttribute:First-Name': 'Test',
+                    'maxAttribute:Middle-Name': None,
+                    'maxAttribute:Last-Name': 'User'
+                }
+
+    accountHandler.set_user_name(user, mock_cas_attrs)
+
+    assert user.name == 'Test User'
+
+
+@pytest.mark.usefixtures("user_constants")
 def test_set_max_perms(database, monkeypatch):
     """Verify that we get the _highest_ permission within our CGAC"""
     cgac_abc = CGACFactory(cgac_code='ABC')

--- a/tests/unit/dataactbroker/test_account_handler.py
+++ b/tests/unit/dataactbroker/test_account_handler.py
@@ -79,8 +79,7 @@ def test_max_login_failure(monkeypatch):
     assert error_message == json.loads(json_response.get_data().decode("utf-8"))['message']
 
 
-@pytest.mark.usefixtures("user_constants")
-def test_set_user_name_middle_name(database, monkeypatch):
+def test_set_user_name_middle_name():
     user = UserFactory()
 
     mock_cas_attrs = {
@@ -94,8 +93,7 @@ def test_set_user_name_middle_name(database, monkeypatch):
     assert user.name == 'Test A. User'
 
 
-@pytest.mark.usefixtures("user_constants")
-def test_set_user_name_empty_middle_name(database, monkeypatch):
+def test_set_user_name_empty_middle_name():
     user = UserFactory()
 
     mock_cas_attrs = {
@@ -109,8 +107,7 @@ def test_set_user_name_empty_middle_name(database, monkeypatch):
     assert user.name == 'Test User'
 
 
-@pytest.mark.usefixtures("user_constants")
-def test_set_user_name_none_middle_name(database, monkeypatch):
+def test_set_user_name_no_middle_name():
     user = UserFactory()
 
     mock_cas_attrs = {

--- a/tests/unit/dataactbroker/test_account_handler.py
+++ b/tests/unit/dataactbroker/test_account_handler.py
@@ -79,7 +79,25 @@ def test_max_login_failure(monkeypatch):
     assert error_message == json.loads(json_response.get_data().decode("utf-8"))['message']
 
 
+def test_set_user_name_updated():
+    """ Tests set_user_name()  updates a user's name """
+
+    user = UserFactory(name="No User")
+
+    mock_cas_attrs = {
+                    'maxAttribute:First-Name': 'New',
+                    'maxAttribute:Middle-Name': '',
+                    'maxAttribute:Last-Name': 'Name'
+                    }
+
+    accountHandler.set_user_name(user, mock_cas_attrs)
+
+    assert user.name == 'New Name'
+
+
 def test_set_user_name_middle_name():
+    """ Tests set_user_name() adds a middle name initial to the user's name when a middle name is provided """
+
     user = UserFactory()
 
     mock_cas_attrs = {
@@ -94,6 +112,7 @@ def test_set_user_name_middle_name():
 
 
 def test_set_user_name_empty_middle_name():
+    """ Tests set_user_name() omits a middle name initial to the user's name when a middle name is empty (spaces) """
     user = UserFactory()
 
     mock_cas_attrs = {
@@ -108,6 +127,8 @@ def test_set_user_name_empty_middle_name():
 
 
 def test_set_user_name_no_middle_name():
+    """ Tests set_user_name() omits a middle name initial to the user's name when a middle name is empty (None) """
+
     user = UserFactory()
 
     mock_cas_attrs = {


### PR DESCRIPTION
Adding the ability to update the user name upon login, so that the broker remains updated with MAX. 

[Bug ticket](https://federal-spending-transparency.atlassian.net/browse/DEV-1132)