### PR TITLE
DEV-1205: Block D file generation

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1196,6 +1196,13 @@ def check_generation_prereqs(submission_id, file_type):
     # Check cross-file validation if generating E or F
     if file_type in ['E', 'F']:
         unfinished_prereqs = prereq_query.filter(Job.job_type_id == JOB_TYPE_DICT['validation']).count()
+    # Check A, B, C files if generating a D file
+    elif file_type in ['D1', 'D2']:
+        unfinished_prereqs = prereq_query.filter(Job.file_type_id.in_([FILE_TYPE_DICT['appropriations'],
+                                                                       FILE_TYPE_DICT['program_activity'],
+                                                                       FILE_TYPE_DICT['award_financial']])).count()
+    else:
+        raise ResponseException('Invalid type for file generation', StatusCode.CLIENT_ERROR)
 
     return unfinished_prereqs == 0
 

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -819,7 +819,7 @@ class FileTests(BaseTestAPI):
         self.assertEqual(json["message"], "end: Must be in the format MM/DD/YYYY")
 
     def test_generate_d_file_no_start(self):
-        """ Test bad format on start date """
+        """ Test that there is an error if no start date is provided for D file generation. """
         post_json = {"submission_id": self.generation_submission_id, "file_type": "D1", "end": "02/03/2016"}
         response = self.app.post_json("/v1/generate_file/", post_json, headers={"x-session-id": self.session_id},
                                       expect_errors=True)
@@ -829,7 +829,7 @@ class FileTests(BaseTestAPI):
         self.assertEqual(json["message"], "Must have a start and end date for D file generation")
 
     def test_generate_ef_file_no_start(self):
-        """ Test bad format on start date """
+        """ Test that there is no error when no start date is provided for E/F file generation """
         post_json = {"submission_id": self.generation_submission_id, "file_type": "E", "end": "02/03/2016"}
         response = self.app.post_json("/v1/generate_file/", post_json, headers={"x-session-id": self.session_id})
 
@@ -1072,7 +1072,7 @@ class FileTests(BaseTestAPI):
         self.session.add(submission)
         self.session.commit()
 
-        job_1 = self.insert_job(self.session, FILE_TYPE_DICT['appropriations'], JOB_STATUS_DICT['finished'],
+        job_1 = self.insert_job(self.session, FILE_TYPE_DICT['award'], JOB_STATUS_DICT['finished'],
                                 JOB_TYPE_DICT['csv_record_validation'], submission.submission_id, num_errors=1)
         job_2 = self.insert_job(self.session, FILE_TYPE_DICT['award_procurement'], JOB_STATUS_DICT['finished'],
                                 JOB_TYPE_DICT['file_upload'], submission.submission_id)

--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -899,15 +899,17 @@ def test_process_job_status():
 
 @pytest.mark.usefixtures("job_constants")
 def test_check_generation_prereqs_ef_valid(database):
-    """ Tests a set of conditions that passes the prerequisite checks to allow E/F files to be generated. """
+    """ Tests a set of conditions that passes the prerequisite checks to allow E/F files to be generated. Show that
+        warnings do not prevent generation.
+    """
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
     cross_val = JobFactory(submission_id=sub.submission_id,
                            job_type=sess.query(JobType).filter_by(name='validation').one(),
-                           file_type=sess.query(FileType).filter_by(name='appropriations').one(),
+                           file_type=None,
                            job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                           number_of_errors=0, number_of_warnings=0, error_message=None)
+                           number_of_errors=0, number_of_warnings=1, error_message=None)
     sess.add_all([sub, cross_val])
     sess.commit()
 
@@ -917,13 +919,13 @@ def test_check_generation_prereqs_ef_valid(database):
 
 @pytest.mark.usefixtures("job_constants")
 def test_check_generation_prereqs_ef_not_finished(database):
-    """ Tests a set of conditions that passes the prerequisite checks to allow E/F files to be generated. """
+    """ Tests a set of conditions that has cross-file still waiting, fail the generation check for E/F files. """
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
     cross_val = JobFactory(submission_id=sub.submission_id,
                            job_type=sess.query(JobType).filter_by(name='validation').one(),
-                           file_type=sess.query(FileType).filter_by(name='appropriations').one(),
+                           file_type=None,
                            job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
                            number_of_errors=0, number_of_warnings=0, error_message=None)
     sess.add_all([sub, cross_val])
@@ -935,13 +937,13 @@ def test_check_generation_prereqs_ef_not_finished(database):
 
 @pytest.mark.usefixtures("job_constants")
 def test_check_generation_prereqs_ef_has_errors(database):
-    """ Tests a set of conditions that passes the prerequisite checks to allow E/F files to be generated. """
+    """ Tests a set of conditions that has an error in cross-file, fail the generation check for E/F files. """
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
     cross_val = JobFactory(submission_id=sub.submission_id,
                            job_type=sess.query(JobType).filter_by(name='validation').one(),
-                           file_type=sess.query(FileType).filter_by(name='appropriations').one(),
+                           file_type=None,
                            job_status=sess.query(JobStatus).filter_by(name='finished').one(),
                            number_of_errors=1, number_of_warnings=0, error_message=None)
     sess.add_all([sub, cross_val])
