### PR TITLE
Hotfix: DEV-1301 b9 fyq fix

### DIFF
--- a/dataactvalidator/config/sqlrules/b9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/b9_award_financial.sql
@@ -30,6 +30,6 @@ WHERE af.program_activity_code <> '0000'
             AND af.main_account_code = pa.account_number
             AND UPPER(COALESCE(af.program_activity_name, '')) = UPPER(pa.program_activity_name)
             AND COALESCE(af.program_activity_code, '') = pa.program_activity_code
-            AND pa.fiscal_year_quarter = 'FY' || sub.reporting_fiscal_year || 'Q' || sub.reporting_fiscal_period / 3
+            AND pa.fiscal_year_quarter = 'FY' || RIGHT(CAST(sub.reporting_fiscal_year AS CHAR(4)), 2) || 'Q' || sub.reporting_fiscal_period / 3
 
     );

--- a/tests/unit/dataactvalidator/test_b9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_b9_award_financial.py
@@ -28,7 +28,7 @@ def test_success(database):
     af_2 = AwardFinancialFactory(row_number=2, agency_identifier='test', submission_id=1,  main_account_code='test',
                                  program_activity_name='test', program_activity_code='test')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2017Q1', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q1', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=3,
@@ -45,7 +45,7 @@ def test_success_null(database):
     af = AwardFinancialFactory(row_number=1, agency_identifier='test', main_account_code='test',
                                program_activity_name=None, program_activity_code=None)
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2017Q2', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q2', agency_id='test', allocation_transfer_id='test',
                                 account_number='test')
 
     assert number_of_errors(_FILE, database, models=[af, pa]) == 0
@@ -59,7 +59,7 @@ def test_success_fiscal_year_quarter(database):
     af = AwardFinancialFactory(row_number=1, submission_id=1, agency_identifier='test',
                                main_account_code='test', program_activity_name='test', program_activity_code='test')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2016Q1', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY16Q1', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2016', reporting_fiscal_period=3,
@@ -80,7 +80,7 @@ def test_failure_fiscal_year_quarter(database):
     pa_1 = ProgramActivityFactory(fiscal_year_quarter='FQY', agency_id='test', allocation_transfer_id='test',
                                   account_number='test', program_activity_name='test', program_activity_code='test')
 
-    pa_2 = ProgramActivityFactory(fiscal_year_quarter='FY2016Q1', agency_id='test2', allocation_transfer_id='test2',
+    pa_2 = ProgramActivityFactory(fiscal_year_quarter='FY16Q1', agency_id='test2', allocation_transfer_id='test2',
                                   account_number='test2', program_activity_name='test2', program_activity_code='test2')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2016', reporting_fiscal_period=3,
@@ -97,7 +97,7 @@ def test_success_ignore_recertification(database):
     af = AwardFinancialFactory(row_number=1, submission_id=1, agency_identifier='test',
                                main_account_code='test', program_activity_name='test', program_activity_code='test')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2017Q3', agency_id='test2', allocation_transfer_id='test2',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q3', agency_id='test2', allocation_transfer_id='test2',
                                 account_number='test2', program_activity_name='test2', program_activity_code='test2')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=9,
@@ -114,7 +114,7 @@ def test_failure_recertification(database):
     af = AwardFinancialFactory(row_number=1, submission_id=1, agency_identifier='test',
                                main_account_code='test', program_activity_name='test', program_activity_code='test')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2017Q3', agency_id='test2', allocation_transfer_id='test2',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q3', agency_id='test2', allocation_transfer_id='test2',
                                 account_number='test2', program_activity_name='test2', program_activity_code='test2')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=9,
@@ -131,7 +131,7 @@ def test_success_ignore_case(database):
     af = AwardFinancialFactory(row_number=1, submission_id=1, agency_identifier='test', main_account_code='test',
                                program_activity_name='TEST', program_activity_code='test')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2016Q4', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY16Q4', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2016', reporting_fiscal_period=12,
@@ -155,7 +155,7 @@ def test_failure_program_activity_name(database):
                                  main_account_code='test', program_activity_name='test_wrong',
                                  program_activity_code='0000')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2015Q5', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY15Q5', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2015', reporting_fiscal_period=15,
@@ -176,7 +176,7 @@ def test_failure_program_activity_code(database):
     af_2 = AwardFinancialFactory(row_number=1, submission_id=1, agency_identifier='test', main_account_code='test',
                                  program_activity_name='Unknown/Other', program_activity_code='12345')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2016Q4', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY16Q4', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2016', reporting_fiscal_period=12,

--- a/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
@@ -32,7 +32,7 @@ def test_success(database):
                                              program_activity_code='test'
                                              )
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2016Q4', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY16Q4', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2016', reporting_fiscal_period=12,
@@ -50,7 +50,7 @@ def test_success_fiscal_year_quarter(database):
                                            main_account_code='test', program_activity_name='test',
                                            program_activity_code='test')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2017Q1', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q1', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=3,
@@ -68,7 +68,7 @@ def test_failure_fiscal_year_quarter(database):
                                            main_account_code='test2', program_activity_name='test2',
                                            program_activity_code='test2')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2015Q1', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY15Q1', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2018', reporting_fiscal_period=9,
@@ -88,7 +88,7 @@ def test_failure_success_ignore_recertification(database):
                                            main_account_code='test2', program_activity_name='test2',
                                            program_activity_code='test2')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2014Q1', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY14Q1', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=6,
@@ -106,7 +106,7 @@ def test_failure_not_recertification(database):
                                            main_account_code='test2', program_activity_name='test2',
                                            program_activity_code='test2')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2014Q1', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY14Q1', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=6,
@@ -164,7 +164,7 @@ def test_success_ignore_case(database):
                                            agency_identifier='test', main_account_code='test',
                                            program_activity_name='TEST', program_activity_code='test')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2017Q4', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q4', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=12,
@@ -185,7 +185,7 @@ def test_failure_program_activity_name(database):
     op_2 = ObjectClassProgramActivityFactory(row_number=1, agency_identifier='test', main_account_code='test',
                                              program_activity_name='test_wrong', program_activity_code='0000')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2017Q1', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q1', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=3,
@@ -207,7 +207,7 @@ def test_failure_program_activity_code(database):
     op_2 = ObjectClassProgramActivityFactory(row_number=1, agency_identifier='test', main_account_code='test',
                                              program_activity_name='Unknown/Other', program_activity_code='123456')
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY2016Q1', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY16Q1', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2016', reporting_fiscal_period=3,


### PR DESCRIPTION
**High level description:**
Fixing B9 error. Speeding up B9

**Technical details:**
B9 was checking for the format `FY####Q#` when the actual program activity column contained `FY##Q#`, fixing this in the rule. Also including a speedup to drop the amount of time B9 takes

**Link to JIRA Ticket:**
[DEV-1301](https://federal-spending-transparency.atlassian.net/browse/DEV-1301)
[DEV-1300](https://federal-spending-transparency.atlassian.net/browse/DEV-1300) (this one was looped in because it made sense to fit it in here)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed