### PR TITLE
DEV-1158: Update FABS parent DUNS

### DIFF
--- a/dataactcore/scripts/loadDUNS.py
+++ b/dataactcore/scripts/loadDUNS.py
@@ -151,8 +151,12 @@ if __name__ == '__main__':
             elif historic_parent_duns:
                 yearly_files = [yearly_file for yearly_file in sorted_monthly_file_names
                                 if re.match(".*MONTHLY_\d{4}12\d{2}\.ZIP", yearly_file.upper())]
+                # Add the last monthly file if the last yearly file doesn't cover the current year
+                if (re.findall(".*MONTHLY_(\d{4})12\d{2}\.ZIP", yearly_files[-1])[0] != str(updated_date.year) and
+                        sorted_monthly_file_names[-1] != yearly_files[-1]):
+                    yearly_files.append(sorted_monthly_file_names[-1])
                 for yearly_file in yearly_files:
-                    year = re.findall(".*MONTHLY_(\d{4})12\d{2}\.ZIP", yearly_file)[0]
+                    year = re.findall(".*MONTHLY_(\d{4})\d{4}\.ZIP", yearly_file)[0]
                     if sftp.sock.closed:
                         # Reconnect if channel is closed
                         ssh_client = get_client()

--- a/dataactcore/scripts/update_fabs_parent_duns.py
+++ b/dataactcore/scripts/update_fabs_parent_duns.py
@@ -1,0 +1,130 @@
+import argparse
+import logging
+
+from dataactcore.interfaces.db import GlobalDB
+from dataactcore.logging import configure_logging
+from dataactvalidator.health_check import create_app
+
+from dataactcore.models.domainModels import HistoricParentDUNS
+from dataactcore.utils.parentDuns import sams_config_is_valid, get_name_from_sams
+
+logger = logging.getLogger(__name__)
+
+FABS_PARENT_DUNS_SQL_MATCH = """
+    WITH joined_historical_fabs AS (
+        SELECT
+            hfabs.published_award_financial_assistance_id AS "fabs_id",
+            hpd.ultimate_parent_unique_ide AS "parent_duns",
+            hpd.ultimate_parent_legal_enti AS "parent_name"
+        FROM published_award_financial_assistance hfabs
+        JOIN historic_parent_duns hpd ON (
+            hfabs.awardee_or_recipient_uniqu=hpd.awardee_or_recipient_uniqu AND
+            EXTRACT(YEAR FROM cast_as_date(hfabs.action_date))=hpd.year
+        )
+        WHERE (
+            hfabs.ultimate_parent_unique_ide IS NULL
+        )
+    )
+    UPDATE published_award_financial_assistance AS fabs
+    SET
+       ultimate_parent_unique_ide = joined_historical_fabs.parent_duns,
+       ultimate_parent_legal_enti = joined_historical_fabs.parent_name
+    FROM joined_historical_fabs
+    WHERE
+       joined_historical_fabs.fabs_id = fabs.published_award_financial_assistance_id 
+"""
+
+FABS_PARENT_DUNS_SQL_EARLIEST = """
+    WITH min_years AS (
+        SELECT awardee_or_recipient_uniqu, MIN(year) as "min_year"
+        FROM historic_parent_duns
+        GROUP BY awardee_or_recipient_uniqu
+    ),
+    joined_historical_fabs AS (
+        SELECT
+            hfabs.published_award_financial_assistance_id AS "fabs_id",
+            hfabs.awardee_or_recipient_uniqu,
+            hfabs.action_date,
+            min_years.min_year,
+            hpd.ultimate_parent_unique_ide AS "parent_duns",
+            hpd.ultimate_parent_legal_enti AS "parent_name"
+        FROM published_award_financial_assistance hfabs
+        JOIN historic_parent_duns hpd ON (
+            hfabs.awardee_or_recipient_uniqu=hpd.awardee_or_recipient_uniqu
+        )
+        JOIN min_years ON (
+            hfabs.awardee_or_recipient_uniqu = min_years.awardee_or_recipient_uniqu
+        )
+        WHERE (
+            hpd.year = min_years.min_year AND
+            hfabs.ultimate_parent_unique_ide IS NULL
+        )
+    )
+    UPDATE published_award_financial_assistance AS fabs
+    SET
+       ultimate_parent_unique_ide = joined_historical_fabs.parent_duns,
+       ultimate_parent_legal_enti = joined_historical_fabs.parent_name
+    FROM joined_historical_fabs
+    WHERE
+       joined_historical_fabs.fabs_id = fabs.published_award_financial_assistance_id;
+"""
+
+def update_historic_parent_names():
+    client = sams_config_is_valid()
+    hist_duns = sess.query(HistoricParentDUNS).filter(HistoricParentDUNS.ultimate_parent_unique_ide.isnot(None),
+                                                      HistoricParentDUNS.ultimate_parent_legal_enti.is_(None))
+    duns_count = hist_duns.count()
+    if not duns_count:
+        logger.info("Historical Parent DUNS table already has the names updated.")
+        return
+    block_size = 100
+    batch = 0
+    batches = duns_count // block_size
+    logger.info("Updating historical parent duns names")
+    all_models = []
+    while batch <= batches:
+        batch_start = batch * block_size
+        sliced_duns = hist_duns.order_by(HistoricParentDUNS.duns_id).slice(batch_start, batch_start + block_size)
+        models = {}
+        for row in sliced_duns:
+            if row.ultimate_parent_unique_ide not in models:
+                models[row.ultimate_parent_unique_ide] = [row]
+            else:
+                models[row.ultimate_parent_unique_ide].append(row)
+        sliced_duns_list = [str(duns) for duns in list(models.keys())]
+        duns_parent_df = get_name_from_sams(client, sliced_duns_list)
+        duns_parent_df = duns_parent_df.rename(columns={'awardee_or_recipient_uniqu': 'ultimate_parent_unique_ide',
+                                                        'legal_business_name': 'ultimate_parent_legal_enti'})
+        for _, row in duns_parent_df.iterrows():
+            parent_duns = row['ultimate_parent_unique_ide']
+            if parent_duns not in models:
+                models[parent_duns] = [HistoricParentDUNS()]
+            for field, value in row.items():
+                for model in models[parent_duns]:
+                    setattr(model, field, value)
+        all_models.extend([model for model_list in models.values() for model in model_list])
+    sess.add_all(models.values())
+    sess.commit()
+
+if __name__ == '__main__':
+    configure_logging()
+
+    with create_app().app_context():
+        parser = argparse.ArgumentParser(description='Update parent duns columns in FABS table')
+        args = parser.parse_args()
+        sess = GlobalDB.db().session
+
+        # Update the names of the historic duns that don't have names associated with them
+        logger.info("Gathering historical parent duns names via SAM service")
+        update_historic_parent_names()
+
+        # Update the FABS whose action_date falls within a yearly SAMS snapshot of DUNS data
+        logger.info("Updating FABS with action dates matching the years within the parent duns")
+        sess.execute(FABS_PARENT_DUNS_SQL_MATCH)
+        # Update the FABS whose action_dates do not fall within a yearly snapshot
+        # Using the earliest year provided
+        logger.info("Updating FABS with action dates not matching the parent duns, using the earliest match")
+        sess.execute(FABS_PARENT_DUNS_SQL_EARLIEST)
+        sess.close()
+
+        logger.info("Historical parent DUNS FABS updates complete.")

