### PR TITLE
Program activity fixes to accommodate for new headers and date problem

### DIFF
--- a/dataactvalidator/scripts/load_program_activity.py
+++ b/dataactvalidator/scripts/load_program_activity.py
@@ -56,6 +56,7 @@ def get_date_of_current_pa_upload(base_path):
     if CONFIG_BROKER["use_aws"]:
         last_uploaded = boto3.client('s3', region_name=CONFIG_BROKER['aws_region']). \
             head_object(Bucket=PA_BUCKET, Key=PA_SUB_KEY+PA_FILE_NAME)['LastModified']
+        print(last_uploaded)
     else:
         pa_file = get_program_activity_file(base_path)
         last_uploaded = datetime.datetime.utcfromtimestamp(os.path.getmtime(pa_file))

--- a/dataactvalidator/scripts/load_program_activity.py
+++ b/dataactvalidator/scripts/load_program_activity.py
@@ -57,6 +57,7 @@ def get_date_of_current_pa_upload(base_path):
         last_uploaded = boto3.client('s3', region_name=CONFIG_BROKER['aws_region']). \
             head_object(Bucket=PA_BUCKET, Key=PA_SUB_KEY+PA_FILE_NAME)['LastModified']
         print(last_uploaded)
+        last_uploaded = datetime.datetime(last_uploaded)
     else:
         pa_file = get_program_activity_file(base_path)
         last_uploaded = datetime.datetime.utcfromtimestamp(os.path.getmtime(pa_file))
@@ -78,7 +79,6 @@ def get_stored_pa_last_upload():
         last_stored = datetime.datetime.utcfromtimestamp(0)
     else:
         last_stored = last_stored_obj.last_load_date
-    print("HERE: {}".format(last_stored))
     return last_stored
 
 

--- a/dataactvalidator/scripts/load_program_activity.py
+++ b/dataactvalidator/scripts/load_program_activity.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 PA_BUCKET = 'da-data-sources'
 PA_SUB_KEY = 'OMB_Data/'
 PA_FILE_NAME = "DATA Act Program Activity List for Treas.csv"
-VALID_HEADERS = {'YEAR', 'AGENCY_ID', 'ALLOCATION_ID', 'ACCOUNT', 'PA_CODE', 'PA_NAME', 'FYQ'}
+VALID_HEADERS = {'YEAR', 'AGENCY_CODE', 'ALLOCATION_ID', 'ACCOUNT_CODE', 'PA_CODE', 'PA_TITLE', 'FYQ'}
 
 
 def get_program_activity_file(base_path):
@@ -56,9 +56,8 @@ def get_date_of_current_pa_upload(base_path):
     if CONFIG_BROKER["use_aws"]:
         last_uploaded = boto3.client('s3', region_name=CONFIG_BROKER['aws_region']). \
             head_object(Bucket=PA_BUCKET, Key=PA_SUB_KEY+PA_FILE_NAME)['LastModified']
-        print(last_uploaded)
+        # LastModified is coming back to us in UTC already; just drop the TZ.
         last_uploaded = last_uploaded.replace(tzinfo=None)
-        print(last_uploaded)
     else:
         pa_file = get_program_activity_file(base_path)
         last_uploaded = datetime.datetime.utcfromtimestamp(os.path.getmtime(pa_file))
