### PR TITLE
DEV-1286: clean up JobFactory

### DIFF
--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -8,8 +8,8 @@ import pytest
 import calendar
 
 from dataactbroker.handlers import fileHandler
-from dataactcore.models.jobModels import JobStatus, JobType, FileType, CertifiedFilesHistory
-from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT
+from dataactcore.models.jobModels import FileType, CertifiedFilesHistory
+from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
 from dataactcore.utils.responseException import ResponseException
 from tests.unit.dataactbroker.utils import add_models, delete_models
 from tests.unit.dataactcore.factories.domain import CGACFactory
@@ -91,12 +91,10 @@ def test_list_submissions_success(database, monkeypatch):
     assert result['submissions'][0]['status'] == "validation_successful_warnings"
     delete_models(database, [user, sub])
 
-    sess = database.session
     user = UserFactory(user_id=1)
     sub = SubmissionFactory(user_id=1, submission_id=1, publish_status_id=1)
-    job = JobFactory(submission_id=1, job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one())
+    job = JobFactory(submission_id=1, job_status_id=JOB_STATUS_DICT['finished'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
     add_models(database, [user, sub, job])
 
     result = list_submissions_result()
@@ -104,12 +102,10 @@ def test_list_submissions_success(database, monkeypatch):
     assert result['submissions'][0]['status'] == "validation_successful"
     delete_models(database, [user, sub, job])
 
-    sess = database.session
     user = UserFactory(user_id=1)
     sub = SubmissionFactory(user_id=1, submission_id=1, publish_status_id=1)
-    job = JobFactory(submission_id=1, job_status=sess.query(JobStatus).filter_by(name='running').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one())
+    job = JobFactory(submission_id=1, job_status_id=JOB_STATUS_DICT['running'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
     add_models(database, [user, sub, job])
 
     result = list_submissions_result()
@@ -117,12 +113,10 @@ def test_list_submissions_success(database, monkeypatch):
     assert result['submissions'][0]['status'] == "running"
     delete_models(database, [user, sub, job])
 
-    sess = database.session
     user = UserFactory(user_id=1)
     sub = SubmissionFactory(user_id=1, submission_id=1, publish_status_id=1)
-    job = JobFactory(submission_id=1, job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one())
+    job = JobFactory(submission_id=1, job_status_id=JOB_STATUS_DICT['waiting'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
     add_models(database, [user, sub, job])
 
     result = list_submissions_result()
@@ -130,12 +124,10 @@ def test_list_submissions_success(database, monkeypatch):
     assert result['submissions'][0]['status'] == "waiting"
     delete_models(database, [user, sub, job])
 
-    sess = database.session
     user = UserFactory(user_id=1)
     sub = SubmissionFactory(user_id=1, submission_id=1, publish_status_id=1)
-    job = JobFactory(submission_id=1, job_status=sess.query(JobStatus).filter_by(name='ready').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one())
+    job = JobFactory(submission_id=1, job_status_id=JOB_STATUS_DICT['ready'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
     add_models(database, [user, sub, job])
 
     result = list_submissions_result()
@@ -143,12 +135,10 @@ def test_list_submissions_success(database, monkeypatch):
     assert result['submissions'][0]['status'] == "ready"
     delete_models(database, [user, sub, job])
 
-    sess = database.session
     user = UserFactory(user_id=1)
     sub = SubmissionFactory(user_id=1, submission_id=1, publish_status_id=1, d2_submission=True)
-    job = JobFactory(submission_id=1, job_status=sess.query(JobStatus).filter_by(name='ready').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one())
+    job = JobFactory(submission_id=1, job_status_id=JOB_STATUS_DICT['ready'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
     add_models(database, [user, sub, job])
 
     result = list_submissions_result(d2_submission=True)
@@ -169,12 +159,10 @@ def test_list_submissions_failure(database, monkeypatch):
     assert result['submissions'][0]['status'] == "validation_errors"
     delete_models(database, [user, sub])
 
-    sess = database.session
     user = UserFactory(user_id=1)
     sub = SubmissionFactory(user_id=1, submission_id=1, publish_status_id=1)
-    job = JobFactory(submission_id=1, job_status=sess.query(JobStatus).filter_by(name='failed').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one())
+    job = JobFactory(submission_id=1, job_status_id=JOB_STATUS_DICT['failed'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
     add_models(database, [user, sub, job])
 
     result = list_submissions_result()
@@ -182,12 +170,10 @@ def test_list_submissions_failure(database, monkeypatch):
     assert result['submissions'][0]['status'] == "failed"
     delete_models(database, [user, sub, job])
 
-    sess = database.session
     user = UserFactory(user_id=1)
     sub = SubmissionFactory(user_id=1, submission_id=1, publish_status_id=1)
-    job = JobFactory(submission_id=1, job_status=sess.query(JobStatus).filter_by(name='invalid').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one())
+    job = JobFactory(submission_id=1, job_status_id=JOB_STATUS_DICT['invalid'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
     add_models(database, [user, sub, job])
 
     result = list_submissions_result()
@@ -411,11 +397,9 @@ def test_get_upload_file_url_local(database, monkeypatch, tmpdir):
     monkeypatch.setattr(fileHandler, 'CONFIG_BROKER', {'local': True, 'broker_files': file_path})
 
     # create and insert submission/job
-    sess = database.session
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
-    job = JobFactory(submission_id=1, job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                     job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-                     file_type=sess.query(FileType).filter_by(name='appropriations').one(),
+    job = JobFactory(submission_id=1, job_status_id=JOB_STATUS_DICT['finished'],
+                     job_type_id=JOB_TYPE_DICT['file_upload'], file_type_id=FILE_TYPE_DICT['appropriations'],
                      filename='a/path/to/some_file.csv')
     add_models(database, [sub, job])
 
@@ -450,11 +434,9 @@ def test_get_upload_file_url_no_file(database):
     """ Test that a proper error is thrown when an upload job doesn't have a file associated with it
         get_upload_file_url.
     """
-    sess = database.session
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
-    job = JobFactory(submission_id=1, job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                     job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-                     file_type=sess.query(FileType).filter_by(name='appropriations').one(),
+    job = JobFactory(submission_id=1, job_status_id=JOB_STATUS_DICT['finished'],
+                     job_type_id=JOB_TYPE_DICT['file_upload'], file_type_id=FILE_TYPE_DICT['appropriations'],
                      filename=None)
     add_models(database, [sub, job])
 
@@ -473,11 +455,9 @@ def test_get_upload_file_url_s3(database, monkeypatch):
     monkeypatch.setattr(fileHandler, 'S3Handler', s3_url_handler)
 
     # create and insert submission/job
-    sess = database.session
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
-    job = JobFactory(submission_id=1, job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                     job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-                     file_type=sess.query(FileType).filter_by(name='appropriations').one(),
+    job = JobFactory(submission_id=1, job_status_id=JOB_STATUS_DICT['finished'],
+                     job_type_id=JOB_TYPE_DICT['file_upload'], file_type_id=FILE_TYPE_DICT['appropriations'],
                      filename='1/some_file.csv')
     add_models(database, [sub, job])
 
@@ -504,29 +484,29 @@ def test_move_certified_files(database, monkeypatch):
     cert_hist_local = CertifyHistoryFactory(submission_id=sub.submission_id)
     cert_hist_remote = CertifyHistoryFactory(submission_id=sub.submission_id)
 
-    finished_job = sess.query(JobStatus).filter_by(name='finished').one()
-    upload_job = sess.query(JobType).filter_by(name='file_upload').one()
+    finished_job = JOB_STATUS_DICT['finished']
+    upload_job = JOB_TYPE_DICT['file_upload']
     appropriations_job = JobFactory(submission=sub, filename="/path/to/appropriations/file_a.csv",
-                                    file_type=sess.query(FileType).filter_by(name='appropriations').one(),
-                                    job_type=upload_job, job_status=finished_job)
+                                    file_type_id=FILE_TYPE_DICT['appropriations'], job_type_id=upload_job,
+                                    job_status_id=finished_job)
     prog_act_job = JobFactory(submission=sub, filename="/path/to/prog/act/file_b.csv",
-                              file_type=sess.query(FileType).filter_by(name='program_activity').one(),
-                              job_type=upload_job, job_status=finished_job)
+                              file_type_id=FILE_TYPE_DICT['program_activity'], job_type_id=upload_job,
+                              job_status_id=finished_job)
     award_fin_job = JobFactory(submission=sub, filename="/path/to/award/fin/file_c.csv",
-                               file_type=sess.query(FileType).filter_by(name='award_financial').one(),
-                               job_type=upload_job, job_status=finished_job)
+                               file_type_id=FILE_TYPE_DICT['award_financial'], job_type_id=upload_job,
+                               job_status_id=finished_job)
     award_proc_job = JobFactory(submission=sub, filename="/path/to/award/proc/file_d1.csv",
-                                file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-                                job_type=upload_job, job_status=finished_job)
+                                file_type_id=FILE_TYPE_DICT['award_procurement'], job_type_id=upload_job,
+                                job_status_id=finished_job)
     award_job = JobFactory(submission=sub, filename="/path/to/award/file_d2.csv",
-                           file_type=sess.query(FileType).filter_by(name='award').one(),
-                           job_type=upload_job, job_status=finished_job)
+                           file_type_id=FILE_TYPE_DICT['award'], job_type_id=upload_job,
+                           job_status_id=finished_job)
     exec_comp_job = JobFactory(submission=sub, filename="/path/to/exec/comp/file_e.csv",
-                               file_type=sess.query(FileType).filter_by(name='executive_compensation').one(),
-                               job_type=upload_job, job_status=finished_job)
+                               file_type_id=FILE_TYPE_DICT['executive_compensation'], job_type_id=upload_job,
+                               job_status_id=finished_job)
     sub_award_job = JobFactory(submission=sub, filename="/path/to/sub/award/file_f.csv",
-                               file_type=sess.query(FileType).filter_by(name='sub_award').one(),
-                               job_type=upload_job, job_status=finished_job)
+                               file_type_id=FILE_TYPE_DICT['sub_award'], job_type_id=upload_job,
+                               job_status_id=finished_job)
 
     award_fin_narr = SubmissionNarrativeFactory(submission=sub, narrative="Test narrative",
                                                 file_type=sess.query(FileType).filter_by(name='award_financial').one())
@@ -551,8 +531,7 @@ def test_move_certified_files(database, monkeypatch):
     assert len(all_local_certs) == 11
 
     c_cert_hist = sess.query(CertifiedFilesHistory).\
-        filter_by(certify_history_id=local_id,
-                  file_type_id=sess.query(FileType).filter_by(name='award_financial').one().file_type_id).one()
+        filter_by(certify_history_id=local_id, file_type_id=FILE_TYPE_DICT['award_financial']).one()
     assert c_cert_hist.filename == "/path/to/award/fin/file_c.csv"
     assert c_cert_hist.warning_filename == "/path/to/error/reports/submission_{}_award_financial_warning_report.csv".\
         format(sub.submission_id)
@@ -572,8 +551,7 @@ def test_move_certified_files(database, monkeypatch):
     remote_id = cert_hist_remote.certify_history_id
 
     c_cert_hist = sess.query(CertifiedFilesHistory). \
-        filter_by(certify_history_id=remote_id,
-                  file_type_id=sess.query(FileType).filter_by(name='award_financial').one().file_type_id).one()
+        filter_by(certify_history_id=remote_id, file_type_id=FILE_TYPE_DICT['award_financial']).one()
     assert c_cert_hist.filename == "zyxwv/2017/2/{}/file_c.csv".format(remote_id)
     assert c_cert_hist.warning_filename == "zyxwv/2017/2/{}/submission_{}_award_financial_warning_report.csv". \
         format(remote_id, sub.submission_id)
@@ -702,15 +680,11 @@ def test_get_status_fabs(database):
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=True)
-    job_up = JobFactory(submission_id=sub.submission_id,
-                        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-                        file_type=sess.query(FileType).filter_by(name='fabs').one(),
-                        job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+    job_up = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['file_upload'],
+                        file_type_id=FILE_TYPE_DICT['fabs'], job_status_id=JOB_STATUS_DICT['finished'],
                         number_of_errors=0, number_of_warnings=0)
-    job_val = JobFactory(submission_id=sub.submission_id,
-                         job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                         file_type=sess.query(FileType).filter_by(name='fabs').one(),
-                         job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+    job_val = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                         file_type_id=FILE_TYPE_DICT['fabs'], job_status_id=JOB_STATUS_DICT['finished'],
                          number_of_errors=0, number_of_warnings=4)
 
     sess.add_all([sub, job_up, job_val])
@@ -728,67 +702,58 @@ def test_get_status_dabs(database):
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
-    upload_job = sess.query(JobType).filter_by(name='file_upload').one()
-    validation_job = sess.query(JobType).filter_by(name='csv_record_validation').one()
-    finished_status = sess.query(JobStatus).filter_by(name='finished').one()
+    upload_job = JOB_TYPE_DICT['file_upload']
+    validation_job = JOB_TYPE_DICT['csv_record_validation']
+    finished_status = JOB_STATUS_DICT['finished']
 
     # Completed, warnings, errors
-    job_1_up = JobFactory(submission_id=sub.submission_id, job_type=upload_job,
-                          file_type=sess.query(FileType).filter_by(name='appropriations').one(),
-                          job_status=finished_status, number_of_errors=0, number_of_warnings=0, error_message=None)
-    job_1_val = JobFactory(submission_id=sub.submission_id, job_type=validation_job,
-                           file_type=sess.query(FileType).filter_by(name='appropriations').one(),
-                           job_status=finished_status, number_of_errors=10, number_of_warnings=4, error_message=None)
-    # Invalid upload
-    job_2_up = JobFactory(submission_id=sub.submission_id, job_type=upload_job,
-                          file_type=sess.query(FileType).filter_by(name='program_activity').one(),
-                          job_status=sess.query(JobStatus).filter_by(name='invalid').one(),
+    job_1_up = JobFactory(submission_id=sub.submission_id, job_type_id=upload_job,
+                          file_type_id=FILE_TYPE_DICT['appropriations'], job_status_id=finished_status,
                           number_of_errors=0, number_of_warnings=0, error_message=None)
-    job_2_val = JobFactory(submission_id=sub.submission_id, job_type=validation_job,
-                           file_type=sess.query(FileType).filter_by(name='program_activity').one(),
-                           job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
+    job_1_val = JobFactory(submission_id=sub.submission_id, job_type_id=validation_job,
+                           file_type_id=FILE_TYPE_DICT['appropriations'], job_status_id=finished_status,
+                           number_of_errors=10, number_of_warnings=4, error_message=None)
+    # Invalid upload
+    job_2_up = JobFactory(submission_id=sub.submission_id, job_type_id=upload_job,
+                          file_type_id=FILE_TYPE_DICT['program_activity'], job_status_id=JOB_STATUS_DICT['invalid'],
+                          number_of_errors=0, number_of_warnings=0, error_message=None)
+    job_2_val = JobFactory(submission_id=sub.submission_id, job_type_id=validation_job,
+                           file_type_id=FILE_TYPE_DICT['program_activity'], job_status_id=JOB_STATUS_DICT['waiting'],
                            number_of_errors=0, number_of_warnings=0, error_message=None)
     # Validating
-    job_3_up = JobFactory(submission_id=sub.submission_id, job_type=upload_job,
-                          file_type=sess.query(FileType).filter_by(name='award_financial').one(),
-                          job_status=finished_status, number_of_errors=0, number_of_warnings=0, error_message=None)
-    job_3_val = JobFactory(submission_id=sub.submission_id, job_type=validation_job,
-                           file_type=sess.query(FileType).filter_by(name='award_financial').one(),
-                           job_status=sess.query(JobStatus).filter_by(name='running').one(),
+    job_3_up = JobFactory(submission_id=sub.submission_id, job_type_id=upload_job,
+                          file_type_id=FILE_TYPE_DICT['award_financial'], job_status_id=finished_status,
+                          number_of_errors=0, number_of_warnings=0, error_message=None)
+    job_3_val = JobFactory(submission_id=sub.submission_id, job_type_id=validation_job,
+                           file_type_id=FILE_TYPE_DICT['award_financial'], job_status_id=JOB_STATUS_DICT['running'],
                            number_of_errors=0, number_of_warnings=0, error_message=None)
     # Uploading
-    job_4_up = JobFactory(submission_id=sub.submission_id, job_type=upload_job,
-                          file_type=sess.query(FileType).filter_by(name='award').one(),
-                          job_status=sess.query(JobStatus).filter_by(name='running').one(),
+    job_4_up = JobFactory(submission_id=sub.submission_id, job_type_id=upload_job,
+                          file_type_id=FILE_TYPE_DICT['award'], job_status_id=JOB_STATUS_DICT['running'],
                           number_of_errors=0, number_of_warnings=0, error_message=None)
-    job_4_val = JobFactory(submission_id=sub.submission_id, job_type=validation_job,
-                           file_type=sess.query(FileType).filter_by(name='award').one(),
-                           job_status=sess.query(JobStatus).filter_by(name='ready').one(),
+    job_4_val = JobFactory(submission_id=sub.submission_id, job_type_id=validation_job,
+                           file_type_id=FILE_TYPE_DICT['award'], job_status_id=JOB_STATUS_DICT['ready'],
                            number_of_errors=0, number_of_warnings=0, error_message=None)
     # Invalid on validation
-    job_5_up = JobFactory(submission_id=sub.submission_id, job_type=upload_job,
-                          file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-                          job_status=finished_status, number_of_errors=0, number_of_warnings=0, error_message=None)
-    job_5_val = JobFactory(submission_id=sub.submission_id, job_type=validation_job,
-                           file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-                           job_status=sess.query(JobStatus).filter_by(name='invalid').one(),
+    job_5_up = JobFactory(submission_id=sub.submission_id, job_type_id=upload_job,
+                          file_type_id=FILE_TYPE_DICT['award_procurement'], job_status_id=finished_status,
+                          number_of_errors=0, number_of_warnings=0, error_message=None)
+    job_5_val = JobFactory(submission_id=sub.submission_id, job_type_id=validation_job,
+                           file_type_id=FILE_TYPE_DICT['award_procurement'], job_status_id=JOB_STATUS_DICT['invalid'],
                            number_of_errors=0, number_of_warnings=0, error_message=None)
     # Failed
-    job_6_up = JobFactory(submission_id=sub.submission_id, job_type=upload_job,
-                          file_type=sess.query(FileType).filter_by(name='executive_compensation').one(),
-                          job_status=sess.query(JobStatus).filter_by(name='failed').one(),
-                          number_of_errors=0, number_of_warnings=0, error_message='test message')
+    job_6_up = JobFactory(submission_id=sub.submission_id, job_type_id=upload_job,
+                          file_type_id=FILE_TYPE_DICT['executive_compensation'],
+                          job_status_id=JOB_STATUS_DICT['failed'], number_of_errors=0, number_of_warnings=0,
+                          error_message='test message')
     # Ready
-    job_7_up = JobFactory(submission_id=sub.submission_id, job_type=upload_job,
-                          file_type=sess.query(FileType).filter_by(name='sub_award').one(),
-                          job_status=sess.query(JobStatus).filter_by(name='ready').one(),
+    job_7_up = JobFactory(submission_id=sub.submission_id, job_type_id=upload_job,
+                          file_type_id=FILE_TYPE_DICT['sub_award'], job_status_id=JOB_STATUS_DICT['ready'],
                           number_of_errors=0, number_of_warnings=0, error_message=None)
     # Waiting
-    job_8_val = JobFactory(submission_id=sub.submission_id,
-                           job_type=sess.query(JobType).filter_by(name='validation').one(),
-                           file_type=None,
-                           job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-                           number_of_errors=0, number_of_warnings=5, error_message=None)
+    job_8_val = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['validation'], file_type_id=None,
+                           job_status_id=JOB_STATUS_DICT['waiting'], number_of_errors=0, number_of_warnings=5,
+                           error_message=None)
 
     sess.add_all([sub, job_1_up, job_1_val, job_2_up, job_2_val, job_3_up, job_3_val, job_4_up, job_4_val, job_5_up,
                   job_5_val, job_6_up, job_7_up, job_8_val])
@@ -905,11 +870,9 @@ def test_check_generation_prereqs_ef_valid(database):
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
-    cross_val = JobFactory(submission_id=sub.submission_id,
-                           job_type=sess.query(JobType).filter_by(name='validation').one(),
-                           file_type=None,
-                           job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                           number_of_errors=0, number_of_warnings=1, error_message=None)
+    cross_val = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['validation'],
+                           file_type_id=None, job_status_id=JOB_STATUS_DICT['finished'], number_of_errors=0,
+                           number_of_warnings=1, error_message=None)
     sess.add_all([sub, cross_val])
     sess.commit()
 
@@ -923,11 +886,9 @@ def test_check_generation_prereqs_ef_not_finished(database):
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
-    cross_val = JobFactory(submission_id=sub.submission_id,
-                           job_type=sess.query(JobType).filter_by(name='validation').one(),
-                           file_type=None,
-                           job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-                           number_of_errors=0, number_of_warnings=0, error_message=None)
+    cross_val = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['validation'], file_type_id=None,
+                           job_status_id=JOB_STATUS_DICT['waiting'], number_of_errors=0, number_of_warnings=0,
+                           error_message=None)
     sess.add_all([sub, cross_val])
     sess.commit()
 
@@ -941,11 +902,9 @@ def test_check_generation_prereqs_ef_has_errors(database):
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
-    cross_val = JobFactory(submission_id=sub.submission_id,
-                           job_type=sess.query(JobType).filter_by(name='validation').one(),
-                           file_type=None,
-                           job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                           number_of_errors=1, number_of_warnings=0, error_message=None)
+    cross_val = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['validation'], file_type_id=None,
+                           job_status_id=JOB_STATUS_DICT['finished'], number_of_errors=1, number_of_warnings=0,
+                           error_message=None)
     sess.add_all([sub, cross_val])
     sess.commit()
 
@@ -961,20 +920,14 @@ def test_check_generation_prereqs_d_valid(database):
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
-    job_1 = JobFactory(submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='appropriations').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+    job_1 = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                       file_type_id=FILE_TYPE_DICT['appropriations'], job_status_id=JOB_STATUS_DICT['finished'],
                        number_of_errors=0, number_of_warnings=0, error_message=None)
-    job_2 = JobFactory(submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='program_activity').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+    job_2 = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                       file_type_id=FILE_TYPE_DICT['program_activity'], job_status_id=JOB_STATUS_DICT['finished'],
                        number_of_errors=0, number_of_warnings=0, error_message=None)
-    job_3 = JobFactory(submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='award_financial').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+    job_3 = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                       file_type_id=FILE_TYPE_DICT['award_financial'], job_status_id=JOB_STATUS_DICT['finished'],
                        number_of_errors=0, number_of_warnings=1, error_message=None)
     sess.add_all([sub, job_1, job_2, job_3])
     sess.commit()
@@ -989,20 +942,14 @@ def test_check_generation_prereqs_d_not_finished(database):
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
-    job_1 = JobFactory(submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='appropriations').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+    job_1 = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                       file_type_id=FILE_TYPE_DICT['appropriations'], job_status_id=JOB_STATUS_DICT['finished'],
                        number_of_errors=0, number_of_warnings=0, error_message=None)
-    job_2 = JobFactory(submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='program_activity').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
+    job_2 = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                       file_type_id=FILE_TYPE_DICT['program_activity'], job_status_id=JOB_STATUS_DICT['waiting'],
                        number_of_errors=0, number_of_warnings=0, error_message=None)
-    job_3 = JobFactory(submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='award_financial').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+    job_3 = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                       file_type_id=FILE_TYPE_DICT['award_financial'], job_status_id=JOB_STATUS_DICT['finished'],
                        number_of_errors=0, number_of_warnings=0, error_message=None)
     sess.add_all([sub, job_1, job_2, job_3])
     sess.commit()
@@ -1017,20 +964,14 @@ def test_check_generation_prereqs_d_has_errors(database):
     sess = database.session
 
     sub = SubmissionFactory(submission_id=1, d2_submission=False)
-    job_1 = JobFactory(submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='appropriations').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+    job_1 = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                       file_type_id=FILE_TYPE_DICT['appropriations'], job_status_id=JOB_STATUS_DICT['finished'],
                        number_of_errors=1, number_of_warnings=0, error_message=None)
-    job_2 = JobFactory(submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='program_activity').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+    job_2 = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                       file_type_id=FILE_TYPE_DICT['program_activity'], job_status_id=JOB_STATUS_DICT['finished'],
                        number_of_errors=0, number_of_warnings=0, error_message=None)
-    job_3 = JobFactory(submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='award_financial').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
+    job_3 = JobFactory(submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                       file_type_id=FILE_TYPE_DICT['award_financial'], job_status_id=JOB_STATUS_DICT['finished'],
                        number_of_errors=0, number_of_warnings=0, error_message=None)
     sess.add_all([sub, job_1, job_2, job_3])
     sess.commit()

--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -8,7 +8,7 @@ import pytest
 import calendar
 
 from dataactbroker.handlers import fileHandler
-from dataactcore.models.jobModels import FileType, CertifiedFilesHistory
+from dataactcore.models.jobModels import CertifiedFilesHistory
 from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
 from dataactcore.utils.responseException import ResponseException
 from tests.unit.dataactbroker.utils import add_models, delete_models
@@ -509,7 +509,7 @@ def test_move_certified_files(database, monkeypatch):
                                job_status_id=finished_job)
 
     award_fin_narr = SubmissionNarrativeFactory(submission=sub, narrative="Test narrative",
-                                                file_type=sess.query(FileType).filter_by(name='award_financial').one())
+                                                file_type_id=FILE_TYPE_DICT['award_financial'])
     database.session.add_all([cert_hist_local, cert_hist_remote, appropriations_job, prog_act_job, award_fin_job,
                               award_proc_job, award_job, exec_comp_job, sub_award_job, award_fin_narr])
     database.session.commit()
@@ -571,22 +571,21 @@ def test_list_certifications(database):
     database.session.commit()
 
     # add some data to certified_files_history for the cert_history ID
-    sess = database.session
     history_id = cert_hist.certify_history_id
     sub_id = sub.submission_id
     file_hist_1 = CertifiedFilesHistoryFactory(certify_history_id=history_id, submission_id=sub_id,
                                                filename="/path/to/file_a.csv",
                                                warning_filename="/path/to/warning_file_a.csv",
                                                narrative="A has a narrative",
-                                               file_type=sess.query(FileType).filter_by(name='appropriations').one())
+                                               file_type_id=FILE_TYPE_DICT['appropriations'])
     file_hist_2 = CertifiedFilesHistoryFactory(certify_history_id=history_id, submission_id=sub_id,
                                                filename="/path/to/file_d2.csv",
                                                warning_filename=None,
-                                               file_type=sess.query(FileType).filter_by(name='award').one())
+                                               file_type_id=FILE_TYPE_DICT['award'])
     file_hist_3 = CertifiedFilesHistoryFactory(certify_history_id=history_id, submission_id=sub_id,
                                                filename=None,
                                                warning_filename="/path/to/warning_file_cross_test.csv",
-                                               file_type=None)
+                                               file_type_id=None)
     database.session.add_all([file_hist_1, file_hist_2, file_hist_3])
     database.session.commit()
 