--- a/dataactcore/scripts/update_fabs_parent_duns.py
+++ b/dataactcore/scripts/update_fabs_parent_duns.py
@@ -67,7 +67,7 @@ FABS_PARENT_DUNS_SQL_EARLIEST = """
        joined_historical_fabs.fabs_id = fabs.published_award_financial_assistance_id;
 """
 
-def update_historic_parent_names_duns_service():
+def update_historic_parent_names_duns_service(sess):
     start = time.time()
     logger.info("Gathering historical parent duns names via SAM service")
     client = sams_config_is_valid()

--- a/dataactcore/scripts/update_fabs_parent_duns.py
+++ b/dataactcore/scripts/update_fabs_parent_duns.py
@@ -111,16 +111,12 @@ if __name__ == '__main__':
         args = parser.parse_args()
         sess = GlobalDB.db().session
 
-        # Update the names of the historic duns that don't have names associated with them
         logger.info("Gathering historical parent duns names via SAM service")
         update_historic_parent_names()
 
-        # Update the FABS whose action_date falls within a yearly SAMS snapshot of DUNS data
         logger.info("Updating FABS with action dates matching the years within the parent duns")
         sess.execute(FABS_PARENT_DUNS_SQL_MATCH)
-        
-        # Update the FABS whose action_dates do not fall within a yearly snapshot
-        # Using the earliest year provided
+
         logger.info("Updating FABS with action dates not matching the parent duns, using the earliest match")
         sess.execute(FABS_PARENT_DUNS_SQL_EARLIEST)
         sess.close()

