### PR TITLE
DEV-1194 upload dabs bad params

### DIFF
--- a/tests/integration/detachedUploadTests.py
+++ b/tests/integration/detachedUploadTests.py
@@ -133,6 +133,25 @@ class DetachedUploadTests(BaseTestAPI):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], 'existing_submission_id must be a valid submission_id')
 
+    def test_upload_detached_file_missing_fabs(self):
+        new_submission_json = {
+            "agency_code": "WRONG",
+            "is_quarter": False}
+        response = self.app.post_json("/v1/upload_detached_file/", new_submission_json,
+                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], "fabs: Missing data for required field.")
+
+    def test_upload_detached_file_dabs_submission(self):
+        new_submission_json = {
+            "existing_submission_id": str(self.other_submission),
+            "is_quarter": False,
+            "fabs": "test_file.csv"}
+        response = self.app.post_json("/v1/upload_detached_file/", new_submission_json,
+                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], "Existing submission must be a FABS submission")
+
     @staticmethod
     def insert_submission(sess, submission_user_id, cgac_code=None, start_date=None, end_date=None,
                           is_quarter=False, publish_status_id=1, d2_submission=True):

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -280,6 +280,47 @@ class FileTests(BaseTestAPI):
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.json['message'], "A submission with the same period already exists.")
 
+    def test_submit_file_fabs_dabs_route(self):
+        """ Test trying to update a FABS submission via the DABS route """
+        update_json = {
+            "existing_submission_id": self.test_fabs_submission_id,
+            "is_quarter": True,
+            "appropriations": "appropriations.csv",
+            "award_financial": "award_financial.csv",
+            "program_activity": "program_activity.csv",
+            "reporting_period_start_date": "07/2015",
+            "reporting_period_end_date": "09/2015"}
+        response = self.app.post_json("/v1/submit_files/", update_json,
+                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], "Existing submission must be a DABS submission")
+
+    def test_submit_file_new_missing_params(self):
+        """ Test file submission for a new submission while missing any of the parameters """
+        update_json = {
+            "cgac_code": "TEST",
+            "is_quarter": True,
+            "appropriations": "appropriations.csv",
+            "award_financial": "award_financial.csv",
+            "reporting_period_start_date": "07/2015",
+            "reporting_period_end_date": "09/2015"}
+        response = self.app.post_json("/v1/submit_files/", update_json,
+                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], "Must include all files for a new submission")
+
+    def test_submit_file_old_no_params(self):
+        """ Test file submission for an existing submission while not providing any file parameters """
+        update_json = {
+            "existing_submission_id": self.status_check_submission_id,
+            "is_quarter": True,
+            "reporting_period_start_date": "07/2015",
+            "reporting_period_end_date": "09/2015"}
+        response = self.app.post_json("/v1/submit_files/", update_json,
+                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], "Must include at least one file for an existing submission")
+
     def test_submit_file_wrong_permissions_wrong_user(self):
         self.login_user()
         new_submission_json = {


### PR DESCRIPTION
Making checks for DABS file upload params happen before a new submission is created or an old one is altered so we don't break it when we don't pass the file names.