### PR TITLE
DEV-1212: get_obligations from a POST to a GET

### DIFF
--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -194,7 +194,7 @@ def add_file_routes(app, create_credentials, is_local, server_path):
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
         return file_manager.publish_fabs_submission(submission)
 
-    @app.route("/v1/get_obligations/", methods=["POST"])
+    @app.route("/v1/get_obligations/", methods=["GET"])
     @convert_to_submission_id
     @requires_submission_perms('reader')
     def get_obligations(submission):

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -607,17 +607,17 @@ class FileTests(BaseTestAPI):
         self.assertEqual({"appropriations"}, response_keys)
 
     def test_get_obligations(self):
+        """ Test submission obligations with an existing Submission """
         submission = SubmissionFactory()
         self.session.add(submission)
         self.session.commit()
-        response = self.app.post_json("/v1/get_obligations/", {"submission_id": submission.submission_id},
-                                      headers={"x-session-id": self.session_id})
+        response = self.app.get("/v1/get_obligations/", {"submission_id": submission.submission_id},
+                                headers={"x-session-id": self.session_id})
         assert response.status_code == 200
         assert "total_obligations" in response.json
 
     def test_get_protected_files(self):
         """ Check get_protected_files route """
-
         if CONFIG_BROKER["use_aws"]:
             response = self.app.get("/v1/get_protected_files/", headers={"x-session-id": self.session_id})
             self.assertEqual(response.status_code, 200, msg=str(response.json))


### PR DESCRIPTION
**High level description:**
Update `get_obligations` from a POST request to a GET.

**Technical details:**
Replace POST request to `get_obligations` to a GET request from `get_obligations`. Update tests to reflect this change.

**Link to JIRA Ticket:**
[DEV-1212](https://federal-spending-transparency.atlassian.net/browse/DEV-1212)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [ ] Merged concurrently with [#902](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/902)