--- a/dataactcore/scripts/update_fabs_parent_duns.py
+++ b/dataactcore/scripts/update_fabs_parent_duns.py
@@ -118,6 +118,7 @@ if __name__ == '__main__':
         # Update the FABS whose action_date falls within a yearly SAMS snapshot of DUNS data
         logger.info("Updating FABS with action dates matching the years within the parent duns")
         sess.execute(FABS_PARENT_DUNS_SQL_MATCH)
+        
         # Update the FABS whose action_dates do not fall within a yearly snapshot
         # Using the earliest year provided
         logger.info("Updating FABS with action dates not matching the parent duns, using the earliest match")

--- a/dataactcore/scripts/update_fabs_parent_duns.py
+++ b/dataactcore/scripts/update_fabs_parent_duns.py
@@ -132,12 +132,14 @@ if __name__ == '__main__':
         start = time.time()
         logger.info("Updating FABS with action dates matching the years within the parent duns")
         sess.execute(FABS_PARENT_DUNS_SQL_MATCH)
+        sess.commit()
         logger.info("Updated FABS with action dates matching the years within the parent duns, took {} seconds"
                     .format(time.time()-start))
 
         start = time.time()
         logger.info("Updating FABS with action dates not matching the parent duns, using the earliest match")
         sess.execute(FABS_PARENT_DUNS_SQL_EARLIEST)
+        sess.commit()
         logger.info("Updated FABS with action dates not matching the parent duns, using the earliest match, "
                     "took {} seconds".format(time.time()-start))
 

--- a/dataactcore/scripts/update_fabs_parent_duns.py
+++ b/dataactcore/scripts/update_fabs_parent_duns.py
@@ -105,7 +105,7 @@ def update_historic_parent_names_duns_service(sess):
                         setattr(model, field, value)
             all_models.extend([model for model_list in models.values() for model in model_list])
         batch += 1
-    sess.add_all(models.values())
+    sess.add_all(all_models)
     sess.commit()
     logger.info("Updated historical Parent DUNS names through SAM service, took {} seconds".format(time.time()-start))
 

--- a/dataactcore/scripts/update_fabs_parent_duns.py
+++ b/dataactcore/scripts/update_fabs_parent_duns.py
@@ -35,13 +35,20 @@ FABS_PARENT_DUNS_SQL_MATCH = """
        joined_historical_fabs.fabs_id = fabs.published_award_financial_assistance_id
 """
 
-FABS_PARENT_DUNS_SQL_EARLIEST = """
-    WITH min_years AS (
+CREATE_TEMP_MIN_YEARS_MATVIEW = """
+    CREATE MATERIALIZED VIEW tmp_matview_min_years
+    AS (
         SELECT awardee_or_recipient_uniqu, MIN(year) as "min_year"
         FROM historic_parent_duns
         GROUP BY awardee_or_recipient_uniqu
-    ),
-    joined_historical_fabs AS (
+    );
+
+    CREATE INDEX min_years_min_year_idx ON tmp_matview_min_years (min_year);
+    CREATE INDEX min_years_awardee_or_recipient_uniqu_idx ON tmp_matview_min_years (awardee_or_recipient_uniqu);
+"""
+
+FABS_PARENT_DUNS_SQL_EARLIEST = """
+    WITH joined_historical_fabs AS (
         SELECT
             hfabs.published_award_financial_assistance_id AS "fabs_id",
             hpd.ultimate_parent_unique_ide AS "parent_duns",
@@ -50,7 +57,7 @@ FABS_PARENT_DUNS_SQL_EARLIEST = """
         JOIN historic_parent_duns hpd ON (
             hfabs.awardee_or_recipient_uniqu=hpd.awardee_or_recipient_uniqu
         )
-        JOIN min_years ON (
+        JOIN tmp_matview_min_years min_years ON (
             hfabs.awardee_or_recipient_uniqu = min_years.awardee_or_recipient_uniqu
         )
         WHERE (
@@ -66,6 +73,13 @@ FABS_PARENT_DUNS_SQL_EARLIEST = """
     WHERE
        joined_historical_fabs.fabs_id = fabs.published_award_financial_assistance_id;
 """
+
+DROP_TEMP_MIN_YEARS_MATVIEW = """
+    DROP INDEX min_years_min_year_idx;
+    DROP INDEX min_years_awardee_or_recipient_uniqu_idx;
+    DROP MATERIALIZED VIEW tmp_matview_min_years;
+"""
+
 
 def update_historic_parent_names_duns_service(sess):
     start = time.time()
@@ -138,7 +152,11 @@ if __name__ == '__main__':
 
         start = time.time()
         logger.info("Updating FABS with action dates not matching the parent duns, using the earliest match")
+        sess.execute(CREATE_TEMP_MIN_YEARS_MATVIEW)
+        sess.commit()
         sess.execute(FABS_PARENT_DUNS_SQL_EARLIEST)
+        sess.commit()
+        sess.execute(DROP_TEMP_MIN_YEARS_MATVIEW)
         sess.commit()
         logger.info("Updated FABS with action dates not matching the parent duns, using the earliest match, "
                     "took {} seconds".format(time.time()-start))

--- a/dataactcore/scripts/update_fabs_parent_duns.py
+++ b/dataactcore/scripts/update_fabs_parent_duns.py
@@ -43,9 +43,6 @@ FABS_PARENT_DUNS_SQL_EARLIEST = """
     joined_historical_fabs AS (
         SELECT
             hfabs.published_award_financial_assistance_id AS "fabs_id",
-            hfabs.awardee_or_recipient_uniqu,
-            hfabs.action_date,
-            min_years.min_year,
             hpd.ultimate_parent_unique_ide AS "parent_duns",
             hpd.ultimate_parent_legal_enti AS "parent_name"
         FROM published_award_financial_assistance hfabs

--- a/dataactcore/utils/parentDuns.py
+++ b/dataactcore/utils/parentDuns.py
@@ -27,6 +27,7 @@ def sams_config_is_valid():
         })
         sys.exit(1)
 
+
 def get_name_from_sams(client, duns_list):
     """Calls SAM API to retrieve DUNS name by DUNS number. Returns DUNS info as Data Frame"""
     duns_name = [{

--- a/dataactcore/utils/parentDuns.py
+++ b/dataactcore/utils/parentDuns.py
@@ -27,6 +27,18 @@ def sams_config_is_valid():
         })
         sys.exit(1)
 
+def get_name_from_sams(client, duns_list):
+    """Calls SAM API to retrieve DUNS name by DUNS number. Returns DUNS info as Data Frame"""
+    duns_name = [{
+        'awardee_or_recipient_uniqu': suds_obj.entityIdentification.DUNS,
+        'legal_business_name': (suds_obj.entityIdentification.legalBusinessName or '').upper()
+    }
+        for suds_obj in get_entities(client, duns_list)
+        if suds_obj.entityIdentification.legalBusinessName
+    ]
+
+    return pd.DataFrame(duns_name)
+
 
 def get_parent_from_sams(client, duns_list):
     """Calls SAM API to retrieve parent DUNS data by DUNS number. Returns DUNS info as Data Frame"""

--- a/dataactcore/utils/parentDuns.py
+++ b/dataactcore/utils/parentDuns.py
@@ -57,7 +57,7 @@ def get_parent_from_sams(client, duns_list):
     return pd.DataFrame(duns_parent)
 
 