@@ -623,7 +622,7 @@ def test_file_history_url(database, monkeypatch):
     file_hist = CertifiedFilesHistoryFactory(certify_history_id=cert_hist.certify_history_id,
                                              submission_id=sub.submission_id, filename="/path/to/file_d2.csv",
                                              warning_filename="/path/to/warning_file_cross.csv",
-                                             narrative=None, file_type=None)
+                                             narrative=None, file_type_id=None)
     database.session.add(file_hist)
     database.session.commit()
 

--- a/tests/unit/dataactbroker/test_file_routes.py
+++ b/tests/unit/dataactbroker/test_file_routes.py
@@ -5,12 +5,11 @@ from flask import g
 import pytest
 
 from dataactbroker import file_routes
-from dataactcore.models.lookups import PUBLISH_STATUS_DICT
+from dataactcore.models.lookups import PUBLISH_STATUS_DICT, JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
 from tests.unit.dataactcore.factories.domain import CGACFactory
 from tests.unit.dataactcore.factories.job import (JobFactory, SubmissionFactory, SubmissionWindowFactory,
                                                   ApplicationTypeFactory)
 from tests.unit.dataactcore.factories.user import UserFactory
-from dataactcore.models.jobModels import JobStatus, JobType, FileType
 from datetime import datetime, timedelta
 
 
