### PR TITLE
DEV-1067: DABS service account permissions

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -24,7 +24,7 @@ The `/dataactbroker/scripts` folder contains the install scripts needed to setup
 ### Handlers
 The `dataactbroker/handlers` folder contains the logic to handle requests that are dispatched from the `domainRoutes.py`, `fileRoutes.py`, `loginRoutes.py`, and `userRoutes.py` files. Routes defined in these files may include the `@requires_login` and `@requires_submission_perms` tags to the route definition. This tag adds a wrapper that checks if there exists a session for the current user and if the user is logged in, as well as checking the user's permissions to determine if the user has access to this route. If user is not logged in to the system or does not have access to the route, a 401 HTTP error will be returned. This tags are defined in `dataactbroker/permissions.py`.
 
-`accountHandler.py` contains the functions to check logins and to log users out.
+`account_handler.py` contains the functions to check logins and to log users out.
 
 `fileHandler.py` contains functions for managing user file interaction. It creates all of the jobs that are part of the user submission and has query methods to get the status of a submission. In addition, this class creates downloadable links to error reports created by the DATA Act Validator.
 

--- a/dataactbroker/app.py
+++ b/dataactbroker/app.py
@@ -8,7 +8,7 @@ from flask import Flask, g, session
 from dataactbroker.domainRoutes import add_domain_routes
 from dataactbroker.exception_handler import add_exception_handlers
 from dataactbroker.fileRoutes import add_file_routes
-from dataactbroker.handlers.accountHandler import AccountHandler
+from dataactbroker.handlers.account_handler import AccountHandler
 from dataactbroker.handlers.aws.sesEmail import SesEmail
 from dataactbroker.handlers.aws.session import UserSessionInterface
 from dataactbroker.loginRoutes import add_login_routes

--- a/dataactbroker/handlers/accountHandler.py
+++ b/dataactbroker/handlers/accountHandler.py
@@ -295,27 +295,30 @@ def perms_to_affiliations(perms, user_id):
                 continue
 
         perm_level = perm_level.lower()
-        if perm_level not in 'rwsf':
+        if perm_level not in 'rwsfa':
             logger.warning(log_data)
             continue
+        elif perm_level == 'a':
+            perm_level = 'we'
 
-        if frec_code:
-            yield UserAffiliation(
-                cgac=available_cgacs[cgac_code],
-                frec=None,
-                permission_type_id=PERMISSION_SHORT_DICT['r']
-            )
-            yield UserAffiliation(
-                cgac=None,
-                frec=available_frecs[frec_code],
-                permission_type_id=PERMISSION_SHORT_DICT[perm_level]
-            )
-        else:
-            yield UserAffiliation(
-                cgac=available_cgacs[cgac_code] if cgac_code else None,
-                frec=None,
-                permission_type_id=PERMISSION_SHORT_DICT[perm_level]
-            )
+        for permission in perm_level:
+            if frec_code:
+                yield UserAffiliation(
+                    cgac=available_cgacs[cgac_code],
+                    frec=None,
+                    permission_type_id=PERMISSION_SHORT_DICT['r']
+                )
+                yield UserAffiliation(
+                    cgac=None,
+                    frec=available_frecs[frec_code],
+                    permission_type_id=PERMISSION_SHORT_DICT[permission]
+                )
+            else:
+                yield UserAffiliation(
+                    cgac=available_cgacs[cgac_code] if cgac_code else None,
+                    frec=None,
+                    permission_type_id=PERMISSION_SHORT_DICT[permission]
+                )
 
 
 def best_affiliation(affiliations):

--- a/dataactbroker/handlers/account_handler.py
+++ b/dataactbroker/handlers/account_handler.py
@@ -338,7 +338,7 @@ def best_affiliation(affiliations):
     for affil in sorted(dabs_affils, key=attrgetter('permission_type_id')):
         dabs_dict[affil.cgac, affil.frec] = affil
 
-    for affil in sorted(fabs_affils, key=attrgetter('permission_type_id'), reverse=True):
+    for affil in sorted(fabs_affils, key=attrgetter('permission_type_id')):
         fabs_dict[affil.cgac, affil.frec] = affil
 
     all_affils = list(dabs_dict.values()) + list(fabs_dict.values())