@@ -133,8 +132,8 @@ def load_program_activity_data(base_path):
             dropped_count, data = clean_data(
                 data,
                 ProgramActivity,
-                {"fyq": "fiscal_year_quarter", "agency_id": "agency_id", "allocation_id": "allocation_transfer_id",
-                 "account": "account_number", "pa_code": "program_activity_code", "pa_name": "program_activity_name"},
+                {"fyq": "fiscal_year_quarter", "agency_code": "agency_id", "allocation_id": "allocation_transfer_id",
+                 "account_code": "account_number", "pa_code": "program_activity_code", "pa_title": "program_activity_name"},
                 {"program_activity_code": {"pad_to_length": 4}, "agency_id": {"pad_to_length": 3},
                  "allocation_transfer_id": {"pad_to_length": 3, "keep_null": True},
                  "account_number": {"pad_to_length": 4}},

--- a/dataactvalidator/scripts/load_program_activity.py
+++ b/dataactvalidator/scripts/load_program_activity.py
@@ -78,6 +78,7 @@ def get_stored_pa_last_upload():
         last_stored = datetime.datetime.utcfromtimestamp(0)
     else:
         last_stored = last_stored_obj.last_load_date
+    print("HERE: {}".format(last_stored))
     return last_stored
 
 

--- a/dataactvalidator/scripts/load_program_activity.py
+++ b/dataactvalidator/scripts/load_program_activity.py
@@ -57,7 +57,8 @@ def get_date_of_current_pa_upload(base_path):
         last_uploaded = boto3.client('s3', region_name=CONFIG_BROKER['aws_region']). \
             head_object(Bucket=PA_BUCKET, Key=PA_SUB_KEY+PA_FILE_NAME)['LastModified']
         print(last_uploaded)
-        last_uploaded = datetime.datetime(last_uploaded)
+        last_uploaded = last_uploaded.replace(tzinfo=None)
+        print(last_uploaded)
     else:
         pa_file = get_program_activity_file(base_path)
         last_uploaded = datetime.datetime.utcfromtimestamp(os.path.getmtime(pa_file))

--- a/dataactvalidator/scripts/load_program_activity.py
+++ b/dataactvalidator/scripts/load_program_activity.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 PA_BUCKET = 'da-data-sources'
 PA_SUB_KEY = 'OMB_Data/'
 PA_FILE_NAME = "DATA Act Program Activity List for Treas.csv"
-VALID_HEADERS = {'YEAR', 'AGENCY_CODE', 'ALLOCATION_ID', 'ACCOUNT_CODE', 'PA_CODE', 'PA_TITLE', 'FYQ'}
+VALID_HEADERS = {'AGENCY_CODE', 'ALLOCATION_ID', 'ACCOUNT_CODE', 'PA_CODE', 'PA_TITLE', 'FYQ'}
 
 
 def get_program_activity_file(base_path):

--- a/tests/unit/dataactvalidator/test_load_program_activity.py
+++ b/tests/unit/dataactvalidator/test_load_program_activity.py
@@ -71,7 +71,7 @@ def test_load_program_activity_data(mocked_get_pa_file, mocked_get_current_date,
     monkeypatch.setattr(load_program_activity, 'CONFIG_BROKER', {'use_aws': False})
 
     mocked_get_pa_file.return_value = StringIO(
-        """YEAR,AGENCY_ID,ALLOCATION_ID,ACCOUNT,PA_CODE,PA_NAME,FYQ\n2000,000,111,0000,1111,Test Name,FY2015Q1"""
+        """AGENCY_CODE,ALLOCATION_ID,ACCOUNT_CODE,PA_CODE,PA_TITLE,FYQ\n2000,000,111,0000,1111,Test Name,FY2015Q1"""
     )
 
     mocked_get_current_date.return_value = datetime.datetime(2017, 12, 31, 0, 0, 0)
@@ -102,7 +102,7 @@ def test_load_program_activity_data_only_header(mocked_get_pa_file, mocked_get_c
     monkeypatch.setattr(load_program_activity, 'CONFIG_BROKER', {'use_aws': False})
 
     mocked_get_pa_file.return_value = StringIO(
-        """YEAR,AGENCY_ID,ALLOCATION_ID,ACCOUNT,PA_CODE,PA_NAME,FYQ"""
+        """AGENCY_CODE,ALLOCATION_ID,ACCOUNT_CODE,PA_CODE,PA_TITLE,FYQ"""
     )
 
     mocked_get_current_date.return_value = datetime.datetime(2017, 12, 31, 0, 0, 0)


### PR DESCRIPTION
headers have changed to ```

PA_CODE | FYQ | OMB_BUREAU_TITLE_OPTNL | OMB_ACCOUNT_TITLE_OPTNL | AGENCY_CODE | ALLOCATION_ID | ACCOUNT_CODE | PA_TITLE
-- | -- | -- | -- | -- | -- | -- | --

```
And there was a bug in comparing naive and aware times.
