### PR TITLE
DEV-1191: Fix upload_detached_file permissions check

### DIFF
--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -10,8 +10,8 @@ from dataactbroker.handlers.submission_handler import (
     certify_dabs_submission, find_existing_submissions_in_period, get_submission_metadata, get_submission_data,
     get_revalidation_threshold)
 from dataactbroker.decorators import convert_to_submission_id
-from dataactbroker.permissions import (current_user_can, requires_login, requires_submission_perms,
-                                       requires_agency_perms, requires_sub_agency_perms)
+from dataactbroker.permissions import (requires_login, requires_submission_perms, requires_agency_perms,
+                                       requires_sub_agency_perms)
 
 from dataactcore.interfaces.function_bag import get_fabs_meta
 from dataactcore.models.lookups import FILE_TYPE_DICT, FILE_TYPE_DICT_LETTER

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -9,9 +9,9 @@ from dataactbroker.handlers.submission_handler import (
     delete_all_submission_data, get_submission_stats, list_windows, check_current_submission_page,
     certify_dabs_submission, find_existing_submissions_in_period, get_submission_metadata, get_submission_data,
     get_revalidation_threshold)
-
 from dataactbroker.decorators import convert_to_submission_id
-from dataactbroker.permissions import current_user_can, requires_login, requires_submission_perms
+from dataactbroker.permissions import (current_user_can, requires_login, requires_submission_perms,
+                                       requires_sub_agency_perms)
 
 from dataactcore.interfaces.function_bag import get_fabs_meta
 from dataactcore.models.lookups import FILE_TYPE_DICT, FILE_TYPE_DICT_LETTER
@@ -181,10 +181,8 @@ def add_file_routes(app, create_credentials, is_local, server_path):
         return JsonResponse.create(StatusCode.OK, get_fabs_meta(submission.submission_id))
 
     @app.route("/v1/upload_detached_file/", methods=["POST"])
-    @requires_login
+    @requires_sub_agency_perms('edit_fabs')
     def upload_detached_file():
-        current_user_can('editfabs', cgac_code=request.json.get('cgac_code', None),
-                         frec_code=request.json.get('frec_code', None))
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
         return file_manager.upload_fabs_file(create_credentials)
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -19,7 +19,7 @@ from werkzeug.utils import secure_filename
 from dataactbroker.handlers.fabsDerivationsHandler import fabs_derivations
 from dataactbroker.handlers.submission_handler import (create_submission, get_submission_status, get_submission_files,
                                                        reporting_date, job_to_dict)
-from dataactbroker.permissions import current_user_can, current_user_can_on_submission
+from dataactbroker.permissions import current_user_can_on_submission
 
 from dataactcore.aws.s3Handler import S3Handler
 from dataactcore.config import CONFIG_BROKER, CONFIG_SERVICES

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -603,10 +603,6 @@ class FileHandler:
             job_data['reporting_start_date'] = None
             job_data['reporting_end_date'] = None
 
-            if not current_user_can('editfabs', cgac_code=cgac_code, frec_code=frec_code):
-                raise ResponseException("User does not have permission to create FABS jobs for this agency",
-                                        StatusCode.PERMISSION_DENIED)
-
             submission = create_submission(g.user.user_id, job_data, existing_submission_obj)
             sess.add(submission)
             sess.commit()

--- a/dataactbroker/permissions.py
+++ b/dataactbroker/permissions.py
@@ -167,7 +167,6 @@ def requires_agency_perms(perm):
         @requires_login
         @wraps(fn)
         def wrapped(*args, **kwargs):
