### PR TITLE
DEV-1068: FABS service account permissions

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -793,7 +793,7 @@ File download or redirect to signed URL
 
 #### POST "/v1/submit_detached_file"
 
-This route sends a request to the backend with ID of the FABS submission we're submitting in order to process it.
+This route sends a request to the backend with ID of the FABS submission we're submitting in order to publish it.
 
 ##### Body (JSON)
 

--- a/dataactbroker/app.py
+++ b/dataactbroker/app.py
@@ -7,7 +7,7 @@ from flask import Flask, g, session
 
 from dataactbroker.domainRoutes import add_domain_routes
 from dataactbroker.exception_handler import add_exception_handlers
-from dataactbroker.fileRoutes import add_file_routes
+from dataactbroker.file_routes import add_file_routes
 from dataactbroker.handlers.account_handler import AccountHandler
 from dataactbroker.handlers.aws.sesEmail import SesEmail
 from dataactbroker.handlers.aws.session import UserSessionInterface

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -26,7 +26,6 @@ def add_file_routes(app, create_credentials, is_local, server_path):
     # Keys for the post route will correspond to the four types of files
     @app.route("/v1/submit_files/", methods=["POST"])
     @requires_login
-    @requires_submission_perms('writer')
     def submit_files():
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
         return file_manager.validate_submit_files(create_credentials)

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -225,7 +225,7 @@ def add_file_routes(app, create_credentials, is_local, server_path):
     @requires_submission_perms('writer', check_fabs='editfabs')
     def delete_submission(submission):
         """ Deletes all data associated with the specified submission
-            NOTE: THERE IS NO WAY TO UNDO THIS 
+            NOTE: THERE IS NO WAY TO UNDO THIS
         """
         return delete_all_submission_data(submission)
 

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -129,7 +129,6 @@ def add_file_routes(app, create_credentials, is_local, server_path):
         required=True,
         validate=webargs_validate.OneOf(FILE_TYPE_DICT_LETTER.values())
     )})
-    @requires_submission_perms('writer')
     def generate_file(submission_id, file_type):
         """ Generate file from external API """
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -129,6 +129,7 @@ def add_file_routes(app, create_credentials, is_local, server_path):
         required=True,
         validate=webargs_validate.OneOf(FILE_TYPE_DICT_LETTER.values())
     )})
+    @requires_submission_perms('writer')
     def generate_file(submission_id, file_type):
         """ Generate file from external API """
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
@@ -177,7 +178,7 @@ def add_file_routes(app, create_credentials, is_local, server_path):
         return JsonResponse.create(StatusCode.OK, get_fabs_meta(submission.submission_id))
 
     @app.route("/v1/upload_detached_file/", methods=["POST"])
-    @requires_submission_perms('editfabs')
+    @requires_login
     def upload_detached_file():
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
         return file_manager.upload_detached_file(create_credentials)
@@ -220,10 +221,10 @@ def add_file_routes(app, create_credentials, is_local, server_path):
 
     @app.route("/v1/delete_submission/", methods=['POST'])
     @convert_to_submission_id