@@ -949,3 +951,101 @@ def test_check_generation_prereqs_ef_has_errors(database):
 
     can_generate = fileHandler.check_generation_prereqs(sub.submission_id, 'E')
     assert can_generate is False
+
+
+@pytest.mark.usefixtures("job_constants")
+def test_check_generation_prereqs_d_valid(database):
+    """ Tests a set of conditions that passes the prerequisite checks to allow D files to be generated. Show that
+        warnings do not prevent generation.
+    """
+    sess = database.session
+
+    sub = SubmissionFactory(submission_id=1, d2_submission=False)
+    job_1 = JobFactory(submission_id=sub.submission_id,
+                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
+                       file_type=sess.query(FileType).filter_by(name='appropriations').one(),
+                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+                       number_of_errors=0, number_of_warnings=0, error_message=None)
+    job_2 = JobFactory(submission_id=sub.submission_id,
+                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
+                       file_type=sess.query(FileType).filter_by(name='program_activity').one(),
+                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+                       number_of_errors=0, number_of_warnings=0, error_message=None)
+    job_3 = JobFactory(submission_id=sub.submission_id,
+                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
+                       file_type=sess.query(FileType).filter_by(name='award_financial').one(),
+                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+                       number_of_errors=0, number_of_warnings=1, error_message=None)
+    sess.add_all([sub, job_1, job_2, job_3])
+    sess.commit()
+
+    can_generate = fileHandler.check_generation_prereqs(sub.submission_id, 'D1')
+    assert can_generate is True
+
+
+@pytest.mark.usefixtures("job_constants")
+def test_check_generation_prereqs_d_not_finished(database):
+    """ Tests a set of conditions that has one of the A,B,C files incomplete, prevent D file generation. """
+    sess = database.session
+
+    sub = SubmissionFactory(submission_id=1, d2_submission=False)
+    job_1 = JobFactory(submission_id=sub.submission_id,
+                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
+                       file_type=sess.query(FileType).filter_by(name='appropriations').one(),
+                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+                       number_of_errors=0, number_of_warnings=0, error_message=None)
+    job_2 = JobFactory(submission_id=sub.submission_id,
+                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
+                       file_type=sess.query(FileType).filter_by(name='program_activity').one(),
+                       job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
+                       number_of_errors=0, number_of_warnings=0, error_message=None)
+    job_3 = JobFactory(submission_id=sub.submission_id,
+                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
+                       file_type=sess.query(FileType).filter_by(name='award_financial').one(),
+                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+                       number_of_errors=0, number_of_warnings=0, error_message=None)
+    sess.add_all([sub, job_1, job_2, job_3])
+    sess.commit()
+
+    can_generate = fileHandler.check_generation_prereqs(sub.submission_id, 'D1')
+    assert can_generate is False
+
+
+@pytest.mark.usefixtures("job_constants")
+def test_check_generation_prereqs_d_has_errors(database):
+    """ Tests a set of conditions that has an error in one of the A,B,C files, prevent D file generation. """
+    sess = database.session
+
+    sub = SubmissionFactory(submission_id=1, d2_submission=False)
+    job_1 = JobFactory(submission_id=sub.submission_id,
+                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
+                       file_type=sess.query(FileType).filter_by(name='appropriations').one(),
+                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+                       number_of_errors=1, number_of_warnings=0, error_message=None)
+    job_2 = JobFactory(submission_id=sub.submission_id,
+                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
+                       file_type=sess.query(FileType).filter_by(name='program_activity').one(),
+                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+                       number_of_errors=0, number_of_warnings=0, error_message=None)
+    job_3 = JobFactory(submission_id=sub.submission_id,
+                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
+                       file_type=sess.query(FileType).filter_by(name='award_financial').one(),
+                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+                       number_of_errors=0, number_of_warnings=0, error_message=None)
+    sess.add_all([sub, job_1, job_2, job_3])
+    sess.commit()
+
+    can_generate = fileHandler.check_generation_prereqs(sub.submission_id, 'D1')
+    assert can_generate is False
+
+
+@pytest.mark.usefixtures("job_constants")
+def test_check_generation_prereqs_bad_type(database):
+    """ Tests that check_generation_prereqs raises an error if an invalid type is provided. """
+    sess = database.session
+    sub = SubmissionFactory()
+    sess.add(sub)
+    sess.commit()
+
+    with pytest.raises(ResponseException):
+        fileHandler.check_generation_prereqs(sub.submission_id, 'A')


### PR DESCRIPTION
**High level description:**
Blocking D file generation until every step before it is complete.

**Technical details:**
Blocks D1/D2 file generation until all A,B,C jobs are complete with 0 errors

**Link to JIRA Ticket:**
[DEV-1205](https://federal-spending-transparency.atlassian.net/browse/DEV-1205)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed