### PR TITLE
DEV-1208: Switch check_generation_status and check_detached_generation_status to GET

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1219,19 +1219,15 @@ Possible HTTP Status Codes:
 - 403: Permission denied, user does not have permission to view this submission
 
 
-### POST "/v1/check\_detached\_generation\_status"
+### GET "/v1/check\_detached\_generation\_status"
 
 This route returns either a signed S3 URL to the generated file or, if the file is not yet ready or have failed to generate for other reasons, returns a status indicating that. This route is used for file generation **independent** from a submission.
 
-#### Sample Request Body (JSON)
+#### Sample Request (JSON)
 
-```
-{
-    "job_id": 1
-}
-```
+`/v1/check_detached_generation_status/job_id=1`
 
-### Body Description
+### Request Params
 
 - `job_id` - **required** - an integer corresponding the job_id for the generation. Provided in the response of the call to `generate_detached_file`
 

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1156,20 +1156,15 @@ Response will be the same format as those returned from `/v1/check_generation_st
 
 
 ## File Status
-### POST "/v1/check\_generation\_status"
+### GET "/v1/check\_generation\_status"
 
 This route returns either a signed S3 URL to the generated file or, if the file is not yet ready or have failed to generate for other reasons, returns a status indicating that. This route is used for file generation **within** a submission.
 
-#### Sample Request Body (JSON)
+#### Sample Request
 
-```
-{
-    "submission_id": 123,
-    "file_type": "D1"
-}
-```
+`/v1/check_generation_status/?submission_id=123&file_type=D1`
 
-#### Body Params
+#### Request Params
 
 - `submission_id` - An integer representing the ID of the current submission
 - `file_type` - **required** - a string indicating the file type whose status we are checking. Allowable values are:
@@ -1177,7 +1172,6 @@ This route returns either a signed S3 URL to the generated file or, if the file 
     - `D2` - generate a D2 file
     - `E` - generate a E file
     - `F` - generate a F file
-
 
 #### Response (JSON)
 

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -161,7 +161,7 @@ def add_file_routes(app, create_credentials, is_local, server_path):
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
         return file_manager.generate_detached_file(file_type, cgac_code, frec_code, start, end)
 
-    @app.route("/v1/check_detached_generation_status/", methods=["POST"])
+    @app.route("/v1/check_detached_generation_status/", methods=["GET"])
     @requires_login
     @use_kwargs({'job_id': webargs_fields.Int(required=True)})
     def check_detached_generation_status(job_id):
@@ -169,7 +169,7 @@ def add_file_routes(app, create_credentials, is_local, server_path):
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
         return file_manager.check_detached_generation(job_id)
 
-    @app.route("/v1/check_generation_status/", methods=["POST"])
+    @app.route("/v1/check_generation_status/", methods=["GET"])
     @convert_to_submission_id
     @requires_submission_perms('reader')
     @use_kwargs({'file_type': webargs_fields.String(

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -681,8 +681,8 @@ class FileTests(BaseTestAPI):
     def test_bad_file_type_check_generation_status(self):
         """ Test that an error comes back if an invalid file type is provided for check_generation_status. """
         post_json = {"submission_id": self.generation_submission_id, "file_type": "A"}
-        response = self.app.post_json("/v1/check_generation_status/", post_json,
-                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        response = self.app.get("/v1/check_generation_status/", post_json, headers={"x-session-id": self.session_id},
+                                expect_errors=True)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json["message"], "file_type: Must be either D1, D2, E or F")
 
@@ -690,8 +690,7 @@ class FileTests(BaseTestAPI):
         """ Test the check generation status route for finished generation """
         # Then call check generation route for D2, E and F and check results
         post_json = {"submission_id": self.generation_submission_id, "file_type": "E"}
-        response = self.app.post_json("/v1/check_generation_status/", post_json,
-                                      headers={"x-session-id": self.session_id})
+        response = self.app.get("/v1/check_generation_status/", post_json, headers={"x-session-id": self.session_id})
 
         self.assertEqual(response.status_code, 200)
         json = response.json
@@ -703,8 +702,7 @@ class FileTests(BaseTestAPI):
     def test_check_generation_status_failed_file_level_errors(self):
         """ Test the check generation status route for a failed generation because of file level errors """
         post_json = {"submission_id": self.generation_submission_id, "file_type": "D2"}
-        response = self.app.post_json("/v1/check_generation_status/", post_json,
-                                      headers={"x-session-id": self.session_id})
+        response = self.app.get("/v1/check_generation_status/", post_json, headers={"x-session-id": self.session_id})
 
         self.assertEqual(response.status_code, 200)
         json = response.json
@@ -716,8 +714,7 @@ class FileTests(BaseTestAPI):
     def test_check_generation_status_failed_invalid_file(self):
         """ Test the check generation status route for a failed generation because of an invalid file """
         post_json = {"submission_id": self.generation_submission_id, "file_type": "F"}
-        response = self.app.post_json("/v1/check_generation_status/", post_json,
-                                      headers={"x-session-id": self.session_id})
+        response = self.app.get("/v1/check_generation_status/", post_json, headers={"x-session-id": self.session_id})
 
         self.assertEqual(response.status_code, 200)
         json = response.json
@@ -822,13 +819,13 @@ class FileTests(BaseTestAPI):
 
         # call check generation status route for D2 and check results
         post_json = {}
-        response = self.app.post_json("/v1/check_detached_generation_status/", post_json,
-                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        response = self.app.get("/v1/check_detached_generation_status/", post_json,
+                                headers={"x-session-id": self.session_id}, expect_errors=True)
         assert response.json['message'] == ('job_id: Missing data for required field.')
 
         post_json = {'job_id': -1}
-        response = self.app.post_json("/v1/check_detached_generation_status/", post_json,
-                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        response = self.app.get("/v1/check_detached_generation_status/", post_json,
+                                headers={"x-session-id": self.session_id}, expect_errors=True)
         json = response.json
         self.assertEqual(json["message"], 'No generation job found with the specified ID')
 


### PR DESCRIPTION
**High level description:**
Update `check_generation_status` and `check_detached_generation_status` from POST requests to GET.

**Technical details:**
Change the router for `check_generation_status` and `check_detached_generation_status` from POST to GET. Update README and tests.

**Link to JIRA Ticket:**
[DEV-1208](https://federal-spending-transparency.atlassian.net/browse/DEV-1208)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [ ] Merged concurrently with [Frontend#904](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/904)