@@ -141,36 +140,30 @@ def test_current_page(file_app, database):
 
     sub = SubmissionFactory(user_id=1, cgac_code=cgac.cgac_code)
     database.session.add(sub)
+    database.session.commit()
 
-    csv_validation = database.session.query(JobType).filter_by(name='csv_record_validation').one()
-    upload = database.session.query(JobType).filter_by(name='file_upload').one()
-    validation = database.session.query(JobType).filter_by(name='validation').one()
-    finished_job = database.session.query(JobStatus).filter_by(name='finished').one()
-    waiting = database.session.query(JobStatus).filter_by(name='waiting').one()
+    csv_validation = JOB_TYPE_DICT['csv_record_validation']
+    upload = JOB_TYPE_DICT['file_upload']
+    validation = JOB_TYPE_DICT['validation']
+    finished_job = JOB_STATUS_DICT['finished']
+    waiting = JOB_STATUS_DICT['waiting']
 
-    job_a = JobFactory(submission_id=sub.submission_id, file_type=database.session.query(FileType)
-                       .filter_by(name='appropriations').one(), job_type=csv_validation, number_of_errors=0,
-                       file_size=123, job_status=finished_job)
-    job_b = JobFactory(submission_id=sub.submission_id, file_type=database.session.query(FileType)
-                       .filter_by(name='program_activity').one(), job_type=csv_validation, number_of_errors=0,
-                       file_size=123, job_status=finished_job)
-    job_c = JobFactory(submission_id=sub.submission_id, file_type=database.session.query(FileType)
-                       .filter_by(name='award_financial').one(), job_type=csv_validation, number_of_errors=0,
-                       file_size=123, job_status=finished_job)
-    job_d1 = JobFactory(submission_id=sub.submission_id, file_type=database.session.query(FileType)
-                        .filter_by(name='award_procurement').one(), job_type=csv_validation, number_of_errors=0,
-                        file_size=123, job_status=finished_job)
-    job_d2 = JobFactory(submission_id=sub.submission_id, file_type=database.session.query(FileType)
-                        .filter_by(name='award').one(), job_type=csv_validation, number_of_errors=0, file_size=123,
-                        job_status=finished_job)
-    job_e = JobFactory(submission_id=sub.submission_id, file_type=database.session.query(FileType)
-                       .filter_by(name='executive_compensation').one(), job_type=upload, number_of_errors=0,
-                       file_size=123, job_status=finished_job)
-    job_f = JobFactory(submission_id=sub.submission_id, file_type=database.session.query(FileType)
-                       .filter_by(name='sub_award').one(), job_type=upload, number_of_errors=0, file_size=123,
-                       job_status=finished_job)
-    job_cross_file = JobFactory(submission_id=sub.submission_id, file_type=None, job_type=validation,
-                                number_of_errors=0, file_size=123, job_status=finished_job)
+    job_a = JobFactory(submission_id=sub.submission_id, file_type_id=FILE_TYPE_DICT['appropriations'],
+                       job_type_id=csv_validation, number_of_errors=0, file_size=123, job_status_id=finished_job)
+    job_b = JobFactory(submission_id=sub.submission_id, file_type_id=FILE_TYPE_DICT['program_activity'],
+                       job_type_id=csv_validation, number_of_errors=0, file_size=123, job_status_id=finished_job)
+    job_c = JobFactory(submission_id=sub.submission_id, file_type_id=FILE_TYPE_DICT['award_financial'],
+                       job_type_id=csv_validation, number_of_errors=0, file_size=123, job_status_id=finished_job)
+    job_d1 = JobFactory(submission_id=sub.submission_id, file_type_id=FILE_TYPE_DICT['award_procurement'],
+                        job_type_id=csv_validation, number_of_errors=0, file_size=123, job_status_id=finished_job)
+    job_d2 = JobFactory(submission_id=sub.submission_id, file_type_id=FILE_TYPE_DICT['award'],
+                        job_type_id=csv_validation, number_of_errors=0, file_size=123, job_status_id=finished_job)
+    job_e = JobFactory(submission_id=sub.submission_id, file_type_id=FILE_TYPE_DICT['executive_compensation'],
+                       job_type_id=upload, number_of_errors=0, file_size=123, job_status_id=finished_job)
+    job_f = JobFactory(submission_id=sub.submission_id, file_type_id=FILE_TYPE_DICT['sub_award'], job_type_id=upload,
+                       number_of_errors=0, file_size=123, job_status_id=finished_job)
+    job_cross_file = JobFactory(submission_id=sub.submission_id, file_type_id=None, job_type_id=validation,
+                                number_of_errors=0, file_size=123, job_status_id=finished_job)
 
     database.session.add_all([job_a, job_b, job_c, job_d1, job_d2, job_e, job_f, job_cross_file])
     database.session.commit()