-    @requires_submission_perms('reader', check_fabs='editfabs')
+    @requires_submission_perms('writer', check_fabs='editfabs')
     def delete_submission(submission):
         """ Deletes all data associated with the specified submission
-        NOTE: THERE IS NO WAY TO UNDO THIS """
+            NOTE: THERE IS NO WAY TO UNDO THIS """
         return delete_all_submission_data(submission)
 
     @app.route("/v1/check_year_quarter/", methods=["GET"])
@@ -245,7 +246,7 @@ def add_file_routes(app, create_credentials, is_local, server_path):
 
     @app.route("/v1/restart_validation/", methods=['POST'])
     @convert_to_submission_id
-    @requires_submission_perms('reader', check_fabs='editfabs')
+    @requires_submission_perms('writer', check_fabs='editfabs')
     @use_kwargs({'d2_submission': webargs_fields.Bool(missing=False)})
     def restart_validation(submission, d2_submission):
         return FileHandler.restart_validation(submission, d2_submission)

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -185,10 +185,10 @@ def add_file_routes(app, create_credentials, is_local, server_path):
 
     @app.route("/v1/submit_detached_file/", methods=["POST"])
     @convert_to_submission_id
-    @requires_submission_perms('writer')
+    @requires_submission_perms('fabs')
     def submit_detached_file(submission):
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
-        return file_manager.submit_detached_file(submission)
+        return file_manager.publish_fabs_submission(submission)
 
     @app.route("/v1/get_obligations/", methods=["POST"])
     @convert_to_submission_id

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -11,7 +11,7 @@ from dataactbroker.handlers.submission_handler import (
     get_revalidation_threshold)
 
 from dataactbroker.decorators import convert_to_submission_id
-from dataactbroker.permissions import requires_login, requires_submission_perms
+from dataactbroker.permissions import current_user_can, requires_login, requires_submission_perms
 
 from dataactcore.interfaces.function_bag import get_fabs_meta
 from dataactcore.models.lookups import FILE_TYPE_DICT, FILE_TYPE_DICT_LETTER
@@ -27,6 +27,7 @@ def add_file_routes(app, create_credentials, is_local, server_path):
     @app.route("/v1/submit_files/", methods=["POST"])
     @requires_login
     def submit_files():
+        current_user_can('writer', request.json.get('cgac_code', None), request.json.get('frec_code', None))
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
         return file_manager.validate_submit_files(create_credentials)
 
@@ -179,8 +180,9 @@ def add_file_routes(app, create_credentials, is_local, server_path):
     @app.route("/v1/upload_detached_file/", methods=["POST"])
     @requires_login
     def upload_detached_file():
+        current_user_can('editfabs', request.json.get('cgac_code', None), request.json.get('frec_code', None))
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
-        return file_manager.upload_detached_file(create_credentials)
+        return file_manager.upload_fabs_file(create_credentials)
 
     @app.route("/v1/submit_detached_file/", methods=["POST"])
     @convert_to_submission_id

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -225,7 +225,8 @@ def add_file_routes(app, create_credentials, is_local, server_path):
     @requires_submission_perms('writer', check_fabs='editfabs')
     def delete_submission(submission):
         """ Deletes all data associated with the specified submission
-            NOTE: THERE IS NO WAY TO UNDO THIS """
+            NOTE: THERE IS NO WAY TO UNDO THIS 
+        """
         return delete_all_submission_data(submission)
 
     @app.route("/v1/check_year_quarter/", methods=["GET"])

--- a/dataactbroker/handlers/account_handler.py
+++ b/dataactbroker/handlers/account_handler.py
@@ -298,6 +298,7 @@ def perms_to_affiliations(perms, user_id):
         if perm_level not in 'rwsfa':
             logger.warning(log_data)
             continue
+        # Replace MAX Service Account permissions with Broker "write" and "editfabs" permissions
         elif perm_level == 'a':
             perm_level = 'we'
 

--- a/dataactbroker/handlers/account_handler.py
+++ b/dataactbroker/handlers/account_handler.py
@@ -295,7 +295,7 @@ def perms_to_affiliations(perms, user_id):
                 continue
 
         perm_level = perm_level.lower()
-        if perm_level not in 'rwsfa':
+        if perm_level not in 'rwsefa':
             logger.warning(log_data)
             continue
         # Replace MAX Service Account permissions with Broker "write" and "editfabs" permissions

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -336,7 +336,7 @@ class FileHandler:
             # Compare user ID with user who submitted job, if no match return 400
             job = sess.query(Job).filter_by(job_id=job_id).one()
             submission = sess.query(Submission).filter_by(submission_id=job.submission_id).one()
-            if (submission.d2_submission and not current_user_can_on_submission('fabs', submission)) or \
+            if (submission.d2_submission and not current_user_can_on_submission('editfabs', submission)) or \
                     (not submission.d2_submission and not current_user_can_on_submission('writer', submission)):
                 # This user cannot finalize this job
                 raise ResponseException("Cannot finalize a job for a different agency", StatusCode.CLIENT_ERROR)