--- a/dataactbroker/handlers/account_handler.py
+++ b/dataactbroker/handlers/account_handler.py
@@ -20,7 +20,7 @@ from dataactcore.models.jobModels import Submission
 from dataactcore.utils.statusCode import StatusCode
 from dataactcore.interfaces.function_bag import get_email_template, check_correct_password
 from dataactcore.config import CONFIG_BROKER
-from dataactcore.models.lookups import PERMISSION_SHORT_DICT
+from dataactcore.models.lookups import PERMISSION_SHORT_DICT, DABS_PERMISSION_ID_LIST, FABS_PERMISSION_ID_LIST
 
 
 logger = logging.getLogger(__name__)
@@ -330,15 +330,18 @@ def best_affiliation(affiliations):
         Returns:
             List of all affiliations the user has (with duplicates, highest of each type/agency provided)
     """
-    dabs_affils, fabs_affils = {}, {}
-    affiliations = sorted(affiliations, key=attrgetter('permission_type_id'))
-    for affiliation in affiliations:
-        if affiliation.permission_type_id == PERMISSION_SHORT_DICT['f']:
-            fabs_affils[affiliation.cgac, affiliation.frec] = affiliation
-        else:
-            dabs_affils[affiliation.cgac, affiliation.frec] = affiliation
+    dabs_dict, fabs_dict = {}, {}
+    affils_list = list(affiliations)
+    dabs_affils = [affil for affil in affils_list if affil.permission_type_id in DABS_PERMISSION_ID_LIST]
+    fabs_affils = [affil for affil in affils_list if affil.permission_type_id in FABS_PERMISSION_ID_LIST]
 
-    all_affils = list(dabs_affils.values()) + list(fabs_affils.values())
+    for affil in sorted(dabs_affils, key=attrgetter('permission_type_id')):
+        dabs_dict[affil.cgac, affil.frec] = affil
+
+    for affil in sorted(fabs_affils, key=attrgetter('permission_type_id'), reverse=True):
+        fabs_dict[affil.cgac, affil.frec] = affil
+
+    all_affils = list(dabs_dict.values()) + list(fabs_dict.values())
     return all_affils
 
 

--- a/dataactbroker/handlers/account_handler.py
+++ b/dataactbroker/handlers/account_handler.py
@@ -331,15 +331,16 @@ def best_affiliation(affiliations):
             List of all affiliations the user has (with duplicates, highest of each type/agency provided)
     """
     dabs_dict, fabs_dict = {}, {}
-    affils_list = list(affiliations)
-    dabs_affils = [affil for affil in affils_list if affil.permission_type_id in DABS_PERMISSION_ID_LIST]
-    fabs_affils = [affil for affil in affils_list if affil.permission_type_id in FABS_PERMISSION_ID_LIST]
 
-    for affil in sorted(dabs_affils, key=attrgetter('permission_type_id')):
-        dabs_dict[affil.cgac, affil.frec] = affil
+    # Sort all affiliations from lowest to highest permission
+    sorted_affiliations = sorted(list(affiliations), key=attrgetter('permission_type_id'))
 
-    for affil in sorted(fabs_affils, key=attrgetter('permission_type_id')):
-        fabs_dict[affil.cgac, affil.frec] = affil
+    for affiliation in sorted_affiliations:
+        # Overwrite low permissions with high permissions; keep DABS and FABS separate so FABS doesn't overwrite DABS
+        if affiliation.permission_type_id in DABS_PERMISSION_ID_LIST:
+            dabs_dict[affiliation.cgac, affiliation.frec] = affiliation
+        elif affiliation.permission_type_id in FABS_PERMISSION_ID_LIST:
+            fabs_dict[affiliation.cgac, affiliation.frec] = affiliation
 
     all_affils = list(dabs_dict.values()) + list(fabs_dict.values())
     return all_affils

--- a/dataactbroker/loginRoutes.py
+++ b/dataactbroker/loginRoutes.py
@@ -2,7 +2,7 @@ from flask import g, request, session
 
 from dataactcore.utils.jsonResponse import JsonResponse
 from dataactcore.utils.statusCode import StatusCode
-from dataactbroker.handlers.accountHandler import AccountHandler, logout
+from dataactbroker.handlers.account_handler import AccountHandler, logout
 
 
 def add_login_routes(app, bcrypt):

--- a/dataactbroker/userRoutes.py
+++ b/dataactbroker/userRoutes.py
@@ -1,6 +1,6 @@
 from flask import g, request
 
-from dataactbroker.handlers.accountHandler import AccountHandler, json_for_user, list_user_emails
+from dataactbroker.handlers.account_handler import AccountHandler, json_for_user, list_user_emails
 from dataactbroker.permissions import requires_login
 from dataactcore.utils.jsonResponse import JsonResponse
 from dataactcore.utils.statusCode import StatusCode

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -87,9 +87,8 @@ PERMISSION_TYPES = [
     LookupType(1, 'reader', 'This user is allowed to view any submission for their agency'),
     LookupType(2, 'writer', 'This user is allowed to create and edit any submission for their agency'),
     LookupType(3, 'submitter', 'This user is allowed to certify and submit any submission for their agency'),
-    # Placeholder 4: website_admin
-    LookupType(5, 'fabs', 'This user is allowed to publish any FABS data for their agency'),
-    LookupType(6, 'editfabs', 'This user is allowed to create and edit any FABS data for their agency')
+    LookupType(4, 'editfabs', 'This user is allowed to create and edit any FABS data for their agency'),
+    LookupType(5, 'fabs', 'This user is allowed to publish any FABS data for their agency')
 ]
 PERMISSION_TYPE_DICT = {item.name: item.id for item in PERMISSION_TYPES[:3]}
 PERMISSION_TYPE_DICT_ID = {item.id: item.name for item in PERMISSION_TYPES}

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -94,6 +94,8 @@ PERMISSION_TYPES = [
 PERMISSION_TYPE_DICT = {item.name: item.id for item in PERMISSION_TYPES[:3]}
 PERMISSION_TYPE_DICT_ID = {item.id: item.name for item in PERMISSION_TYPES}
 PERMISSION_SHORT_DICT = {item.name[0]: item.id for item in PERMISSION_TYPES}
+DABS_PERMISSION_ID_LIST = [item.id for item in PERMISSION_TYPES[:3]]
+FABS_PERMISSION_ID_LIST = [item.id for item in PERMISSION_TYPES[3:]]
 
 FIELD_TYPE = [
     LookupType(1, 'INT', 'integer type'),

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -88,7 +88,8 @@ PERMISSION_TYPES = [
     LookupType(2, 'writer', 'This user is allowed to create and edit any submission for their agency'),
     LookupType(3, 'submitter', 'This user is allowed to certify and submit any submission for their agency'),
     # Placeholder 4: website_admin
-    LookupType(5, 'fabs', 'This user is allowed to create and publish any FABS data for their agency')
+    LookupType(5, 'fabs', 'This user is allowed to publish any FABS data for their agency'),
+    LookupType(6, 'editfabs', 'This user is allowed to create and edit any FABS data for their agency')
 ]
 PERMISSION_TYPE_DICT = {item.name: item.id for item in PERMISSION_TYPES[:3]}
 PERMISSION_TYPE_DICT_ID = {item.id: item.name for item in PERMISSION_TYPES}

--- a/tests/unit/dataactbroker/test_account_handler.py
+++ b/tests/unit/dataactbroker/test_account_handler.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from unittest.mock import Mock
 
-from dataactbroker.handlers import accountHandler
+from dataactbroker.handlers import account_handler
 from dataactcore.models.lookups import PERMISSION_TYPE_DICT, PERMISSION_SHORT_DICT
 from dataactcore.models.userModel import UserAffiliation
 from dataactcore.utils.jsonResponse import JsonResponse
@@ -30,18 +30,18 @@ def make_max_dict(group_str):
 
 @pytest.mark.usefixtures("user_constants")
 def test_max_login_success(monkeypatch):
-    ah = accountHandler.AccountHandler(Mock())
+    ah = account_handler.AccountHandler(Mock())
 
     mock_dict = Mock()
     mock_dict.return_value.safeDictionary.side_effect = {'ticket': '', 'service': ''}
-    monkeypatch.setattr(accountHandler, 'RequestDictionary', mock_dict)
+    monkeypatch.setattr(account_handler, 'RequestDictionary', mock_dict)
 
     max_dict = {'cas:serviceResponse': {}}
-    monkeypatch.setattr(accountHandler, 'get_max_dict', Mock(return_value=max_dict))
+    monkeypatch.setattr(account_handler, 'get_max_dict', Mock(return_value=max_dict))
     config = {'parent_group': 'parent-group'}
-    monkeypatch.setattr(accountHandler, 'CONFIG_BROKER', config)
+    monkeypatch.setattr(account_handler, 'CONFIG_BROKER', config)
     max_dict = make_max_dict('parent-group,parent-group-CGAC_SYS')
-    monkeypatch.setattr(accountHandler, 'get_max_dict', Mock(return_value=max_dict))
+    monkeypatch.setattr(account_handler, 'get_max_dict', Mock(return_value=max_dict))
 
     # If it gets to this point, that means the user was in all the right groups aka successful login
     monkeypatch.setattr(ah, 'create_session_and_response',
@@ -51,7 +51,7 @@ def test_max_login_success(monkeypatch):
     assert "Login successful" == json.loads(json_response.get_data().decode("utf-8"))['message']
 
     max_dict = make_max_dict('')
-    monkeypatch.setattr(accountHandler, 'get_max_dict', Mock(return_value=max_dict))
+    monkeypatch.setattr(account_handler, 'get_max_dict', Mock(return_value=max_dict))
 
     # If it gets to this point, that means the user was in all the right groups aka successful login
     monkeypatch.setattr(ah, 'create_session_and_response',
@@ -62,16 +62,16 @@ def test_max_login_success(monkeypatch):
 
 
 def test_max_login_failure(monkeypatch):
-    ah = accountHandler.AccountHandler(Mock())
+    ah = account_handler.AccountHandler(Mock())
     config = {'parent_group': 'parent-group'}
-    monkeypatch.setattr(accountHandler, 'CONFIG_BROKER', config)
+    monkeypatch.setattr(account_handler, 'CONFIG_BROKER', config)
 
     mock_dict = Mock()
     mock_dict.return_value.safeDictionary.side_effect = {'ticket': '', 'service': ''}
-    monkeypatch.setattr(accountHandler, 'RequestDictionary', mock_dict)
+    monkeypatch.setattr(account_handler, 'RequestDictionary', mock_dict)
 
     max_dict = {'cas:serviceResponse': {}}
-    monkeypatch.setattr(accountHandler, 'get_max_dict', Mock(return_value=max_dict))
+    monkeypatch.setattr(account_handler, 'get_max_dict', Mock(return_value=max_dict))
     json_response = ah.max_login(Mock())
     error_message = "You have failed to login successfully with MAX"
 
@@ -90,7 +90,7 @@ def test_set_user_name_updated():
                     'maxAttribute:Last-Name': 'Name'
                     }
 
-    accountHandler.set_user_name(user, mock_cas_attrs)
+    account_handler.set_user_name(user, mock_cas_attrs)
 
     assert user.name == 'New Name'
 
@@ -106,7 +106,7 @@ def test_set_user_name_middle_name():
                     'maxAttribute:Last-Name': 'User'
                     }
 
-    accountHandler.set_user_name(user, mock_cas_attrs)
+    account_handler.set_user_name(user, mock_cas_attrs)
 
     assert user.name == 'Test A. User'
 
@@ -121,7 +121,7 @@ def test_set_user_name_empty_middle_name():
                     'maxAttribute:Last-Name': 'User'
                 }
 
-    accountHandler.set_user_name(user, mock_cas_attrs)
+    account_handler.set_user_name(user, mock_cas_attrs)
 
     assert user.name == 'Test User'
 
@@ -137,7 +137,7 @@ def test_set_user_name_no_middle_name():
                     'maxAttribute:Last-Name': 'User'
                 }
 
-    accountHandler.set_user_name(user, mock_cas_attrs)
+    account_handler.set_user_name(user, mock_cas_attrs)
 
     assert user.name == 'Test User'
 
@@ -153,10 +153,10 @@ def test_set_max_perms(database, monkeypatch):
     database.session.add_all([cgac_abc, cgac_def, frec_abc, frec_def, user])
     database.session.commit()
 
-    monkeypatch.setitem(accountHandler.CONFIG_BROKER, 'parent_group', 'prefix')
+    monkeypatch.setitem(account_handler.CONFIG_BROKER, 'parent_group', 'prefix')
 
     # test creating permission from string
-    accountHandler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_W')
+    account_handler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_W')
     database.session.commit()   # populate ids
     assert len(user.affiliations) == 1
     affil = user.affiliations[0]
@@ -164,7 +164,7 @@ def test_set_max_perms(database, monkeypatch):
     assert affil.permission_type_id == PERMISSION_TYPE_DICT['writer']
 
     # test creating max CGAC permission from two strings
-    accountHandler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_R,prefix-CGAC_ABC-PERM_S')
+    account_handler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_R,prefix-CGAC_ABC-PERM_S')
     database.session.commit()   # populate ids
     assert len(user.affiliations) == 1
     affil = user.affiliations[0]
@@ -172,7 +172,7 @@ def test_set_max_perms(database, monkeypatch):
     assert affil.permission_type_id == PERMISSION_TYPE_DICT['submitter']
 
     # test creating two CGAC permissions with two strings
-    accountHandler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_R,prefix-CGAC_DEF-PERM_S')
+    account_handler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_R,prefix-CGAC_DEF-PERM_S')
     database.session.commit()
     assert len(user.affiliations) == 2
     affiliations = list(sorted(user.affiliations, key=lambda a: a.cgac.cgac_code))
@@ -185,7 +185,7 @@ def test_set_max_perms(database, monkeypatch):
     assert def_aff.permission_type_id == PERMISSION_TYPE_DICT['submitter']
 
     # test creating max FREC permission from two strings
-    accountHandler.set_max_perms(user, 'prefix-CGAC_ABC-FREC_ABCD-PERM_R,prefix-CGAC_ABC-FREC_ABCD-PERM_S')
+    account_handler.set_max_perms(user, 'prefix-CGAC_ABC-FREC_ABCD-PERM_R,prefix-CGAC_ABC-FREC_ABCD-PERM_S')
     database.session.commit()
     assert len(user.affiliations) == 2
     frec_affils = [affil for affil in user.affiliations if affil.frec is not None]
@@ -198,7 +198,7 @@ def test_set_max_perms(database, monkeypatch):
     assert cgac_affils[0].permission_type_id == PERMISSION_TYPE_DICT['reader']
 
     # test creating two FREC permissions from two strings
-    accountHandler.set_max_perms(user, 'prefix-CGAC_ABC-FREC_ABCD-PERM_R,prefix-CGAC_ABC-FREC_EFGH-PERM_S')
+    account_handler.set_max_perms(user, 'prefix-CGAC_ABC-FREC_ABCD-PERM_R,prefix-CGAC_ABC-FREC_EFGH-PERM_S')
     database.session.commit()
     assert len(user.affiliations) == 3
     frec_affils = [affil for affil in user.affiliations if affil.frec is not None]
@@ -216,7 +216,7 @@ def test_set_max_perms(database, monkeypatch):
     assert cgac_affils[0].permission_type_id == PERMISSION_TYPE_DICT['reader']
 
     # test creating one CGAC and one FREC permission from two strings
-    accountHandler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_S,prefix-CGAC_DEF-FREC_ABCD-PERM_R')
+    account_handler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_S,prefix-CGAC_DEF-FREC_ABCD-PERM_R')
     database.session.commit()
     assert len(user.affiliations) == 3
     frec_affils = [affil for affil in user.affiliations if affil.frec is not None]
@@ -234,7 +234,7 @@ def test_set_max_perms(database, monkeypatch):
     assert def_aff.permission_type_id == PERMISSION_TYPE_DICT['reader']
 
     # test creating max DABS and FABS CGAC permissions from three strings
-    accountHandler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_R,prefix-CGAC_ABC-PERM_S,prefix-CGAC_ABC-PERM_F')
+    account_handler.set_max_perms(user, 'prefix-CGAC_ABC-PERM_R,prefix-CGAC_ABC-PERM_S,prefix-CGAC_ABC-PERM_F')
     database.session.commit()
     assert len(user.affiliations) == 2
     affiliations = list(sorted(user.affiliations, key=lambda a: a.permission_type_id))
@@ -248,7 +248,7 @@ def test_set_max_perms(database, monkeypatch):
 
     # test creating max DABS and FABS FREC permissions from three strings
     perms_string = 'prefix-CGAC_ABC-FREC_ABCD-PERM_R,prefix-CGAC_ABC-FREC_ABCD-PERM_S,prefix-CGAC_ABC-FREC_ABCD-PERM_F'
-    accountHandler.set_max_perms(user, perms_string)
+    account_handler.set_max_perms(user, perms_string)
     database.session.commit()
     assert len(user.affiliations) == 3
     frec_affils = [affil for affil in user.affiliations if affil.frec is not None]
@@ -265,6 +265,38 @@ def test_set_max_perms(database, monkeypatch):
     assert cgac_affils[0].frec is None
     assert cgac_affils[0].permission_type_id == PERMISSION_TYPE_DICT['reader']
 
+    # test creating DABS and FABS CGAC permissions from service accounts
+    perms_string = 'prefix-CGAC_ABC-PERM_A'
+    account_handler.set_max_perms(user, perms_string)
+    database.session.commit()
+    assert len(user.affiliations) == 2
+    abc_aff, def_aff = list(sorted(user.affiliations, key=lambda a: a.permission_type_id))
+    assert abc_aff.cgac.cgac_code == 'ABC'
+    assert abc_aff.frec is None
+    assert abc_aff.permission_type_id == PERMISSION_TYPE_DICT['writer']
+    assert def_aff.cgac.cgac_code == 'ABC'
+    assert def_aff.frec is None
+    assert def_aff.permission_type_id == PERMISSION_SHORT_DICT['e']
+
+    # test creating DABS and FABS FREC permissions from service accounts
+    perms_string = 'prefix-CGAC_ABC-FREC_ABCD-PERM_A'
+    account_handler.set_max_perms(user, perms_string)
+    database.session.commit()
+    assert len(user.affiliations) == 3
+    frec_affils = [affil for affil in user.affiliations if affil.frec is not None]
+    frec_affiliations = list(sorted(frec_affils, key=lambda a: a.permission_type_id))
+    dabs_aff, fabs_aff = frec_affiliations
+    assert dabs_aff.cgac is None
+    assert dabs_aff.frec.frec_code == 'ABCD'
+    assert dabs_aff.permission_type_id == PERMISSION_TYPE_DICT['writer']
+    assert fabs_aff.cgac is None
+    assert fabs_aff.frec.frec_code == 'ABCD'
+    assert fabs_aff.permission_type_id == PERMISSION_SHORT_DICT['e']
+    cgac_affils = [affil for affil in user.affiliations if affil.cgac is not None]
+    assert cgac_affils[0].cgac.cgac_code == 'ABC'
+    assert cgac_affils[0].frec is None
+    assert cgac_affils[0].permission_type_id == PERMISSION_TYPE_DICT['reader']
+
 
 @pytest.mark.usefixtures("user_constants")
 def test_create_session_and_response(database, monkeypatch):
@@ -275,9 +307,9 @@ def test_create_session_and_response(database, monkeypatch):
     ])
     database.session.add_all(cgacs + [user])
     database.session.commit()
-    monkeypatch.setattr(accountHandler, 'LoginSession', Mock())
+    monkeypatch.setattr(account_handler, 'LoginSession', Mock())
 
-    result = accountHandler.AccountHandler.create_session_and_response(Mock(), user)
+    result = account_handler.AccountHandler.create_session_and_response(Mock(), user)
     result = json.loads(result.data.decode('utf-8'))
     assert result['message'] == 'Login successful'
     assert result['user_id'] == user.user_id

--- a/tests/unit/dataactbroker/test_domainRoutes.py
+++ b/tests/unit/dataactbroker/test_domainRoutes.py
@@ -4,6 +4,7 @@ from flask import g
 import pytest
 
 from dataactbroker import domainRoutes
+from dataactcore.models.lookups import PERMISSION_SHORT_DICT
 from dataactcore.models.userModel import UserAffiliation
 from tests.unit.dataactcore.factories.domain import CGACFactory, FRECFactory, SubTierAgencyFactory
 from tests.unit.dataactcore.factories.user import UserFactory

--- a/tests/unit/dataactbroker/test_domainRoutes.py
+++ b/tests/unit/dataactbroker/test_domainRoutes.py
@@ -26,8 +26,8 @@ def test_list_agencies_limits(domain_app, database):
                                       sub_tier_agency_name="Test Subtier Agency 0"),
                  SubTierAgencyFactory(sub_tier_agency_code='1', cgac=frec_cgac, frec=frec, is_frec=True,
                                       sub_tier_agency_name="Test Subtier Agency 1")]