@@ -210,7 +203,7 @@ def test_current_page(file_app, database):
     response_json = json.loads(response.data.decode('UTF-8'))
     assert response_json['step'] == '1'
 
-    job_cross_file.job_status = waiting
+    job_cross_file.job_status_id = waiting
     job_d1.number_of_errors = 0
     database.session.commit()
     # E and F generated with C file errors

--- a/tests/unit/dataactbroker/test_submission_handler.py
+++ b/tests/unit/dataactbroker/test_submission_handler.py
@@ -9,8 +9,8 @@ from dataactbroker.handlers import fileHandler
 from dataactbroker.handlers.submission_handler import (certify_dabs_submission, get_submission_metadata,
                                                        get_revalidation_threshold, get_submission_data)
 
-from dataactcore.models.lookups import PUBLISH_STATUS_DICT
-from dataactcore.models.jobModels import CertifyHistory, FileType, JobStatus, JobType
+from dataactcore.models.lookups import PUBLISH_STATUS_DICT, JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
+from dataactcore.models.jobModels import CertifyHistory
 
 from tests.unit.dataactcore.factories.domain import CGACFactory, FRECFactory
 from tests.unit.dataactcore.factories.job import (SubmissionFactory, JobFactory, CertifyHistoryFactory,
@@ -36,17 +36,11 @@ def test_get_submission_metadata_quarterly_dabs_cgac(database):
                             number_of_warnings=200)
     # Job for submission
     job = JobFactory(submission_id=sub.submission_id, last_validated=now_plus_10,
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                     file_type=sess.query(FileType).filter_by(name='appropriations').one(),
-                     number_of_rows=3,
-                     file_size=7655)
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], job_status_id=JOB_STATUS_DICT['finished'],
+                     file_type_id=FILE_TYPE_DICT['appropriations'], number_of_rows=3, file_size=7655)
     job_2 = JobFactory(submission_id=sub.submission_id, last_validated=now_plus_10,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                       file_type=sess.query(FileType).filter_by(name='program_activity').one(),
-                       number_of_rows=7,
-                       file_size=12345)
+                       job_type_id=JOB_TYPE_DICT['csv_record_validation'], job_status_id=JOB_STATUS_DICT['finished'],
+                       file_type_id=FILE_TYPE_DICT['program_activity'], number_of_rows=7, file_size=12345)
 
     sess.add_all([cgac, frec_cgac, frec, sub, job, job_2])
     sess.commit()
@@ -276,46 +270,21 @@ def test_get_submission_data_dabs(database):
     sub_2 = SubmissionFactory(submission_id=2, d2_submission=False)
 
     # Job for submission
-    job = JobFactory(job_id=1,
-                     submission_id=sub.submission_id,
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                     file_type=sess.query(FileType).filter_by(name='appropriations').one(),
-                     number_of_rows=3,
-                     file_size=7655,
-                     original_filename='file_1')
-    job_2 = JobFactory(job_id=2,
-                       submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                       file_type=sess.query(FileType).filter_by(name='program_activity').one(),
-                       number_of_rows=None,
-                       file_size=None,
-                       original_filename='file_2')
-    job_3 = JobFactory(job_id=3,
-                       submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='running').one(),
-                       file_type=sess.query(FileType).filter_by(name='program_activity').one(),
-                       number_of_rows=7,
-                       file_size=12345,
-                       original_filename='file_2')
-    job_4 = JobFactory(job_id=4,
-                       submission_id=sub.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='validation').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-                       file_type=None,
-                       number_of_rows=None,
-                       file_size=None,
-                       original_filename=None)
-    job_5 = JobFactory(job_id=5,
-                       submission_id=sub_2.submission_id,
-                       job_type=sess.query(JobType).filter_by(name='validation').one(),
-                       job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-                       file_type=None,
-                       number_of_rows=None,
-                       file_size=None,
-                       original_filename=None)
+    job = JobFactory(job_id=1, submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                     job_status_id=JOB_STATUS_DICT['finished'], file_type_id=FILE_TYPE_DICT['appropriations'],
+                     number_of_rows=3, file_size=7655, original_filename='file_1')
+    job_2 = JobFactory(job_id=2, submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['file_upload'],
+                       job_status_id=JOB_STATUS_DICT['finished'], file_type_id=FILE_TYPE_DICT['program_activity'],
+                       number_of_rows=None, file_size=None, original_filename='file_2')
+    job_3 = JobFactory(job_id=3, submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                       job_status_id=JOB_STATUS_DICT['running'], file_type_id=FILE_TYPE_DICT['program_activity'],
+                       number_of_rows=7, file_size=12345, original_filename='file_2')
+    job_4 = JobFactory(job_id=4, submission_id=sub.submission_id, job_type_id=JOB_TYPE_DICT['validation'],
+                       job_status_id=JOB_STATUS_DICT['waiting'], file_type_id=None, number_of_rows=None,
+                       file_size=None, original_filename=None)
+    job_5 = JobFactory(job_id=5, submission_id=sub_2.submission_id, job_type_id=JOB_TYPE_DICT['validation'],
+                       job_status_id=JOB_STATUS_DICT['waiting'], file_type_id=None, number_of_rows=None,
+                       file_size=None, original_filename=None)
 
     sess.add_all([cgac, sub, sub_2, job, job_2, job_3, job_4, job_5])
     sess.commit()

--- a/tests/unit/dataactcore/factories/job.py
+++ b/tests/unit/dataactcore/factories/job.py
@@ -4,6 +4,7 @@ from factory import fuzzy
 from datetime import date
 
 from dataactcore.models import jobModels
+from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
 from tests.unit.dataactcore.factories.user import UserFactory
 
 
@@ -58,10 +59,10 @@ class JobFactory(factory.Factory):
 
     job_id = None
     filename = fuzzy.FuzzyText()
-    job_status_id = fuzzy.FuzzyInteger(99)
-    job_type_id = fuzzy.FuzzyInteger(99)
+    job_status_id = fuzzy.FuzzyInteger(1, len(JOB_STATUS_DICT))
+    job_type_id = fuzzy.FuzzyInteger(1, 2)
     submission = factory.SubFactory(SubmissionFactory)
-    file_type_id = fuzzy.FuzzyInteger(99)
+    file_type_id = fuzzy.FuzzyInteger(1, len(FILE_TYPE_DICT))
     original_filename = fuzzy.FuzzyText()
     file_size = fuzzy.FuzzyInteger(9999)
     number_of_rows = fuzzy.FuzzyInteger(9999)

--- a/tests/unit/dataactcore/factories/job.py
+++ b/tests/unit/dataactcore/factories/job.py
@@ -58,10 +58,10 @@ class JobFactory(factory.Factory):
 
     job_id = None
     filename = fuzzy.FuzzyText()
-    job_status = factory.SubFactory(JobStatusFactory)
-    job_type = factory.SubFactory(JobTypeFactory)
+    job_status_id = fuzzy.FuzzyInteger(99)
+    job_type_id = fuzzy.FuzzyInteger(99)
     submission = factory.SubFactory(SubmissionFactory)
-    file_type = factory.SubFactory(FileTypeFactory)
+    file_type_id = fuzzy.FuzzyInteger(99)
     original_filename = fuzzy.FuzzyText()
     file_size = fuzzy.FuzzyInteger(9999)
     number_of_rows = fuzzy.FuzzyInteger(9999)

--- a/tests/unit/dataactcore/factories/job.py
+++ b/tests/unit/dataactcore/factories/job.py
@@ -59,10 +59,10 @@ class JobFactory(factory.Factory):
 
     job_id = None
     filename = fuzzy.FuzzyText()
-    job_status_id = fuzzy.FuzzyInteger(1, len(JOB_STATUS_DICT))
-    job_type_id = fuzzy.FuzzyInteger(1, 2)
+    job_status_id = fuzzy.FuzzyChoice(JOB_STATUS_DICT.values())
+    job_type_id = fuzzy.FuzzyChoice(JOB_TYPE_DICT.values())
     submission = factory.SubFactory(SubmissionFactory)
-    file_type_id = fuzzy.FuzzyInteger(1, len(FILE_TYPE_DICT))
+    file_type_id = fuzzy.FuzzyChoice(FILE_TYPE_DICT.values())
     original_filename = fuzzy.FuzzyText()
     file_size = fuzzy.FuzzyInteger(9999)
     number_of_rows = fuzzy.FuzzyInteger(9999)

--- a/tests/unit/dataactcore/factories/job.py
+++ b/tests/unit/dataactcore/factories/job.py
@@ -93,7 +93,6 @@ class CertifiedFilesHistoryFactory(factory.Factory):
     submission_id = fuzzy.FuzzyInteger(9999)
     filename = fuzzy.FuzzyText()
     file_type_id = fuzzy.FuzzyInteger(9999)
-    file_type = factory.SubFactory(FileTypeFactory)
     warning_filename = fuzzy.FuzzyText()
     narrative = fuzzy.FuzzyText()
 
@@ -106,7 +105,6 @@ class SubmissionNarrativeFactory(factory.Factory):
     submission_id = fuzzy.FuzzyInteger(9999)
     submission = factory.SubFactory(SubmissionFactory)
     file_type_id = fuzzy.FuzzyInteger(9999)
-    file_type = factory.SubFactory(FileTypeFactory)
     narrative = fuzzy.FuzzyText()
 
 

--- a/tests/unit/dataactcore/test_function_bag.py
+++ b/tests/unit/dataactcore/test_function_bag.py
@@ -3,8 +3,8 @@ import pytest
 from unittest.mock import patch
 
 from dataactcore.aws.sqsHandler import SQSMockQueue
-from dataactcore.models.jobModels import JobStatus, JobType, FileType, JobDependency
-from dataactcore.models.lookups import JOB_STATUS_DICT
+from dataactcore.models.jobModels import JobDependency
+from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
 from dataactcore.interfaces.function_bag import check_job_dependencies
 
 from tests.unit.dataactcore.factories.job import JobFactory, SubmissionFactory
@@ -15,9 +15,8 @@ def test_check_job_dependencies_not_finished(database):
     """ Tests check_job_dependencies with a job that isn't finished """
     sess = database.session
     sub = SubmissionFactory(submission_id=1)
