### PR TITLE
DEV-1195: Fix submit_files permissions check 

### DIFF
--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -9,9 +9,8 @@ from dataactbroker.handlers.submission_handler import (
     delete_all_submission_data, get_submission_stats, list_windows, check_current_submission_page,
     certify_dabs_submission, find_existing_submissions_in_period, get_submission_metadata, get_submission_data,
     get_revalidation_threshold)
-
 from dataactbroker.decorators import convert_to_submission_id
-from dataactbroker.permissions import current_user_can, requires_login, requires_submission_perms
+from dataactbroker.permissions import current_user_can, requires_login, requires_submission_perms, requires_agency_perms
 
 from dataactcore.interfaces.function_bag import get_fabs_meta
 from dataactcore.models.lookups import FILE_TYPE_DICT, FILE_TYPE_DICT_LETTER
@@ -25,10 +24,8 @@ def add_file_routes(app, create_credentials, is_local, server_path):
 
     # Keys for the post route will correspond to the four types of files
     @app.route("/v1/submit_files/", methods=["POST"])
-    @requires_login
+    @requires_agency_perms('writer')
     def submit_files():
-        current_user_can('writer', cgac_code=request.json.get('cgac_code', None),
-                         frec_code=request.json.get('frec_code', None))
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
         return file_manager.validate_submit_files(create_credentials)
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -195,18 +195,8 @@ class FileHandler:
             submission_data['reporting_end_date'] = formatted_end_date
 
             submission = create_submission(g.user.user_id, submission_data, existing_submission_obj)
-
-            cant_edit = (
-                existing_submission and not current_user_can_on_submission('writer', existing_submission_obj)
-            )
-            cant_create = not current_user_can('writer', cgac_code=submission.cgac_code, frec_code=submission.frec_code)
-            if cant_edit or cant_create:
-                raise ResponseException(
-                    "User does not have permission to create/modify that submission", StatusCode.PERMISSION_DENIED
-                )
-            else:
-                sess.add(submission)
-                sess.commit()
+            sess.add(submission)
+            sess.commit()
 
             # build fileNameMap to be used in creating jobs
             self.build_file_map(request_params, FileHandler.FILE_TYPES, response_dict, upload_files, submission,


### PR DESCRIPTION
**High level description:**
Updated the permissions check for the `submit_files` to function similarly to the rest of the checks.

**Technical details:**
Removed the non-functioning `current_user_can` check within the route and the permissions check within the `submit` function. Added a wrapper to check for permissions based on the agency associated with the request's existing Submission or the `cgac_code`/`frec_code` within the request itself.

**Link to JIRA Ticket:**
[DEV-1195](https://federal-spending-transparency.atlassian.net/browse/DEV-1195)

**The following are ALL required for the PR to be merged:**
- [ ] Backend review completed
- Unit & integration tests updated with relevant test cases N/A
- Frontend impact assessment completed N/A