-            sess = GlobalDB.db().session
             req_args = webargs_parser.parse({
                 'existing_submission_id': webargs_fields.Int(missing=None),
                 'cgac_code': webargs_fields.String(missing=None),
@@ -176,25 +175,16 @@ def requires_agency_perms(perm):
             # Ensure there is either an existing_submission_id, a cgac_code, or a frec_code
             if req_args['existing_submission_id'] is None and req_args['cgac_code'] is None and \
                req_args['frec_code'] is None:
-                raise ResponseException('No valid agency provided', StatusCode.CLIENT_ERROR)
+                raise ResponseException('Missing required parameter: cgac_code, frec_code, or existing_submission_id',
+                                        StatusCode.CLIENT_ERROR)
 
             # Use codes based on existing Submission if existing_submission_id is provided, otherwise use CGAC or FREC
             if req_args['existing_submission_id'] is not None:
-                submission = sess.query(Submission).\
-                    filter(Submission.submission_id == req_args['existing_submission_id']).one_or_none()
-
-                # Ensure submission exists
-                if submission is None:
-                    raise ResponseException('No valid agency provided', StatusCode.CLIENT_ERROR)
-
-                # Check permissions for the submission
-                if not current_user_can_on_submission(perm, submission):
-                    raise ResponseException("User does not have permission to write to that agency",
-                                            StatusCode.PERMISSION_DENIED)
+                check_existing_submission_perms(perm, req_args['existing_submission_id'])
             else:
                 # Check permissions for the agency
                 if not current_user_can(perm, cgac_code=req_args['cgac_code'], frec_code=req_args['frec_code']):
-                    raise ResponseException("User does not have permission to write to that agency",
+                    raise ResponseException("User does not have permissions to write to that agency",
                                             StatusCode.PERMISSION_DENIED)
             return fn(*args, **kwargs)
         return wrapped
@@ -220,23 +210,30 @@ def requires_sub_agency_perms(perm):
         @wraps(fn)
         def wrapped(*args, **kwargs):
             sess = GlobalDB.db().session
-            req_args = webargs_parser.parse({'agency_code': webargs_fields.String(missing=None)})
+            req_args = webargs_parser.parse({
+                'agency_code': webargs_fields.String(missing=None),
+                'existing_submission_id': webargs_fields.String(missing=None)
+            })
+            if req_args['agency_code'] is None and req_args['existing_submission_id'] is None:
+                raise ResponseException('Missing required parameter: agency_code or existing_submission_id',
+                                        StatusCode.CLIENT_ERROR)
 
-            # Retrieve agency codes based on SubTierAgency
-            agency_code = req_args.get('agency_code', None)
-            if agency_code:
+            if req_args['existing_submission_id'] is not None:
+                check_existing_submission_perms(perm, req_args['existing_submission_id'])
+            else:
                 sub_tier_agency = sess.query(SubTierAgency).\
-                    filter(SubTierAgency.sub_tier_agency_code == agency_code).one_or_none()
-                cgac_code = sub_tier_agency.cgac.cgac_code if sub_tier_agency and sub_tier_agency.cgac_id else None
-                frec_code = sub_tier_agency.frec.frec_code if sub_tier_agency and sub_tier_agency.frec_id else None
+                    filter(SubTierAgency.sub_tier_agency_code == req_args['agency_code']).one_or_none()
 
-            if cgac_code is None and frec_code is None:
-                raise ResponseException('No valid agency provided', StatusCode.CLIENT_ERROR)
+                if sub_tier_agency is None:
+                    raise ResponseException('sub_tier_agency must be a valid sub_tier_agency_code',
+                                            StatusCode.CLIENT_ERROR)
 
-            if not current_user_can(perm, cgac_code=cgac_code, frec_code=frec_code):
-                raise ResponseException(
-                    "User does not have '{}' permissions for SubTierAgency {}".format(perm, agency_code),
-                    StatusCode.PERMISSION_DENIED)
+                cgac_code = sub_tier_agency.cgac.cgac_code if sub_tier_agency.cgac_id else None
+                frec_code = sub_tier_agency.frec.frec_code if sub_tier_agency.frec_id else None
+                if not current_user_can(perm, cgac_code=cgac_code, frec_code=frec_code):
+                    raise ResponseException("User does not have permissions to write to that subtier agency",
+                                            StatusCode.PERMISSION_DENIED)
+
             return fn(*args, **kwargs)
         return wrapped
     return inner
@@ -265,3 +262,28 @@ def separate_affiliations(affiliations, app_type):
                 cgac_ids.append(affiliation.cgac.cgac_id)
 
     return cgac_ids, frec_ids
+
+
+def check_existing_submission_perms(perm, submission_id):
+    """ Checks the current user's permissions against the submission with the ID of submission_id
+
+        Args:
+            perm: the type of permission we are checking for
+            submission_id: the ID of the Submission that the user input
+
+        Raises:
+            ResponseException: If the user doesn't have permission to access the submission at the level requested
+                or no valid agency code was provided.
+    """
+    sess = GlobalDB.db().session
+    submission = sess.query(Submission).filter(Submission.submission_id == submission_id).one_or_none()
+
+    # Ensure submission exists
+    if submission is None:
+        raise ResponseException("existing_submission_id must be a valid submission_id",
+                                StatusCode.CLIENT_ERROR)
+
+    # Check permissions for the submission
+    if not current_user_can_on_submission(perm, submission):
+        raise ResponseException("User does not have permissions to write to that submission",
+                                StatusCode.PERMISSION_DENIED)

--- a/tests/integration/detachedUploadTests.py
+++ b/tests/integration/detachedUploadTests.py
@@ -3,9 +3,10 @@ from datetime import datetime
 from tests.integration.baseTestAPI import BaseTestAPI
 from dataactbroker.app import create_app
 from dataactcore.interfaces.db import GlobalDB
+from dataactcore.models.domainModels import CGAC, FREC, SubTierAgency
 from dataactcore.models.userModel import User
-from dataactcore.models.jobModels import Submission
-from dataactcore.models.lookups import PUBLISH_STATUS_DICT
+from dataactcore.models.jobModels import Submission, Job
+from dataactcore.models.lookups import PUBLISH_STATUS_DICT, FILE_STATUS_DICT, FILE_TYPE_DICT, JOB_TYPE_DICT
 
 
 class DetachedUploadTests(BaseTestAPI):
@@ -25,6 +26,7 @@ class DetachedUploadTests(BaseTestAPI):
             agency_user = sess.query(User).filter(User.email == cls.test_users['agency_user']).one()
             cls.admin_user_id = admin_user.user_id
             cls.agency_user_id = agency_user.user_id
+            cls.agency_user_email = agency_user.email
 
             # setup submission/jobs data for test_check_status
             cls.d2_submission = cls.insert_submission(sess, cls.admin_user_id, cgac_code="SYS",
@@ -40,6 +42,11 @@ class DetachedUploadTests(BaseTestAPI):
             cls.other_submission = cls.insert_submission(sess, cls.admin_user_id, cgac_code="SYS",
                                                          start_date="07/2015", end_date="09/2015",
                                                          is_quarter=True, d2_submission=False)
+
+            cls.test_agency_user_submission_id = cls.insert_submission(sess, cls.agency_user_id, cgac_code="NOT",
+                                                                       start_date="10/2015", end_date="12/2015",
+                                                                       is_quarter=True, d2_submission=True)
+            cls.insert_agency_user_submission_data(sess, cls.test_agency_user_submission_id)
 
     def setUp(self):
         """Test set-up."""
@@ -61,7 +68,7 @@ class DetachedUploadTests(BaseTestAPI):
         response = self.app.post_json("/v1/submit_detached_file/", submission,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual("User does not have permission to access that submission", response.json["message"])
+        self.assertEqual(response.json["message"], "User does not have permission to access that submission")
 
     def test_already_published(self):
         """ Test a publish failure because the submission is already published """
@@ -69,7 +76,7 @@ class DetachedUploadTests(BaseTestAPI):
         response = self.app.post_json("/v1/submit_detached_file/", submission,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual("Submission has already been published", response.json["message"])
+        self.assertEqual(response.json["message"], "Submission has already been published")
 
     def test_not_fabs(self):
         """ Test a publish failure because the submission is not FABS """
@@ -77,7 +84,54 @@ class DetachedUploadTests(BaseTestAPI):
         response = self.app.post_json("/v1/submit_detached_file/", submission,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual("Submission is not a FABS submission", response.json["message"])
+        self.assertEqual(response.json["message"], "Submission is not a FABS submission")
+
+    def test_upload_detached_file_wrong_permissions_wrong_user(self):
+        self.login_user()
+        new_submission_json = {
+            "agency_code": "WRONG",
+            "is_quarter": True,
+            "reporting_period_start_date": "07/2015",
+            "reporting_period_end_date": "09/2015"}
+        response = self.app.post_json("/v1/upload_detached_file/", new_submission_json,
+                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json['message'], "User does not have permissions to write to that subtier agency")
+
+    def test_upload_detached_file_wrong_permissions_right_user(self):
+        self.login_user(username=self.agency_user_email)
+        update_submission_json = {
+            "existing_submission_id": str(self.test_agency_user_submission_id),
+            "fabs": "fabs.csv",
+            "is_quarter": True,
+            "reporting_period_start_date": "10/2015",
+            "reporting_period_end_date": "12/2015"}
+        response = self.app.post_json("/v1/upload_detached_file/", update_submission_json,
+                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 200)
+
+    def test_upload_detached_file_missing_parameters(self):
+        self.login_user(username=self.agency_user_email)
+        update_submission_json = {
+            "is_quarter": True,
+            "reporting_period_start_date": "10/2015",
+            "reporting_period_end_date": "12/2015"}
+        response = self.app.post_json("/v1/upload_detached_file/", update_submission_json,
+                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'Missing required parameter: agency_code or existing_submission_id')
+
+    def test_upload_detached_file_incorrect_parameters(self):
+        self.login_user(username=self.agency_user_email)
+        update_submission_json = {
+            "existing_submission_id": "-99",
+            "is_quarter": True,
+            "reporting_period_start_date": "10/2015",
+            "reporting_period_end_date": "12/2015"}
+        response = self.app.post_json("/v1/upload_detached_file/", update_submission_json,
+                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'existing_submission_id must be a valid submission_id')
 
     @staticmethod
     def insert_submission(sess, submission_user_id, cgac_code=None, start_date=None, end_date=None,
@@ -108,3 +162,22 @@ class DetachedUploadTests(BaseTestAPI):
         sess.add(sub)
         sess.commit()
         return sub.submission_id
+
+    @staticmethod
+    def insert_agency_user_submission_data(sess, submission_id):
+        """Insert jobs for the submission, and create a CGAC, FREC, and SubTierAgency"""
+        for job_type in ['file_upload', 'csv_record_validation', 'validation']:
+            sess.add(Job(file_type_id=FILE_TYPE_DICT['fabs'], job_status_id=FILE_STATUS_DICT['complete'],
+                         job_type_id=JOB_TYPE_DICT[job_type], submission_id=submission_id, original_filename=None,
+                         file_size=None, number_of_rows=None))
+            sess.commit()
+
+        cgac = CGAC(cgac_code="NOT")
+        sess.add(cgac)
+        sess.commit()
+        frec = FREC(cgac_id=cgac.cgac_id, frec_code="BLAH")
+        sess.add(frec)
+        sess.commit()
+        sub = SubTierAgency(sub_tier_agency_code="WRONG", cgac_id=cgac.cgac_id, frec_id=frec.frec_id, is_frec=False)
+        sess.add(sub)
+        sess.commit()

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -294,7 +294,7 @@ class FileTests(BaseTestAPI):
         response = self.app.post_json("/v1/submit_files/", new_submission_json,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json['message'], "User does not have permission to write to that agency")
+        self.assertEqual(response.json['message'], "User does not have permissions to write to that agency")
 
     def test_submit_file_wrong_permissions_right_user(self):
         self.login_user(username=self.other_user_email)
@@ -322,7 +322,8 @@ class FileTests(BaseTestAPI):
         response = self.app.post_json("/v1/submit_files/", update_submission_json,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json['message'], 'No valid agency provided')
+        self.assertEqual(response.json['message'],
+                         "Missing required parameter: cgac_code, frec_code, or existing_submission_id")
 
     def test_submit_file_incorrect_parameters(self):
         self.login_user(username=self.other_user_email)
@@ -337,7 +338,7 @@ class FileTests(BaseTestAPI):
         response = self.app.post_json("/v1/submit_files/", update_submission_json,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json['message'], 'No valid agency provided')
+        self.assertEqual(response.json['message'], 'existing_submission_id must be a valid submission_id')
 
     def test_revalidation_threshold_no_login(self):
         """ Test response with no login """


### PR DESCRIPTION
**High level description:**
Updated the permissions check for the `upload_detached_file` to function similarly to the rest of the checks.

**Technical details:**
Removed the non-functioning `current_user_can` check and the check within the `upload_fabs_file` function. Added a wrapper to check for permissions based on the request's `SubTierAgency`.

**Link to JIRA Ticket:**
[DEV-1191](https://federal-spending-transparency.atlassian.net/browse/DEV-1191)

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- Unit & integration tests updated with relevant test cases N/A
- Frontend impact assessment completed N/A