-    job = JobFactory(submission_id=sub.submission_id, job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one())
+    job = JobFactory(submission_id=sub.submission_id, job_status_id=JOB_STATUS_DICT['waiting'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
     sess.add_all([sub, job])
     sess.commit()
 
@@ -30,17 +29,14 @@ def test_check_job_dependencies_has_unfinished_dependencies(database):
     """ Tests check_job_dependencies with a job that isn't finished """
     sess = database.session
     sub = SubmissionFactory(submission_id=1)
-    job = JobFactory(submission_id=sub.submission_id, job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one(), number_of_errors=0)
-    job_2 = JobFactory(submission_id=sub.submission_id,
-                       job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='award').one())
-    job_3 = JobFactory(submission_id=sub.submission_id,
-                       job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='award').one(), number_of_errors=0)
+    job = JobFactory(submission_id=sub.submission_id, job_status_id=JOB_STATUS_DICT['finished'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'],
+                     number_of_errors=0)
+    job_2 = JobFactory(submission_id=sub.submission_id, job_status_id=JOB_STATUS_DICT['waiting'],
+                       job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
+    job_3 = JobFactory(submission_id=sub.submission_id, job_status_id=JOB_STATUS_DICT['waiting'],
+                       job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'],
+                       number_of_errors=0)
     sess.add_all([sub, job, job_2, job_3])
     sess.commit()
 
@@ -61,13 +57,11 @@ def test_check_job_dependencies_prior_dependency_has_errors(database):
     """ Tests check_job_dependencies with a job that is finished but has errors """
     sess = database.session
     sub = SubmissionFactory(submission_id=1)
-    job = JobFactory(submission_id=sub.submission_id, job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one(), number_of_errors=3)
-    job_2 = JobFactory(submission_id=sub.submission_id,
-                       job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='award').one())
+    job = JobFactory(submission_id=sub.submission_id, job_status_id=JOB_STATUS_DICT['finished'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'],
+                     number_of_errors=3)
+    job_2 = JobFactory(submission_id=sub.submission_id, job_status_id=JOB_STATUS_DICT['waiting'],
+                       job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
     sess.add_all([sub, job, job_2])
     sess.commit()
 
@@ -89,13 +83,11 @@ def test_check_job_dependencies_ready(mock_sqs_queue, database):
     mock_sqs_queue.return_value = SQSMockQueue
     sess = database.session
     sub = SubmissionFactory(submission_id=1)
-    job = JobFactory(submission_id=sub.submission_id, job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-                     job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                     file_type=sess.query(FileType).filter_by(name='award').one(), number_of_errors=0)
-    job_2 = JobFactory(submission_id=sub.submission_id,
-                       job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-                       job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-                       file_type=sess.query(FileType).filter_by(name='award').one())
+    job = JobFactory(submission_id=sub.submission_id, job_status_id=JOB_STATUS_DICT['finished'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'],
+                     number_of_errors=0)
+    job_2 = JobFactory(submission_id=sub.submission_id, job_status_id=JOB_STATUS_DICT['waiting'],
+                       job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'])
     sess.add_all([sub, job, job_2])
     sess.commit()
 

--- a/tests/unit/dataactvalidator/validation_handlers/test_file_generation_handler.py
+++ b/tests/unit/dataactvalidator/validation_handlers/test_file_generation_handler.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from flask import Flask
 from unittest.mock import Mock
 
-from dataactcore.models.jobModels import FileType, JobStatus, JobType
+from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
 from dataactcore.models.stagingModels import DetachedAwardProcurement, PublishedAwardFinancialAssistance
 from dataactcore.utils import fileE
 from dataactvalidator.validation_handlers import file_generation_handler
@@ -22,11 +22,8 @@ from tests.unit.dataactcore.factories.staging import (
 def test_job_context_success(database):
     """ When a job successfully runs, it should be marked as "finished" """
     sess = database.session
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='running').one(),
-        job_type=sess.query(JobType).filter_by(name='validation').one(),
-        file_type=sess.query(FileType).filter_by(name='sub_award').one(),
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['running'], job_type_id=JOB_TYPE_DICT['validation'],
+                     file_type_id=FILE_TYPE_DICT['sub_award'])
     sess.add(job)
     sess.commit()
 
@@ -41,12 +38,8 @@ def test_job_context_success(database):
 def test_job_context_fail(database):
     """ When a job raises an exception and has no retries left, it should be marked as failed """
     sess = database.session
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='running').one(),
-        job_type=sess.query(JobType).filter_by(name='validation').one(),
-        file_type=sess.query(FileType).filter_by(name='sub_award').one(),
-        error_message=None,
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['running'], job_type_id=JOB_TYPE_DICT['validation'],
+                     file_type_id=FILE_TYPE_DICT['sub_award'], error_message=None)
     sess.add(job)
     sess.commit()
 
@@ -78,12 +71,9 @@ def test_generate_d1_file_query(mock_broker_config_paths, database):
     sess.add_all([dap_1, dap_2, dap_3, dap_4, dap_5])
 
     file_path = str(mock_broker_config_paths['d_file_storage_path'].join('d1_test'))
-    job = JobFactory(
-        job_status=database.session.query(JobStatus).filter_by(name='running').one(),
-        job_type=database.session.query(JobType).filter_by(name='file_upload').one(),
-        file_type=database.session.query(FileType).filter_by(name='award_procurement').one(),
-        filename=file_path, original_filename='d1_test', start_date='01/01/2017', end_date='01/31/2017',
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['running'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award_procurement'], filename=file_path, original_filename='d1_test',
+                     start_date='01/01/2017', end_date='01/31/2017')
     sess.add(job)
     sess.commit()
 
@@ -126,12 +116,9 @@ def test_generate_d2_file_query(mock_broker_config_paths, database):
     sess.add_all([pafa_1, pafa_2, pafa_3, pafa_4, pafa_5, pafa_6])
 
     file_path = str(mock_broker_config_paths['d_file_storage_path'].join('d2_test'))
-    job = JobFactory(
-        job_status=database.session.query(JobStatus).filter_by(name='running').one(),
-        job_type=database.session.query(JobType).filter_by(name='file_upload').one(),
-        file_type=database.session.query(FileType).filter_by(name='award').one(),
-        filename=file_path, original_filename='d2_test', start_date='01/01/2017', end_date='01/31/2017',
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['running'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award'], filename=file_path, original_filename='d2_test',
+                     start_date='01/01/2017', end_date='01/31/2017')
     sess.add(job)
     sess.commit()
 
@@ -163,19 +150,11 @@ def test_generate_d2_file_query(mock_broker_config_paths, database):
 def test_generate_f_file(monkeypatch, mock_broker_config_paths, database):
     """ A CSV with fields in the right order should be written to the file system """
     file_path1 = str(mock_broker_config_paths['broker_files'].join('f_test1'))
-    job1 = JobFactory(
-        job_status=database.session.query(JobStatus).filter_by(name='running').one(),
-        job_type=database.session.query(JobType).filter_by(name='file_upload').one(),
-        file_type=database.session.query(FileType).filter_by(name='sub_award').one(),
-        filename=file_path1, original_filename='f_test1',
-    )
+    job1 = JobFactory(job_status_id=JOB_STATUS_DICT['running'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                      file_type_id=FILE_TYPE_DICT['sub_award'], filename=file_path1, original_filename='f_test1')
     file_path2 = str(mock_broker_config_paths['broker_files'].join('f_test2'))
-    job2 = JobFactory(
-        job_status=database.session.query(JobStatus).filter_by(name='running').one(),
-        job_type=database.session.query(JobType).filter_by(name='file_upload').one(),
-        file_type=database.session.query(FileType).filter_by(name='sub_award').one(),
-        filename=file_path2, original_filename='f_test2',
-    )
+    job2 = JobFactory(job_status_id=JOB_STATUS_DICT['running'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                      file_type_id=FILE_TYPE_DICT['sub_award'], filename=file_path2, original_filename='f_test2')
     database.session.add(job1, job2)
     database.session.commit()
 
@@ -216,12 +195,9 @@ def test_generate_e_file_query(monkeypatch, mock_broker_config_paths, database):
     sess.commit()
 
     file_path = str(mock_broker_config_paths['broker_files'].join('e_test1'))
-    job = JobFactory(
-        job_status=database.session.query(JobStatus).filter_by(name='running').one(),
-        job_type=database.session.query(JobType).filter_by(name='file_upload').one(),
-        file_type=database.session.query(FileType).filter_by(name='executive_compensation').one(),
-        filename=file_path, original_filename='e_test1', submission_id=sub.submission_id,
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['running'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['executive_compensation'], filename=file_path,
+                     original_filename='e_test1', submission_id=sub.submission_id)
     database.session.add(job)
     database.session.commit()
 
@@ -262,12 +238,9 @@ def test_generate_e_file_csv(monkeypatch, mock_broker_config_paths, database):
     database.session.commit()
 
     file_path = str(mock_broker_config_paths['broker_files'].join('e_test1'))
-    job = JobFactory(
-        job_status=database.session.query(JobStatus).filter_by(name='running').one(),
-        job_type=database.session.query(JobType).filter_by(name='file_upload').one(),
-        file_type=database.session.query(FileType).filter_by(name='executive_compensation').one(),
-        filename=file_path, original_filename='e_test1', submission_id=sub.submission_id,
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['running'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['executive_compensation'], filename=file_path,
+                     original_filename='e_test1', submission_id=sub.submission_id)
     database.session.add(job)
     database.session.commit()
 
@@ -305,17 +278,10 @@ def test_generate_e_file_csv(monkeypatch, mock_broker_config_paths, database):
 def test_copy_parent_file_request_data(database):
     sess = database.session
 
-    job_one = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award').one(),
-    )
-    job_two = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='running').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award').one(),
-        filename='job_id/new_filename'
-    )
+    job_one = JobFactory(job_status_id=JOB_STATUS_DICT['finished'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                         file_type_id=FILE_TYPE_DICT['award'])
+    job_two = JobFactory(job_status_id=JOB_STATUS_DICT['running'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                         file_type_id=FILE_TYPE_DICT['award'], filename='job_id/new_filename')
     sess.add_all([job_one, job_two])
     sess.commit()
 
@@ -337,32 +303,29 @@ def test_check_detached_d_file_generation(database):
     sess = database.session
 
     # Detached D2 generation waiting to be picked up by the Validator
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award').one(),
-        error_message='', filename='job_id/file.csv', original_filename='file.csv'
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award'], error_message='', filename='job_id/file.csv',
+                     original_filename='file.csv')
     sess.add(job)
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'waiting'
 
     # Detached D2 generation running in the Validator
-    job.job_status = sess.query(JobStatus).filter_by(name='running').one()
+    job.job_status_id = JOB_STATUS_DICT['running']
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'waiting'
 
     # Detached D2 generation completed by the Validator
-    job.job_status = sess.query(JobStatus).filter_by(name='finished').one()
+    job.job_status_id = JOB_STATUS_DICT['finished']
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'finished'
     assert response_dict['message'] == ''
 
     # Detached D2 generation with an unknown error
-    job.job_status = sess.query(JobStatus).filter_by(name='failed').one()
+    job.job_status_id = JOB_STATUS_DICT['failed']
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'failed'
@@ -384,31 +347,25 @@ def test_check_submission_d_file_generation(database):
     sess.add(sub)
 
     # D1 generation waiting to be picked up by the Validator
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        submission=sub, error_message='', filename='job_id/file.csv', original_filename='file.csv'
-    )
-    val_job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='csv_record_validation').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        submission=sub, error_message='', number_of_errors=0,
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award_procurement'], submission=sub, error_message='',
+                     filename='job_id/file.csv', original_filename='file.csv')
+    val_job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                         file_type_id=FILE_TYPE_DICT['award_procurement'], submission=sub, error_message='',
+                         number_of_errors=0)
     sess.add_all([job, val_job])
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'waiting'
 
     # D1 generation running in the Validator
-    job.job_status = sess.query(JobStatus).filter_by(name='running').one()
+    job.job_status_id = JOB_STATUS_DICT['running']
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'waiting'
 
     # D1 generation with an unknown error
-    job.job_status = sess.query(JobStatus).filter_by(name='failed').one()
+    job.job_status_id = JOB_STATUS_DICT['failed']
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'failed'
@@ -423,19 +380,19 @@ def test_check_submission_d_file_generation(database):
 
     # D1 generation completed by the Validator; validation waiting to be picked up
     job.error_message = ''
-    job.job_status = sess.query(JobStatus).filter_by(name='finished').one()
+    job.job_status_id = JOB_STATUS_DICT['finished']
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'waiting'
 
     # D1 generation completed; validation running in the Validator
-    val_job.job_status = sess.query(JobStatus).filter_by(name='running').one()
+    val_job.job_status_id = JOB_STATUS_DICT['running']
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'waiting'
 
     # D1 generation completed; validation completed by the Validator
-    val_job.job_status = sess.query(JobStatus).filter_by(name='finished').one()
+    val_job.job_status_id = JOB_STATUS_DICT['finished']
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'finished'
@@ -450,7 +407,7 @@ def test_check_submission_d_file_generation(database):
     # D1 generation completed; validation with an unknown error
     job.error_message = ''
     val_job.error_message = ''
-    val_job.job_status = sess.query(JobStatus).filter_by(name='failed').one()
+    val_job.job_status_id = JOB_STATUS_DICT['failed']
     val_job.number_of_errors = 0
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
@@ -469,7 +426,7 @@ def test_check_submission_d_file_generation(database):
     # D1 generation completed; validation with an unknown error
     job.error_message = ''
     val_job.error_message = ''
-    val_job.job_status = sess.query(JobStatus).filter_by(name='invalid').one()
+    val_job.job_status_id = JOB_STATUS_DICT['invalid']
     sess.commit()
     response_dict = file_generation_handler.check_file_generation(job.job_id)
     assert response_dict['status'] == 'failed'

--- a/tests/unit/dataactvalidator/validation_handlers/test_file_generation_manager.py
+++ b/tests/unit/dataactvalidator/validation_handlers/test_file_generation_manager.py
@@ -1,23 +1,24 @@
+import pytest
+
 from datetime import datetime, timedelta
 from unittest.mock import Mock
 
-from dataactcore.models.jobModels import JobStatus, JobType, FileType, FileRequest
+from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
+from dataactcore.models.jobModels import FileRequest
 from dataactvalidator.validation_handlers import file_generation_handler
 from dataactvalidator.validation_handlers.file_generation_manager import FileGenerationManager
 
 from tests.unit.dataactcore.factories.job import JobFactory, FileRequestFactory
 
 
-def test_generate_new_d1_file_success(monkeypatch, mock_broker_config_paths, database, job_constants):
+@pytest.mark.usefixtures("job_constants")
+def test_generate_new_d1_file_success(monkeypatch, mock_broker_config_paths, database):
     """ Testing that a new D1 file is generated """
     sess = database.session
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
-        start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True,
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award_procurement'],
+                     filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
+                     start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True)
     sess.add(job)
     sess.commit()
 
@@ -35,19 +36,17 @@ def test_generate_new_d1_file_success(monkeypatch, mock_broker_config_paths, dat
 
     assert job.original_filename != 'original'
     assert job.from_cached is False
-    assert job.job_status_id == sess.query(JobStatus).filter_by(name='finished').one().job_status_id
+    assert job.job_status_id == JOB_STATUS_DICT['finished']
 
 
-def test_generate_new_d2_file_success(monkeypatch, mock_broker_config_paths, database, job_constants):
+@pytest.mark.usefixtures("job_constants")
+def test_generate_new_d2_file_success(monkeypatch, mock_broker_config_paths, database):
     """ Testing that a new D2 file is generated """
     sess = database.session
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
-        start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True,
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award'],
+                     filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
+                     start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True)
     sess.add(job)
     sess.commit()
 
@@ -65,33 +64,28 @@ def test_generate_new_d2_file_success(monkeypatch, mock_broker_config_paths, dat
 
     assert job.original_filename != 'original'
     assert job.from_cached is False
-    assert job.job_status_id == sess.query(JobStatus).filter_by(name='finished').one().job_status_id
+    assert job.job_status_id == JOB_STATUS_DICT['finished']
 
 
-def test_generate_noncached_d1_file_success(monkeypatch, mock_broker_config_paths, database, job_constants):
+@pytest.mark.usefixtures("job_constants")
+def test_generate_noncached_d1_file_success(monkeypatch, mock_broker_config_paths, database):
     """ Testing that a new D1 file is generated """
     sess = database.session
-    job1 = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_agency')),
-        start_date='01/01/2017', end_date='01/31/2017', original_filename='diff_agency', from_cached=False,
-    )
-    job2 = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_start_date')),
-        start_date='01/02/2017', end_date='01/31/2017', original_filename='diff_start_date', from_cached=False,
-    )
-    job3 = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_end_date')),
-        start_date='01/01/2017', end_date='01/30/2017', original_filename='diff_end_date', from_cached=False,
-    )
+    job1 = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                      file_type_id=FILE_TYPE_DICT['award_procurement'],
+                      filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_agency')),
+                      start_date='01/01/2017', end_date='01/31/2017', original_filename='diff_agency',
+                      from_cached=False)
+    job2 = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                      file_type_id=FILE_TYPE_DICT['award'],
+                      filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_start_date')),
+                      start_date='01/02/2017', end_date='01/31/2017', original_filename='diff_start_date',
+                      from_cached=False)
+    job3 = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                      file_type_id=FILE_TYPE_DICT['award_procurement'],
+                      filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_end_date')),
+                      start_date='01/01/2017', end_date='01/30/2017', original_filename='diff_end_date',
+                      from_cached=False)
     sess.add_all([job1, job2, job3])
     sess.commit()
 