-def update_missing_parent_names(sess, updated_date=None):
+def update_missing_parent_names(sess, updated_date=None, table=DUNS):
     """Updates DUNS rows in batches where the parent DUNS number is provided but not the parent name.
        Uses other instances of the parent DUNS number where the name is populated to derive blank parent names.
        Updated_date argument used for daily DUNS loads so that only data updated that day is updated.
@@ -67,9 +67,9 @@ def update_missing_parent_names(sess, updated_date=None):
     # Create a mapping of all the unique parent duns -> name mappings from the database
     parent_duns_by_number_name = {}
 
-    distinct_parent_duns = sess.query(DUNS.ultimate_parent_unique_ide, DUNS.ultimate_parent_legal_enti)\
-        .filter(and_(func.coalesce(DUNS.ultimate_parent_legal_enti, '') != '',
-                     DUNS.ultimate_parent_unique_ide.isnot(None))).distinct()
+    distinct_parent_duns = sess.query(table.ultimate_parent_unique_ide, table.ultimate_parent_legal_enti)\
+        .filter(and_(func.coalesce(table.ultimate_parent_legal_enti, '') != '',
+                     table.ultimate_parent_unique_ide.isnot(None))).distinct()
 
     # Creating a mapping (parent_duns_by_number_name) of parent duns numbers to parent name
     for duns in distinct_parent_duns:
@@ -80,17 +80,18 @@ def update_missing_parent_names(sess, updated_date=None):
         parent_duns_by_number_name[duns.ultimate_parent_unique_ide] = duns.ultimate_parent_legal_enti
 
     # Query to find rows where the parent duns number is present, but there is no legal entity name
-    missing_parent_name = sess.query(DUNS).filter(and_(func.coalesce(DUNS.ultimate_parent_legal_enti, '') == '',
-                                                       DUNS.ultimate_parent_unique_ide.isnot(None)))
+    missing_parent_name = sess.query(table).filter(and_(func.coalesce(table.ultimate_parent_legal_enti, '') == '',
+                                                        table.ultimate_parent_unique_ide.isnot(None)))
 
     if updated_date:
-        missing_parent_name = missing_parent_name.filter(DUNS.updated_at >= updated_date)
+        missing_parent_name = missing_parent_name.filter(table.updated_at >= updated_date)
 
     missing_count = missing_parent_name.count()
 
     batch = 0
     block_size = 10000
     batches = missing_count // block_size
+    total_updated_count = 0
 
     while batch <= batches:
         updated_count = 0
@@ -101,20 +102,22 @@ def update_missing_parent_names(sess, updated_date=None):
                             str(missing_count if batch == batches else (batch+1)*block_size)
                             ))
 
-        missing_parent_name_block = missing_parent_name.order_by(DUNS.duns_id).\
+        missing_parent_name_block = missing_parent_name.order_by(table.duns_id).\
             slice(batch_start, batch_start + block_size)
 
         for row in missing_parent_name_block:
-
             if parent_duns_by_number_name.get(row.ultimate_parent_unique_ide):
                 setattr(row, 'ultimate_parent_legal_enti', parent_duns_by_number_name[row.ultimate_parent_unique_ide])
                 updated_count += 1
 
-        logger.info("Updated {} rows in DUNS with the parent name in {} s".format(updated_count, time.time()-start))
+        logger.info("Updated {} rows in {} with the parent name in {} s".format(updated_count, table.__name__,
+                                                                                     time.time()-start))
+        total_updated_count += updated_count
 
         batch += 1
 
     sess.commit()
+    return total_updated_count
 
 
 def get_duns_batches(client, sess, batch_start=None, batch_end=None, updated_date=None):

--- a/dataactcore/utils/parentDuns.py
+++ b/dataactcore/utils/parentDuns.py
@@ -111,7 +111,7 @@ def update_missing_parent_names(sess, updated_date=None, table=DUNS):
                 updated_count += 1
 
         logger.info("Updated {} rows in {} with the parent name in {} s".format(updated_count, table.__name__,
-                                                                                     time.time()-start))
+                                                                                time.time()-start))
         total_updated_count += updated_count
 
         batch += 1


### PR DESCRIPTION
**High level description:**
Includes script to backfill the ultimate parent name/duns for FABS data using the historic parent duns table. 

**Technical Release Notes:**
* Includes function to get the name of a DUNS directly via the SAM service
* Adding the latest monthly file to represent the DUNS data from the latest year
* Includes two SQL statements, one to update the FABS where the action date + DUNS match the historical parent DUNS table, the other to use the earliest action date + DUNS when there isn't a match

**Link to JIRA Ticket:**
[DEV-1158](https://federal-spending-transparency.atlassian.net/browse/DEV-1158)

**The following are ALL required for the PR to be merged:**
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases (N/A)
- Frontend impact assessment completed (N/A)
- [x] Performance Review
- [x] Data Review