@@ -603,13 +603,9 @@ class FileHandler:
             job_data['reporting_start_date'] = None
             job_data['reporting_end_date'] = None
 
-            # TODO: Is this still needed for FABS uploads? Do we do this another way now?
-            """
-            Below lines commented out to temporarily allow all users to upload FABS data for all agencies during testing
-            """
-            # if not current_user_can('writer', job_data["cgac_code"]):
-            #     raise ResponseException("User does not have permission to create jobs for this agency",
-            #                             StatusCode.PERMISSION_DENIED)
+            if not current_user_can('editfabs', job_data["cgac_code"]):
+                raise ResponseException("User does not have permission to create FABS jobs for this agency",
+                                        StatusCode.PERMISSION_DENIED)
 
             submission = create_submission(g.user.user_id, job_data, existing_submission_obj)
             sess.add(submission)
@@ -1644,7 +1640,7 @@ def submission_error(submission_id, file_type):
             response_dict["end"] = ""
         return JsonResponse.error(NoResultFound, StatusCode.CLIENT_ERROR, **response_dict)
 
-    if not current_user_can_on_submission('writer', submission):
+    if not current_user_can_on_submission('editfabs' if submission.d2_submission else 'writer', submission):
         response_dict = {
             "message": "User does not have permission to view that submission",
             "file_type": file_type,

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -674,7 +674,7 @@ class FileHandler:
         return JsonResponse.create(StatusCode.OK, response_dict)
 
     @staticmethod
-    def submit_detached_file(submission):
+    def publish_fabs_submission(submission):
         """ Submits the FABS upload file associated with the submission ID, including processing all the derivations
             and updating relevant tables (such as un-caching all D2 files associated with this agency)
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -543,7 +543,7 @@ class FileHandler:
         # Return same response as check generation route
         return self.check_detached_generation(new_job.job_id)
 
-    def upload_detached_file(self, create_credentials):
+    def upload_fabs_file(self, create_credentials):
         """ Builds S3 URLs for a set of FABS files and adds all related jobs to job tracker database
 
             Flask request should include keys from FILE_TYPES class variable above

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -16,7 +16,16 @@ FABS_PERM = PERMISSION_SHORT_DICT['f']
 
 
 def requires_login(func):
-    """Decorator requiring that _a_ user be logged in (i.e. that we're not using an anonymous session)"""
+    """ Decorator requiring that _a_ user be logged in (i.e. that we're not using an anonymous session)
+
+        Args:
+            permission: single-letter string representing an application permission
+            cgac_code: 3-digit numerical string identifying a CGAC agency
+            frec_code: 4-digit numerical string identifying a FREC agency
+
+        Returns:
+            Boolean result on whether the user has permissions greater than or equal to permission
+    """
     @wraps(func)
     def inner(*args, **kwargs):
         if g.user is None:
@@ -63,7 +72,7 @@ def current_user_can(permission, cgac_code, frec_code):
     except KeyError:
         return False
 
-    # Loop through user's affiliations and return True if _any_ match the permission
+    # Loop through user's affiliations and return True if any match the permission
     for aff in g.user.affiliations:
         # Check if affiliation agency matches agency args
         if (aff.cgac and aff.cgac.cgac_code == cgac_code) or (aff.frec and aff.frec.frec_code == frec_code):

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -81,7 +81,7 @@ def current_user_can(permission, cgac_code, frec_code):
             fabs_perms = aff.permission_type_id <= permission_id and is_fabs
             dabs_perms = aff.permission_type_id >= permission_id and not is_fabs
 
-            if agency and ((permission == 'reader') or dabs_perms or fabs_perms):
+            if (permission == 'reader') or dabs_perms or fabs_perms:
                 return True
 
     return False

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -70,7 +70,7 @@ def current_user_can(permission, cgac_code, frec_code):
     # If the user is not logged in, or the user is a website admin, there is no reason to check their permissions
     if not hasattr(g, 'user'):
         return False
-    elif g.user.website_admin:
+    if g.user.website_admin:
         return True
 
     # Ensure the permission exists and retrieve its ID and type

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -17,7 +17,7 @@ FABS_PERM = PERMISSION_SHORT_DICT['f']
 
 
 def requires_login(func):
-    """ Decorator requiring that _a_ user be logged in (i.e. that we're not using an anonymous session)
+    """ Decorator requiring that a user be logged in (i.e. that we're not using an anonymous session)
 
         Args:
             permission: single-letter string representing an application permission
@@ -67,22 +67,20 @@ def current_user_can(permission, cgac_code, frec_code):
     elif g.user.website_admin:
         return True
 
-    # Ensure the permission exists and retrieve its ID
+    # Ensure the permission exists and retrieve its ID and type
     try:
         permission_id = ALL_PERMISSION_TYPES_DICT[permission]
     except KeyError:
         return False
+    permission_list = FABS_PERMISSION_ID_LIST if permission_id in FABS_PERMISSION_ID_LIST else DABS_PERMISSION_ID_LIST
 
     # Loop through user's affiliations and return True if any match the permission
     for aff in g.user.affiliations:
         # Check if affiliation agency matches agency args
         if (aff.cgac and aff.cgac.cgac_code == cgac_code) or (aff.frec and aff.frec.frec_code == frec_code):
             # Check if affiliation has higher permissions than permission args
-            is_fabs = aff.permission_type_id in FABS_PERMISSION_ID_LIST
-            fabs_perms = aff.permission_type_id <= permission_id and is_fabs
-            dabs_perms = aff.permission_type_id >= permission_id and not is_fabs
-
-            if (permission == 'reader') or dabs_perms or fabs_perms:
+            aff_perm_id = aff.permission_type_id
+            if (permission == 'reader') or (aff_perm_id in permission_list and aff_perm_id >= permission_id):
                 return True
 
     return False

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -20,12 +20,10 @@ def requires_login(func):
     """ Decorator requiring that a user be logged in (i.e. that we're not using an anonymous session)
 
         Args:
-            permission: single-letter string representing an application permission
-            cgac_code: 3-digit numerical string identifying a CGAC agency
-            frec_code: 4-digit numerical string identifying a FREC agency
+            func: the function that this wrapper is wrapped around
 
         Returns:
-            Boolean result on whether the user has permissions greater than or equal to permission
+            LOGIN_REQUIRED JSONResponse object if the user doesn't exist, otherwise it runs the wrapped function
     """
     @wraps(func)
     def inner(*args, **kwargs):
@@ -36,7 +34,15 @@ def requires_login(func):
 
 
 def requires_admin(func):
-    """Decorator requiring the requesting user be a website admin"""
+    """ Decorator requiring the requesting user be a website admin
+
+        Args:
+            func: the function that this wrapper is wrapped around
+
+        Returns:
+            LOGIN_REQUIRED JSONResponse object if the user doesn't exist or is not an admin user, otherwise it runs the
+            wrapped function
+    """
     @wraps(func)
     def inner(*args, **kwargs):
         if g.user is None:
@@ -102,7 +108,7 @@ def current_user_can_on_submission(perm, submission, check_owner=True):
     return (is_owner and check_owner) or current_user_can(perm, submission.cgac_code, submission.frec_code)
 
 
-def requires_submission_perms(perm, check_owner=True, check_fabs=False):
+def requires_submission_perms(perm, check_owner=True, check_fabs=None):
     """ Decorator that checks the current user's permissions and validates that the submission exists. It expects a
         submission_id parameter and will return a submission object
 

--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -92,6 +92,7 @@ PERMISSION_TYPES = [
     LookupType(6, 'editfabs', 'This user is allowed to create and edit any FABS data for their agency')
 ]
 PERMISSION_TYPE_DICT = {item.name: item.id for item in PERMISSION_TYPES[:3]}
+ALL_PERMISSION_TYPES_DICT = {item.name: item.id for item in PERMISSION_TYPES}
 PERMISSION_TYPE_DICT_ID = {item.id: item.name for item in PERMISSION_TYPES}
 PERMISSION_SHORT_DICT = {item.name[0]: item.id for item in PERMISSION_TYPES}
 DABS_PERMISSION_ID_LIST = [item.id for item in PERMISSION_TYPES[:3]]

--- a/tests/unit/dataactbroker/test_file_routes.py
+++ b/tests/unit/dataactbroker/test_file_routes.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 from flask import g
 import pytest
 
-from dataactbroker import fileRoutes
+from dataactbroker import file_routes
 from dataactcore.models.lookups import PUBLISH_STATUS_DICT
 from tests.unit.dataactcore.factories.domain import CGACFactory
 from tests.unit.dataactcore.factories.job import (JobFactory, SubmissionFactory, SubmissionWindowFactory,
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 
 @pytest.fixture
 def file_app(test_app):
-    fileRoutes.add_file_routes(test_app.application, Mock(), Mock(), Mock())
+    file_routes.add_file_routes(test_app.application, Mock(), Mock(), Mock())
     yield test_app
 
 

--- a/tests/unit/dataactbroker/test_permissions.py
+++ b/tests/unit/dataactbroker/test_permissions.py
@@ -359,6 +359,37 @@ def test_current_user_can_multiple_dabs_permissions(database, monkeypatch, user_
     assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
 
 
+def test_current_user_can_multiple_dabs_fabs_permissions(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user_submitter = UserFactory(affiliations=[
+        UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_TYPE_DICT['writer']),
+        UserAffiliation(cgac=user_cgac, permission_type_id=ALL_PERMISSION_TYPES_DICT['fabs'])
+    ])
+    database.session.add_all([user_cgac, other_cgac, user_submitter])
+    database.session.commit()
+
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
+
+    # has permission level, but wrong agency
+    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('writer', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('editfabs', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+
+    # has agency, but not permission level
+    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+
+    # right agency, right permission
+    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('writer', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+
+    # wrong agency, but superuser
+    user_submitter.website_admin = True
+    assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+
+
 def test_current_user_can_on_submission(monkeypatch, database):
     submission = SubmissionFactory()
     user = UserFactory()

--- a/tests/unit/dataactbroker/test_permissions.py
+++ b/tests/unit/dataactbroker/test_permissions.py
@@ -4,7 +4,7 @@ from flask import g
 import pytest
 
 from dataactbroker import permissions
-from dataactcore.models.lookups import PERMISSION_TYPE_DICT, PERMISSION_SHORT_DICT
+from dataactcore.models.lookups import ALL_PERMISSION_TYPES_DICT, PERMISSION_TYPE_DICT, PERMISSION_SHORT_DICT
 from dataactcore.models.userModel import UserAffiliation
 from dataactcore.utils.responseException import ResponseException
 from tests.unit.dataactcore.factories.domain import CGACFactory, FRECFactory
@@ -12,67 +12,291 @@ from tests.unit.dataactcore.factories.job import SubmissionFactory
 from tests.unit.dataactcore.factories.user import UserFactory
 
 
-def test_current_user_can(database, monkeypatch, user_constants):
-    # Test CGAC DABS permissions
+def test_current_user_can_dabs_cgac_reader(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
-    user_one = UserFactory(affiliations=[
-        UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_TYPE_DICT['writer'])
+    user_reader = UserFactory(affiliations=[
+        UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_TYPE_DICT['reader'])
     ])
-    database.session.add_all([user_cgac, other_cgac, user_one])
+    database.session.add_all([user_cgac, other_cgac, user_reader])
     database.session.commit()
 
-    monkeypatch.setattr(permissions, 'g', Mock(user=user_one))
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_reader))
 
     # has permission level, but wrong agency
     assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
+
     # has agency, but not permission level
+    assert not permissions.current_user_can('writer', user_cgac.cgac_code, None)
     assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+
     # right agency, right permission
-    assert permissions.current_user_can('writer', user_cgac.cgac_code, None)
     assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
+
     # wrong permission level, wrong agency, but superuser
-    user_one.website_admin = True
+    user_reader.website_admin = True
     assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
 
-    # Test FREC DABS permissions
-    user_frec, other_frec = [FRECFactory(cgac=user_cgac) for _ in range(2)]
-    user_two = UserFactory(affiliations=[
-        UserAffiliation(frec=user_frec, permission_type_id=PERMISSION_TYPE_DICT['writer'])
+
+def test_current_user_can_dabs_cgac_writer(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user_writer = UserFactory(affiliations=[
+        UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_TYPE_DICT['writer'])
     ])
-    database.session.add_all([user_frec, other_frec, user_two])
+    database.session.add_all([user_cgac, other_cgac, user_writer])
     database.session.commit()
 
-    monkeypatch.setattr(permissions, 'g', Mock(user=user_two))
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_writer))
+
+    # has permission level, but wrong agency
+    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('writer', other_cgac.cgac_code, None)
+
+    # has agency, but not permission level
+    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+
+    # right agency, right permission
+    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('writer', user_cgac.cgac_code, None)
+
+    # wrong permission level, wrong agency, but superuser
+    user_writer.website_admin = True
+    assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+
+
+def test_current_user_can_dabs_cgac_submitter(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user_submitter = UserFactory(affiliations=[
+        UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_TYPE_DICT['submitter'])
+    ])
+    database.session.add_all([user_cgac, other_cgac, user_submitter])
+    database.session.commit()
+
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
+
+    # has permission level, but wrong agency
+    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('writer', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+
+    # has agency, but not permission level
+    assert not permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+
+    # right agency, right permission
+    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('writer', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+
+    # wrong agency, but superuser
+    user_submitter.website_admin = True
+    assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+
+
+def test_current_user_can_dabs_frec_reader(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user_frec, other_frec = FRECFactory(cgac=user_cgac), FRECFactory(cgac=other_cgac)
+    user_reader = UserFactory(affiliations=[
+        UserAffiliation(frec=user_frec, permission_type_id=PERMISSION_TYPE_DICT['reader'])
+    ])
+    database.session.add_all([user_cgac, other_cgac, user_frec, other_frec, user_reader])
+    database.session.commit()
+
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_reader))
 
     # has permission level, but wrong agency
     assert not permissions.current_user_can('reader', None, other_frec.frec_code)
+
     # has agency, but not permission level
+    assert not permissions.current_user_can('writer', None, user_frec.frec_code)
     assert not permissions.current_user_can('submitter', None, user_frec.frec_code)
+    assert not permissions.current_user_can('editfabs', user_frec.frec_code, None)
+    assert not permissions.current_user_can('fabs', user_frec.frec_code, None)
+
     # right agency, right permission
-    assert permissions.current_user_can('writer', None, user_frec.frec_code)
     assert permissions.current_user_can('reader', None, user_frec.frec_code)
+
     # wrong permission level, wrong agency, but superuser
-    user_two.website_admin = True
+    user_reader.website_admin = True
     assert permissions.current_user_can('submitter', None, other_frec.frec_code)
 
-    # Test FABS permissions
-    user_three = UserFactory(affiliations=[
-        UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_SHORT_DICT['f'])
+
+def test_current_user_can_dabs_frec_writer(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user_frec, other_frec = FRECFactory(cgac=user_cgac), FRECFactory(cgac=other_cgac)
+    user_writer = UserFactory(affiliations=[
+        UserAffiliation(frec=user_frec, permission_type_id=PERMISSION_TYPE_DICT['writer'])
     ])
-    database.session.add(user_three)
+    database.session.add_all([user_cgac, other_cgac, user_frec, other_frec, user_writer])
     database.session.commit()
 
-    monkeypatch.setattr(permissions, 'g', Mock(user=user_three))
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_writer))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('reader', None, other_frec.frec_code)
+    assert not permissions.current_user_can('writer', None, other_frec.frec_code)
+
     # has agency, but not permission level
-    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('submitter', None, user_frec.frec_code)
+    assert not permissions.current_user_can('editfabs', user_frec.frec_code, None)
+    assert not permissions.current_user_can('fabs', user_frec.frec_code, None)
+
     # right agency, right permission
-    assert permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('reader', None, user_frec.frec_code)
+    assert permissions.current_user_can('writer', None, user_frec.frec_code)
+
     # wrong permission level, wrong agency, but superuser
-    user_three.website_admin = True
-    assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+    user_writer.website_admin = True
+    assert permissions.current_user_can('submitter', None, other_frec.frec_code)
+
+
+def test_current_user_can_dabs_frec_submitter(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user_frec, other_frec = FRECFactory(cgac=user_cgac), FRECFactory(cgac=other_cgac)
+    user_submitter = UserFactory(affiliations=[
+        UserAffiliation(frec=user_frec, permission_type_id=PERMISSION_TYPE_DICT['submitter'])
+    ])
+    database.session.add_all([user_cgac, other_cgac, user_frec, other_frec, user_submitter])
+    database.session.commit()
+
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
+
+    # has permission level, but wrong agency
+    assert not permissions.current_user_can('reader', None, other_frec.frec_code)
+    assert not permissions.current_user_can('writer', None, other_frec.frec_code)
+    assert not permissions.current_user_can('submitter', None, other_frec.frec_code)
+
+    # has agency, but not permission level
+    assert not permissions.current_user_can('editfabs', user_frec.frec_code, None)
+    assert not permissions.current_user_can('fabs', user_frec.frec_code, None)
+
+    # right agency, right permission
+    assert permissions.current_user_can('reader', None, user_frec.frec_code)
+    assert permissions.current_user_can('writer', None, user_frec.frec_code)
+    assert permissions.current_user_can('submitter', None, user_frec.frec_code)
+
+    # wrong agency, but superuser
+    user_submitter.website_admin = True
+    assert permissions.current_user_can('submitter', None, other_frec.frec_code)
+
+
+def test_current_user_can_fabs_cgac_editfabs(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user_editfabs = UserFactory(affiliations=[
+        UserAffiliation(cgac=user_cgac, permission_type_id=ALL_PERMISSION_TYPES_DICT['editfabs'])
+    ])
+    database.session.add_all([user_cgac, other_cgac, user_editfabs])
+    database.session.commit()
+
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_editfabs))
+
+    # has permission level, but wrong agency
+    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('editfabs', other_cgac.cgac_code, None)
+
+    # has agency, but not permission level
+    assert not permissions.current_user_can('writer', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+
+    # right agency, right permission
+    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
+
+    # wrong permission level, wrong agency, but superuser
+    user_editfabs.website_admin = True
+    assert permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+
+
+def test_current_user_can_fabs_cgac_fabs(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user_fabs = UserFactory(affiliations=[
+        UserAffiliation(cgac=user_cgac, permission_type_id=ALL_PERMISSION_TYPES_DICT['fabs'])
+    ])
+    database.session.add_all([user_cgac, other_cgac, user_fabs])
+    database.session.commit()
+
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_fabs))
+
+    # has permission level, but wrong agency
+    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('editfabs', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+
+    # has agency, but not permission level
+    assert not permissions.current_user_can('writer', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+
+    # right agency, right permission
+    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+
+    # wrong agency, but superuser
+    user_fabs.website_admin = True
+    assert permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+
+
+def test_current_user_can_fabs_frec_editfabs(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user_frec, other_frec = FRECFactory(cgac=user_cgac), FRECFactory(cgac=other_cgac)
+    user_editfabs = UserFactory(affiliations=[
+        UserAffiliation(frec=user_frec, permission_type_id=ALL_PERMISSION_TYPES_DICT['editfabs'])
+    ])
+    database.session.add_all([user_cgac, other_cgac, user_frec, other_frec, user_editfabs])
+    database.session.commit()
+
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_editfabs))
+
+    # has permission level, but wrong agency
+    assert not permissions.current_user_can('reader', None, other_frec.frec_code)
+    assert not permissions.current_user_can('editfabs', None, other_frec.frec_code)
+
+    # has agency, but not permission level
+    assert not permissions.current_user_can('writer', None, user_frec.frec_code)
+    assert not permissions.current_user_can('submitter', None, user_frec.frec_code)
+    assert not permissions.current_user_can('fabs', None, user_frec.frec_code)
+
+    # right agency, right permission
+    assert permissions.current_user_can('reader', None, user_frec.frec_code)
+    assert permissions.current_user_can('editfabs', None, user_frec.frec_code)
+
+    # wrong permission level, wrong agency, but superuser
+    user_editfabs.website_admin = True
+    assert permissions.current_user_can('fabs', None, other_frec.frec_code)
+
+
+def test_current_user_can_fabs_frec_fabs(database, monkeypatch, user_constants):
+    user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
+    user_frec, other_frec = FRECFactory(cgac=user_cgac), FRECFactory(cgac=other_cgac)
+    user_fabs = UserFactory(affiliations=[
+        UserAffiliation(frec=user_frec, permission_type_id=ALL_PERMISSION_TYPES_DICT['fabs'])
+    ])
+    database.session.add_all([user_cgac, other_cgac, user_frec, other_frec, user_fabs])
+    database.session.commit()
+
+    monkeypatch.setattr(permissions, 'g', Mock(user=user_fabs))
+
+    # has permission level, but wrong agency
+    assert not permissions.current_user_can('reader', None, other_frec.frec_code)
+    assert not permissions.current_user_can('editfabs', None, other_frec.frec_code)
+    assert not permissions.current_user_can('fabs', None, other_frec.frec_code)
+
+    # has agency, but not permission level
+    assert not permissions.current_user_can('writer', None, user_frec.frec_code)
+    assert not permissions.current_user_can('submitter', None, user_frec.frec_code)
+
+    # right agency, right permission
+    assert permissions.current_user_can('reader', None, user_frec.frec_code)
+    assert permissions.current_user_can('editfabs', None, user_frec.frec_code)
+    assert permissions.current_user_can('fabs', None, user_frec.frec_code)
+
+    # wrong agency, but superuser
+    user_fabs.website_admin = True
+    assert permissions.current_user_can('fabs', None, other_frec.frec_code)
 
 
 def test_current_user_can_on_submission(monkeypatch, database):

--- a/tests/unit/dataactbroker/test_permissions.py
+++ b/tests/unit/dataactbroker/test_permissions.py
@@ -359,7 +359,6 @@ def test_current_user_can_multiple_dabs_permissions(database, monkeypatch, user_
     assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
 
 
-
 def test_current_user_can_on_submission(monkeypatch, database):
     submission = SubmissionFactory()
     user = UserFactory()

--- a/tests/unit/dataactbroker/test_permissions.py
+++ b/tests/unit/dataactbroker/test_permissions.py
@@ -4,7 +4,7 @@ from flask import g
 import pytest
 
 from dataactbroker import permissions
-from dataactcore.models.lookups import ALL_PERMISSION_TYPES_DICT, PERMISSION_TYPE_DICT, PERMISSION_SHORT_DICT
+from dataactcore.models.lookups import ALL_PERMISSION_TYPES_DICT, PERMISSION_TYPE_DICT
 from dataactcore.models.userModel import UserAffiliation
 from dataactcore.utils.responseException import ResponseException
 from tests.unit.dataactcore.factories.domain import CGACFactory, FRECFactory


### PR DESCRIPTION
Updated all FABS permission checks to also accept `editfabs` permissions, excluding publishing. Updated the permissions checks so when we check for DABS (`reader`<`writer`<`submitter`) permissions we ignore FABS (`reader`<`editfabs`<`fabs`).

- [ ] Reviewed by backend

**Link to JIRA Ticket:**
[DEV-1068](https://federal-spending-transparency.atlassian.net/browse/DEV-1068)