@@ -104,11 +98,8 @@ def test_generate_noncached_d1_file_success(monkeypatch, mock_broker_config_path
     file_request3 = FileRequestFactory(
         job=job1, is_cached_file=True, agency_code='123', start_date='01/01/2017', end_date='01/30/2017',
         file_type='D1', request_date=datetime.now().date())
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        start_date='01/01/2017', end_date='01/31/2017',)
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award_procurement'], start_date='01/01/2017', end_date='01/31/2017')
     sess.add_all([job, file_request1, file_request2, file_request3])
     sess.commit()
 
@@ -128,33 +119,28 @@ def test_generate_noncached_d1_file_success(monkeypatch, mock_broker_config_path
     assert job.original_filename != job2.original_filename
     assert job.original_filename != job3.original_filename
     assert job.from_cached is False
-    assert job.job_status_id == sess.query(JobStatus).filter_by(name='finished').one().job_status_id
+    assert job.job_status_id == JOB_STATUS_DICT['finished']
 
 
-def test_generate_noncached_d2_file_success(monkeypatch, mock_broker_config_paths, database, job_constants):
+@pytest.mark.usefixtures("job_constants")
+def test_generate_noncached_d2_file_success(monkeypatch, mock_broker_config_paths, database):
     """ Testing that a new D2 file is generated """
     sess = database.session
-    job1 = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_agency')),
-        start_date='01/01/2017', end_date='01/31/2017', original_filename='diff_agency', from_cached=False,
-    )
-    job2 = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_start_date')),
-        start_date='01/02/2017', end_date='01/31/2017', original_filename='diff_start_date', from_cached=False,
-    )
-    job3 = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_end_date')),
-        start_date='01/01/2017', end_date='01/30/2017', original_filename='diff_end_date', from_cached=False,
-    )
+    job1 = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                      file_type_id=FILE_TYPE_DICT['award_procurement'],
+                      filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_agency')),
+                      start_date='01/01/2017', end_date='01/31/2017', original_filename='diff_agency',
+                      from_cached=False)
+    job2 = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                      file_type_id=FILE_TYPE_DICT['award'],
+                      filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_start_date')),
+                      start_date='01/02/2017', end_date='01/31/2017', original_filename='diff_start_date',
+                      from_cached=False)
+    job3 = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                      file_type_id=FILE_TYPE_DICT['award_procurement'],
+                      filename=str(mock_broker_config_paths['d_file_storage_path'].join('diff_end_date')),
+                      start_date='01/01/2017', end_date='01/30/2017', original_filename='diff_end_date',
+                      from_cached=False)
     sess.add_all([job1, job2, job3])
     sess.commit()
 
@@ -167,11 +153,8 @@ def test_generate_noncached_d2_file_success(monkeypatch, mock_broker_config_path
     file_request3 = FileRequestFactory(
         job=job1, is_cached_file=True, agency_code='123', start_date='01/01/2017', end_date='01/30/2017',
         file_type='D2', request_date=datetime.now().date())
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        start_date='01/01/2017', end_date='01/31/2017',)
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award_procurement'], start_date='01/01/2017', end_date='01/31/2017')
     sess.add_all([job, file_request1, file_request2, file_request3])
     sess.commit()
 
@@ -191,19 +174,17 @@ def test_generate_noncached_d2_file_success(monkeypatch, mock_broker_config_path
     assert job.original_filename != job2.original_filename
     assert job.original_filename != job3.original_filename
     assert job.from_cached is False
-    assert job.job_status_id == sess.query(JobStatus).filter_by(name='finished').one().job_status_id
+    assert job.job_status_id == JOB_STATUS_DICT['finished']
 
 
-def test_regenerate_same_d1_file_success(monkeypatch, mock_broker_config_paths, database, job_constants):
+@pytest.mark.usefixtures("job_constants")
+def test_regenerate_same_d1_file_success(monkeypatch, mock_broker_config_paths, database):
     """Testing that a new file is not generated if this job already has a successfully generated file"""
     sess = database.session
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
-        start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True,
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award_procurement'],
+                     filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
+                     start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True)
     sess.add(job)
     sess.commit()
 
@@ -227,19 +208,17 @@ def test_regenerate_same_d1_file_success(monkeypatch, mock_broker_config_paths, 
 
     assert job.original_filename == 'original'
     assert job.from_cached is False
-    assert job.job_status_id == sess.query(JobStatus).filter_by(name='finished').one().job_status_id
+    assert job.job_status_id == JOB_STATUS_DICT['finished']
 
 
-def test_regenerate_same_d2_file_success(monkeypatch, mock_broker_config_paths, database, job_constants):
+@pytest.mark.usefixtures("job_constants")
+def test_regenerate_same_d2_file_success(monkeypatch, mock_broker_config_paths, database):
     """Testing that a new file is not generated if this job already has a successfully generated file"""
     sess = database.session
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
-        start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True,
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award'],
+                     filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
+                     start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True)
     sess.add(job)
     sess.commit()
 
