### PR TITLE
Hotfix: current_user_can agency defaults

### DIFF
--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -27,7 +27,8 @@ def add_file_routes(app, create_credentials, is_local, server_path):
     @app.route("/v1/submit_files/", methods=["POST"])
     @requires_login
     def submit_files():
-        current_user_can('writer', request.json.get('cgac_code', None), request.json.get('frec_code', None))
+        current_user_can('writer', cgac_code=request.json.get('cgac_code', None),
+                         frec_code=request.json.get('frec_code', None))
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
         return file_manager.validate_submit_files(create_credentials)
 
@@ -180,7 +181,8 @@ def add_file_routes(app, create_credentials, is_local, server_path):
     @app.route("/v1/upload_detached_file/", methods=["POST"])
     @requires_login
     def upload_detached_file():
-        current_user_can('editfabs', request.json.get('cgac_code', None), request.json.get('frec_code', None))
+        current_user_can('editfabs', cgac_code=request.json.get('cgac_code', None),
+                         frec_code=request.json.get('frec_code', None))
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
         return file_manager.upload_fabs_file(create_credentials)
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -199,7 +199,7 @@ class FileHandler:
             cant_edit = (
                 existing_submission and not current_user_can_on_submission('writer', existing_submission_obj)
             )
-            cant_create = not current_user_can('writer', submission.cgac_code, submission.frec_code)
+            cant_create = not current_user_can('writer', cgac_code=submission.cgac_code, frec_code=submission.frec_code)
             if cant_edit or cant_create:
                 raise ResponseException(
                     "User does not have permission to create/modify that submission", StatusCode.PERMISSION_DENIED
@@ -603,7 +603,7 @@ class FileHandler:
             job_data['reporting_start_date'] = None
             job_data['reporting_end_date'] = None
 
-            if not current_user_can('editfabs', job_data["cgac_code"]):
+            if not current_user_can('editfabs', cgac_code=cgac_code, frec_code=frec_code):
                 raise ResponseException("User does not have permission to create FABS jobs for this agency",
                                         StatusCode.PERMISSION_DENIED)
 

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -55,7 +55,7 @@ def requires_admin(func):
     return inner
 
 
-def current_user_can(permission, cgac_code, frec_code):
+def current_user_can(permission, cgac_code=None, frec_code=None):
     """ Validate whether the current user can perform the act (described by the permission level) for the given
         cgac_code or frec_code
 
@@ -105,7 +105,8 @@ def current_user_can_on_submission(perm, submission, check_owner=True):
             Boolean result on whether the user has permissions greater than or equal to perm
     """
     is_owner = hasattr(g, 'user') and submission.user_id == g.user.user_id
-    return (is_owner and check_owner) or current_user_can(perm, submission.cgac_code, submission.frec_code)
+    user_can = current_user_can(perm, cgac_code=submission.cgac_code, frec_code=submission.frec_code)
+    return (is_owner and check_owner) or user_can
 
 
 def requires_submission_perms(perm, check_owner=True, check_fabs=None):

--- a/tests/unit/dataactbroker/test_permissions.py
+++ b/tests/unit/dataactbroker/test_permissions.py
@@ -23,20 +23,20 @@ def test_current_user_can_dabs_cgac_reader(database, monkeypatch, user_constants
     monkeypatch.setattr(permissions, 'g', Mock(user=user_reader))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
 
     # wrong permission level, wrong agency, but superuser
     user_reader.website_admin = True
-    assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+    assert permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
 
 def test_current_user_can_dabs_cgac_writer(database, monkeypatch, user_constants):
@@ -50,21 +50,21 @@ def test_current_user_can_dabs_cgac_writer(database, monkeypatch, user_constants
     monkeypatch.setattr(permissions, 'g', Mock(user=user_writer))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('writer', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('writer', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('writer', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
 
     # wrong permission level, wrong agency, but superuser
     user_writer.website_admin = True
-    assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+    assert permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
 
 def test_current_user_can_dabs_cgac_submitter(database, monkeypatch, user_constants):
@@ -78,22 +78,22 @@ def test_current_user_can_dabs_cgac_submitter(database, monkeypatch, user_consta
     monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('writer', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('writer', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('writer', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
 
     # wrong agency, but superuser
     user_submitter.website_admin = True
-    assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+    assert permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
 
 def test_current_user_can_dabs_frec_reader(database, monkeypatch, user_constants):
@@ -108,20 +108,20 @@ def test_current_user_can_dabs_frec_reader(database, monkeypatch, user_constants
     monkeypatch.setattr(permissions, 'g', Mock(user=user_reader))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', None, other_frec.frec_code)
+    assert not permissions.current_user_can('reader', frec_code=other_frec.frec_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', None, user_frec.frec_code)
-    assert not permissions.current_user_can('submitter', None, user_frec.frec_code)
-    assert not permissions.current_user_can('editfabs', user_frec.frec_code, None)
-    assert not permissions.current_user_can('fabs', user_frec.frec_code, None)
+    assert not permissions.current_user_can('writer', frec_code=user_frec.frec_code)
+    assert not permissions.current_user_can('submitter', frec_code=user_frec.frec_code)
+    assert not permissions.current_user_can('editfabs', cgac_code=user_frec.frec_code)
+    assert not permissions.current_user_can('fabs', cgac_code=user_frec.frec_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', None, user_frec.frec_code)
+    assert permissions.current_user_can('reader', frec_code=user_frec.frec_code)
 
     # wrong permission level, wrong agency, but superuser
     user_reader.website_admin = True
-    assert permissions.current_user_can('submitter', None, other_frec.frec_code)
+    assert permissions.current_user_can('submitter', frec_code=other_frec.frec_code)
 
 
 def test_current_user_can_dabs_frec_writer(database, monkeypatch, user_constants):
@@ -136,21 +136,21 @@ def test_current_user_can_dabs_frec_writer(database, monkeypatch, user_constants
     monkeypatch.setattr(permissions, 'g', Mock(user=user_writer))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', None, other_frec.frec_code)
-    assert not permissions.current_user_can('writer', None, other_frec.frec_code)
+    assert not permissions.current_user_can('reader', frec_code=other_frec.frec_code)
+    assert not permissions.current_user_can('writer', frec_code=other_frec.frec_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('submitter', None, user_frec.frec_code)
-    assert not permissions.current_user_can('editfabs', user_frec.frec_code, None)
-    assert not permissions.current_user_can('fabs', user_frec.frec_code, None)
+    assert not permissions.current_user_can('submitter', frec_code=user_frec.frec_code)
+    assert not permissions.current_user_can('editfabs', cgac_code=user_frec.frec_code)
+    assert not permissions.current_user_can('fabs', cgac_code=user_frec.frec_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', None, user_frec.frec_code)
-    assert permissions.current_user_can('writer', None, user_frec.frec_code)
+    assert permissions.current_user_can('reader', frec_code=user_frec.frec_code)
+    assert permissions.current_user_can('writer', frec_code=user_frec.frec_code)
 
     # wrong permission level, wrong agency, but superuser
     user_writer.website_admin = True
-    assert permissions.current_user_can('submitter', None, other_frec.frec_code)
+    assert permissions.current_user_can('submitter', frec_code=other_frec.frec_code)
 
 
 def test_current_user_can_dabs_frec_submitter(database, monkeypatch, user_constants):
@@ -165,22 +165,22 @@ def test_current_user_can_dabs_frec_submitter(database, monkeypatch, user_consta
     monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', None, other_frec.frec_code)
-    assert not permissions.current_user_can('writer', None, other_frec.frec_code)
-    assert not permissions.current_user_can('submitter', None, other_frec.frec_code)
+    assert not permissions.current_user_can('reader', frec_code=other_frec.frec_code)
+    assert not permissions.current_user_can('writer', frec_code=other_frec.frec_code)
+    assert not permissions.current_user_can('submitter', frec_code=other_frec.frec_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('editfabs', user_frec.frec_code, None)
-    assert not permissions.current_user_can('fabs', user_frec.frec_code, None)
+    assert not permissions.current_user_can('editfabs', cgac_code=user_frec.frec_code)
+    assert not permissions.current_user_can('fabs', cgac_code=user_frec.frec_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', None, user_frec.frec_code)
-    assert permissions.current_user_can('writer', None, user_frec.frec_code)
-    assert permissions.current_user_can('submitter', None, user_frec.frec_code)
+    assert permissions.current_user_can('reader', frec_code=user_frec.frec_code)
+    assert permissions.current_user_can('writer', frec_code=user_frec.frec_code)
+    assert permissions.current_user_can('submitter', frec_code=user_frec.frec_code)
 
     # wrong agency, but superuser
     user_submitter.website_admin = True
-    assert permissions.current_user_can('submitter', None, other_frec.frec_code)
+    assert permissions.current_user_can('submitter', frec_code=other_frec.frec_code)
 
 
 def test_current_user_can_fabs_cgac_editfabs(database, monkeypatch, user_constants):
@@ -194,21 +194,21 @@ def test_current_user_can_fabs_cgac_editfabs(database, monkeypatch, user_constan
     monkeypatch.setattr(permissions, 'g', Mock(user=user_editfabs))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('editfabs', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('editfabs', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
 
     # wrong permission level, wrong agency, but superuser
     user_editfabs.website_admin = True
-    assert permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+    assert permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
 
 def test_current_user_can_fabs_cgac_fabs(database, monkeypatch, user_constants):
@@ -222,22 +222,22 @@ def test_current_user_can_fabs_cgac_fabs(database, monkeypatch, user_constants):
     monkeypatch.setattr(permissions, 'g', Mock(user=user_fabs))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('editfabs', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('editfabs', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # wrong agency, but superuser
     user_fabs.website_admin = True
-    assert permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+    assert permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
 
 def test_current_user_can_fabs_frec_editfabs(database, monkeypatch, user_constants):
@@ -252,21 +252,21 @@ def test_current_user_can_fabs_frec_editfabs(database, monkeypatch, user_constan
     monkeypatch.setattr(permissions, 'g', Mock(user=user_editfabs))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', None, other_frec.frec_code)
-    assert not permissions.current_user_can('editfabs', None, other_frec.frec_code)
+    assert not permissions.current_user_can('reader', frec_code=other_frec.frec_code)
+    assert not permissions.current_user_can('editfabs', frec_code=other_frec.frec_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', None, user_frec.frec_code)
-    assert not permissions.current_user_can('submitter', None, user_frec.frec_code)
-    assert not permissions.current_user_can('fabs', None, user_frec.frec_code)
+    assert not permissions.current_user_can('writer', frec_code=user_frec.frec_code)
+    assert not permissions.current_user_can('submitter', frec_code=user_frec.frec_code)
+    assert not permissions.current_user_can('fabs', frec_code=user_frec.frec_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', None, user_frec.frec_code)
-    assert permissions.current_user_can('editfabs', None, user_frec.frec_code)
+    assert permissions.current_user_can('reader', frec_code=user_frec.frec_code)
+    assert permissions.current_user_can('editfabs', frec_code=user_frec.frec_code)
 
     # wrong permission level, wrong agency, but superuser
     user_editfabs.website_admin = True
-    assert permissions.current_user_can('fabs', None, other_frec.frec_code)
+    assert permissions.current_user_can('fabs', frec_code=other_frec.frec_code)
 
 
 def test_current_user_can_fabs_frec_fabs(database, monkeypatch, user_constants):
@@ -281,22 +281,22 @@ def test_current_user_can_fabs_frec_fabs(database, monkeypatch, user_constants):
     monkeypatch.setattr(permissions, 'g', Mock(user=user_fabs))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', None, other_frec.frec_code)
-    assert not permissions.current_user_can('editfabs', None, other_frec.frec_code)
-    assert not permissions.current_user_can('fabs', None, other_frec.frec_code)
+    assert not permissions.current_user_can('reader', frec_code=other_frec.frec_code)
+    assert not permissions.current_user_can('editfabs', frec_code=other_frec.frec_code)
+    assert not permissions.current_user_can('fabs', frec_code=other_frec.frec_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', None, user_frec.frec_code)
-    assert not permissions.current_user_can('submitter', None, user_frec.frec_code)
+    assert not permissions.current_user_can('writer', frec_code=user_frec.frec_code)
+    assert not permissions.current_user_can('submitter', frec_code=user_frec.frec_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', None, user_frec.frec_code)
-    assert permissions.current_user_can('editfabs', None, user_frec.frec_code)
-    assert permissions.current_user_can('fabs', None, user_frec.frec_code)
+    assert permissions.current_user_can('reader', frec_code=user_frec.frec_code)
+    assert permissions.current_user_can('editfabs', frec_code=user_frec.frec_code)
+    assert permissions.current_user_can('fabs', frec_code=user_frec.frec_code)
 
     # wrong agency, but superuser
     user_fabs.website_admin = True
-    assert permissions.current_user_can('fabs', None, other_frec.frec_code)
+    assert permissions.current_user_can('fabs', frec_code=other_frec.frec_code)
 
 
 def test_current_user_can_multiple_fabs_permissions(database, monkeypatch, user_constants):
@@ -311,22 +311,22 @@ def test_current_user_can_multiple_fabs_permissions(database, monkeypatch, user_
     monkeypatch.setattr(permissions, 'g', Mock(user=user_fabs))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('editfabs', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('editfabs', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # wrong agency, but superuser
     user_fabs.website_admin = True
-    assert permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+    assert permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
 
 def test_current_user_can_multiple_dabs_permissions(database, monkeypatch, user_constants):
@@ -341,22 +341,22 @@ def test_current_user_can_multiple_dabs_permissions(database, monkeypatch, user_
     monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('writer', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('writer', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
-    assert not permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('writer', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
 
     # wrong agency, but superuser
     user_submitter.website_admin = True
-    assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+    assert permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
 
 def test_current_user_can_multiple_dabs_fabs_permissions(database, monkeypatch, user_constants):
@@ -371,23 +371,23 @@ def test_current_user_can_multiple_dabs_fabs_permissions(database, monkeypatch, 
     monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('writer', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('editfabs', other_cgac.cgac_code, None)
-    assert not permissions.current_user_can('fabs', other_cgac.cgac_code, None)
+    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('writer', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('editfabs', cgac_code=other_cgac.cgac_code)
+    assert not permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('submitter', user_cgac.cgac_code, None)
+    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('writer', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('editfabs', user_cgac.cgac_code, None)
-    assert permissions.current_user_can('fabs', user_cgac.cgac_code, None)
+    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # wrong agency, but superuser
     user_submitter.website_admin = True
-    assert permissions.current_user_can('submitter', other_cgac.cgac_code, None)
+    assert permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
 
 def test_current_user_can_on_submission(monkeypatch, database):


### PR DESCRIPTION
Update current_user_can agency codes to default to `None`.