-    user.affiliations = [UserAffiliation(cgac=cgac, frec=None, permission_type_id=2),
-                         UserAffiliation(cgac=None, frec=frec, permission_type_id=2)]
+    user.affiliations = [UserAffiliation(cgac=cgac, frec=None, permission_type_id=PERMISSION_SHORT_DICT['w']),
+                         UserAffiliation(cgac=None, frec=frec, permission_type_id=PERMISSION_SHORT_DICT['w'])]
     database.session.add_all([cgac] + [frec_cgac] + [frec] + sub_tiers + [user])
     database.session.commit()
 
@@ -75,7 +75,7 @@ def test_list_agencies_all(domain_app, database):
                                            sub_tier_agency_name="Test Subtier Agency "+str(i)) for i in range(3)]
     frec_sub_tiers = [SubTierAgencyFactory(sub_tier_agency_code=str(3+i), cgac=frec_cgac, frec=frecs[i], is_frec=True,
                                            sub_tier_agency_name="Test Subtier Agency "+str(3+i)) for i in range(3)]
-    user.affiliations = [UserAffiliation(cgac=cgacs[0], frec=frecs[0], permission_type_id=2)]
+    user.affiliations = [UserAffiliation(cgac=cgacs[0], frec=frecs[0], permission_type_id=PERMISSION_SHORT_DICT['w'])]
     database.session.add_all(cgacs + [frec_cgac] + frecs + cgac_sub_tiers + frec_sub_tiers + [user])
     database.session.commit()
 
@@ -99,8 +99,8 @@ def test_list_sub_tier_agencies(domain_app, database):
                                            sub_tier_agency_name="Test Subtier Agency " + str(i)) for i in range(3)]
     frec_sub_tiers = [SubTierAgencyFactory(sub_tier_agency_code=str(3 + i), cgac=frec_cgac, frec=frecs[i], is_frec=True,
                                            sub_tier_agency_name="Test Subtier Agency " + str(3 + i)) for i in range(3)]
-    user.affiliations = [UserAffiliation(cgac=cgacs[0], frec=None, permission_type_id=5),
-                         UserAffiliation(cgac=None, frec=frecs[2], permission_type_id=5)]
+    user.affiliations = [UserAffiliation(cgac=cgacs[0], frec=None, permission_type_id=PERMISSION_SHORT_DICT['f']),
+                         UserAffiliation(cgac=None, frec=frecs[2], permission_type_id=PERMISSION_SHORT_DICT['f'])]
     database.session.add_all(cgacs + [frec_cgac] + frecs + cgac_sub_tiers + frec_sub_tiers + [user])
     database.session.commit()
 
@@ -123,8 +123,8 @@ def test_list_sub_tier_agencies_admin(domain_app, database):
                                            sub_tier_agency_name="Test Subtier Agency " + str(i)) for i in range(3)]
     frec_sub_tiers = [SubTierAgencyFactory(sub_tier_agency_code=str(3 + i), cgac=frec_cgac, frec=frecs[i], is_frec=True,
                                            sub_tier_agency_name="Test Subtier Agency " + str(3 + i)) for i in range(3)]
-    user.affiliations = [UserAffiliation(cgac=cgacs[0], frec=None, permission_type_id=5),
-                         UserAffiliation(cgac=None, frec=frecs[2], permission_type_id=5)]
+    user.affiliations = [UserAffiliation(cgac=cgacs[0], frec=None, permission_type_id=PERMISSION_SHORT_DICT['f']),
+                         UserAffiliation(cgac=None, frec=frecs[2], permission_type_id=PERMISSION_SHORT_DICT['f'])]
     database.session.add_all(cgacs + [frec_cgac] + frecs + cgac_sub_tiers + frec_sub_tiers + [user])
     database.session.commit()
 


### PR DESCRIPTION
Updated `perms_to_affiliations` to accept service level accounts (`A`) and give them DABS `w` permissions and the new FABS `e` permissions (which are currently unused).

- [ ] Reviewed by backend

**Link to JIRA Ticket:**
[DEV-1067](https://federal-spending-transparency.atlassian.net/browse/DEV-1067)

**Technical Release Notes:**
Row added to the user permissions table (`PermissionType`): `editfabs`