@@ -263,31 +242,27 @@ def test_regenerate_same_d2_file_success(monkeypatch, mock_broker_config_paths, 
 
     assert job.original_filename == 'original'
     assert job.from_cached is False
-    assert job.job_status_id == sess.query(JobStatus).filter_by(name='finished').one().job_status_id
+    assert job.job_status_id == JOB_STATUS_DICT['finished']
 
 
-def test_regenerate_new_d1_file_success(monkeypatch, mock_broker_config_paths, database, job_constants):
+@pytest.mark.usefixtures("job_constants")
+def test_regenerate_new_d1_file_success(monkeypatch, mock_broker_config_paths, database):
     """Testing that a new file is not generated if another job has already has a successfully generated file"""
     sess = database.session
-    original_job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
-        start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True,
-    )
+    original_job = JobFactory(job_status_id=JOB_STATUS_DICT['finished'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                              file_type_id=FILE_TYPE_DICT['award_procurement'],
+                              filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
+                              start_date='01/01/2017', end_date='01/31/2017', original_filename='original',
+                              from_cached=True)
     sess.add(original_job)
     sess.commit()
 
     file_request = FileRequestFactory(
         job=original_job, is_cached_file=True, agency_code='123', start_date='01/01/2017', end_date='01/31/2017',
         file_type='D1', request_date=datetime.now().date(),)
-    new_job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        start_date='01/01/2017', end_date='01/31/2017',
-    )
+    new_job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                         file_type_id=FILE_TYPE_DICT['award_procurement'], start_date='01/01/2017',
+                         end_date='01/31/2017')
     sess.add_all([file_request, new_job])
     sess.commit()
 
@@ -305,31 +280,26 @@ def test_regenerate_new_d1_file_success(monkeypatch, mock_broker_config_paths, d
 
     assert new_job.original_filename == 'original'
     assert new_job.from_cached is True
-    assert new_job.job_status_id == sess.query(JobStatus).filter_by(name='finished').one().job_status_id
+    assert new_job.job_status_id == JOB_STATUS_DICT['finished']
 
 
-def test_regenerate_new_d2_file_success(monkeypatch, mock_broker_config_paths, database, job_constants):
+@pytest.mark.usefixtures("job_constants")
+def test_regenerate_new_d2_file_success(monkeypatch, mock_broker_config_paths, database):
     """Testing that a new file is not generated if another job has already has a successfully generated file"""
     sess = database.session
-    original_job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
-        start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True,
-    )
+    original_job = JobFactory(job_status_id=JOB_STATUS_DICT['finished'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                              file_type_id=FILE_TYPE_DICT['award'],
+                              filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
+                              start_date='01/01/2017', end_date='01/31/2017', original_filename='original',
+                              from_cached=True)
     sess.add(original_job)
     sess.commit()
 
     file_request = FileRequestFactory(
         job=original_job, is_cached_file=True, agency_code='123', start_date='01/01/2017', end_date='01/31/2017',
         file_type='D2', request_date=datetime.now().date(),)
-    new_job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award').one(),
-        start_date='01/01/2017', end_date='01/31/2017',
-    )
+    new_job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                         file_type_id=FILE_TYPE_DICT['award'], start_date='01/01/2017', end_date='01/31/2017')
     sess.add_all([file_request, new_job])
     sess.commit()
 
@@ -347,19 +317,17 @@ def test_regenerate_new_d2_file_success(monkeypatch, mock_broker_config_paths, d
 
     assert new_job.original_filename == 'original'
     assert new_job.from_cached is True
-    assert new_job.job_status_id == sess.query(JobStatus).filter_by(name='finished').one().job_status_id
+    assert new_job.job_status_id == JOB_STATUS_DICT['finished']
 
 
-def test_uncache_same_d1_file_fpds_success(monkeypatch, mock_broker_config_paths, database, job_constants):
+@pytest.mark.usefixtures("job_constants")
+def test_uncache_same_d1_file_fpds_success(monkeypatch, mock_broker_config_paths, database):
     """Testing that a new file is not generated if this job already has a successfully generated file"""
     sess = database.session
-    job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
-        start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True,
-    )
+    job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                     file_type_id=FILE_TYPE_DICT['award_procurement'],
+                     filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
+                     start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True)
     sess.add(job)
     sess.commit()
 
@@ -383,31 +351,27 @@ def test_uncache_same_d1_file_fpds_success(monkeypatch, mock_broker_config_paths
 
     assert job.original_filename != 'original'
     assert job.from_cached is False
-    assert job.job_status_id == sess.query(JobStatus).filter_by(name='finished').one().job_status_id
+    assert job.job_status_id == JOB_STATUS_DICT['finished']
 
 
-def test_uncache_new_d1_file_fpds_success(monkeypatch, mock_broker_config_paths, database, job_constants):
+@pytest.mark.usefixtures("job_constants")
+def test_uncache_new_d1_file_fpds_success(monkeypatch, mock_broker_config_paths, database):
     """Testing that a new file is not generated if another job has already has a successfully generated file"""
     sess = database.session
-    original_job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='finished').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
-        start_date='01/01/2017', end_date='01/31/2017', original_filename='original', from_cached=True,
-    )
+    original_job = JobFactory(job_status_id=JOB_STATUS_DICT['finished'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                              file_type_id=FILE_TYPE_DICT['award_procurement'],
+                              filename=str(mock_broker_config_paths['d_file_storage_path'].join('original')),
+                              start_date='01/01/2017', end_date='01/31/2017', original_filename='original',
+                              from_cached=True)
     sess.add(original_job)
     sess.commit()
 
     file_request = FileRequestFactory(
         job=original_job, is_cached_file=True, agency_code='123', start_date='01/01/2017', end_date='01/31/2017',
         file_type='D1', request_date=(datetime.now().date() - timedelta(1)),)
-    new_job = JobFactory(
-        job_status=sess.query(JobStatus).filter_by(name='waiting').one(),
-        job_type=sess.query(JobType).filter_by(name='file_upload').one(),
-        file_type=sess.query(FileType).filter_by(name='award_procurement').one(),
-        start_date='01/01/2017', end_date='01/31/2017',
-    )
+    new_job = JobFactory(job_status_id=JOB_STATUS_DICT['waiting'], job_type_id=JOB_TYPE_DICT['file_upload'],
+                         file_type_id=FILE_TYPE_DICT['award_procurement'], start_date='01/01/2017',
+                         end_date='01/31/2017')
     sess.add_all([file_request, new_job])
     sess.commit()
 
@@ -425,4 +389,4 @@ def test_uncache_new_d1_file_fpds_success(monkeypatch, mock_broker_config_paths,
 
     assert new_job.original_filename != 'original'
     assert new_job.from_cached is False
-    assert new_job.job_status_id == sess.query(JobStatus).filter_by(name='finished').one().job_status_id
+    assert new_job.job_status_id == JOB_STATUS_DICT['finished']

--- a/tests/unit/dataactvalidator/validation_handlers/test_validator.py
+++ b/tests/unit/dataactvalidator/validation_handlers/test_validator.py
@@ -1,10 +1,14 @@
+import pytest
+
 from unittest.mock import Mock
 
+from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
 from dataactcore.models.stagingModels import FlexField
 from dataactvalidator.validation_handlers import validator
 from tests.unit.dataactcore.factories.job import JobFactory, SubmissionFactory
 
 
+@pytest.mark.usefixtures("job_constants")
 def test_relevant_flex_data(database):
     """Verify that we can retrieve multiple flex fields from our data"""
     sess = database.session
@@ -12,7 +16,9 @@ def test_relevant_flex_data(database):
     sess.add_all(subs)
     sess.commit()
     # Three jobs per submission
-    jobs = [JobFactory(submission_id=sub.submission_id) for sub in subs for _ in range(3)]
+    jobs = [JobFactory(submission_id=sub.submission_id, file_type_id=FILE_TYPE_DICT['appropriations'],
+                       job_type_id=JOB_TYPE_DICT['csv_record_validation'], job_status_id=JOB_STATUS_DICT['finished'])
+            for sub in subs for _ in range(3)]
     sess.add_all(jobs)
     sess.commit()
     # Set up ten rows of three fields per job

--- a/tests/unit/dataactvalidator/validation_handlers/test_validator.py
+++ b/tests/unit/dataactvalidator/validation_handlers/test_validator.py
@@ -2,7 +2,6 @@ import pytest
 
 from unittest.mock import Mock
 
-from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
 from dataactcore.models.stagingModels import FlexField
 from dataactvalidator.validation_handlers import validator
 from tests.unit.dataactcore.factories.job import JobFactory, SubmissionFactory
@@ -16,9 +15,7 @@ def test_relevant_flex_data(database):
     sess.add_all(subs)
     sess.commit()
     # Three jobs per submission
-    jobs = [JobFactory(submission_id=sub.submission_id, file_type_id=FILE_TYPE_DICT['appropriations'],
-                       job_type_id=JOB_TYPE_DICT['csv_record_validation'], job_status_id=JOB_STATUS_DICT['finished'])
-            for sub in subs for _ in range(3)]
+    jobs = [JobFactory(submission_id=sub.submission_id) for sub in subs for _ in range(3)]
     sess.add_all(jobs)
     sess.commit()
     # Set up ten rows of three fields per job


### PR DESCRIPTION
**High level description:**
Cleaned up JobFactory for easier/cleaner test writing

**Technical details:**
Removed the requirement to query JobStatus, JobType, and FileType every time a JobFactory is created for testing. Simply need to pass the relevant ID from the lookup instead. Bonus: Did the same for CertifiedFilesHistoryFactory and SubmissionNarrativeFactory.

**Link to JIRA Ticket:**
[DEV-1286](https://federal-spending-transparency.atlassian.net/browse/DEV-1286)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases