### PR TITLE
DEV-1280: Remove unnecessary params in upload_detached_file

### DIFF
--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -188,7 +188,7 @@ def add_file_routes(app, create_credentials, is_local, server_path):
         return JsonResponse.create(StatusCode.OK, get_fabs_meta(submission.submission_id))
 
     @app.route("/v1/upload_detached_file/", methods=["POST"])
-    @requires_sub_agency_perms('edit_fabs')
+    @requires_sub_agency_perms('editfabs')
     def upload_detached_file():
         params = RequestDictionary.derive(request)
         api_triggered = params.get('_files', {}).get('fabs', None)

--- a/tests/integration/baseTestAPI.py
+++ b/tests/integration/baseTestAPI.py
@@ -7,7 +7,7 @@ from webtest import TestApp
 from dataactbroker.app import create_app as create_broker_app
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.interfaces.function_bag import create_user_with_password, get_password_hash
-from dataactcore.models.domainModels import CGAC
+from dataactcore.models.domainModels import CGAC, FREC, SubTierAgency
 from dataactcore.models.userModel import User, UserAffiliation
 from dataactcore.scripts.databaseSetup import drop_database
 from dataactcore.scripts.setupUserDB import setup_user_db
@@ -19,7 +19,7 @@ from dataactcore.config import CONFIG_BROKER, CONFIG_DB
 import dataactcore.config
 from dataactbroker.scripts.setupEmails import setup_emails
 from dataactvalidator.health_check import create_app as create_validator_app
-from dataactcore.models.lookups import PERMISSION_TYPE_DICT
+from dataactcore.models.lookups import ALL_PERMISSION_TYPES_DICT
 from tests.unit.dataactcore.factories.user import UserFactory
 
 
@@ -58,7 +58,8 @@ class BaseTestAPI(unittest.TestCase):
                 'admin_user': 'data.act.tester.1@gmail.com',
                 'agency_user': 'data.act.test.2@gmail.com',
                 'agency_user_2': 'data.act.test.3@gmail.com',
-                'no_permissions_user': 'data.act.tester.4@gmail.com'
+                'no_permissions_user': 'data.act.tester.4@gmail.com',
+                'editfabs_user': 'data.act.test.5@gmail.com'
             }
             user_password = '!passw0rdUp!'
             admin_password = '@pprovedPassw0rdy'
@@ -71,15 +72,25 @@ class BaseTestAPI(unittest.TestCase):
             sess.commit()
 
             cgac = CGAC(cgac_code='000', agency_name='Example Agency')
+            sess.add(cgac)
+            sess.commit()
+
+            frec = FREC(frec_code='0001', cgac_id=cgac.cgac_id, agency_name='Example FREC')
+            sess.add(frec)
+            sess.commit()
+            sub_tier = SubTierAgency(cgac_id=cgac.cgac_id, frec_id=frec.frec_id, sub_tier_agency_code='0000',
+                                     sub_tier_agency_name='Example Sub Tier')
+            sess.add(sub_tier)
 
             # set up users for status tests
-            def add_user(email, name, username, website_admin=False):
+            def add_user(email, name, username, permission_type=ALL_PERMISSION_TYPES_DICT['writer'],
+                         website_admin=False):
                 user = UserFactory(
                     email=email, website_admin=website_admin,
                     name=name, username=username,
                     affiliations=[UserAffiliation(
                         cgac=cgac,
-                        permission_type_id=PERMISSION_TYPE_DICT['writer']
+                        permission_type_id=permission_type
                     )]
                 )
                 user.salt, user.password_hash = get_password_hash(user_password, Bcrypt())
@@ -87,6 +98,8 @@ class BaseTestAPI(unittest.TestCase):
 
             add_user(test_users['agency_user'], "Test User", "testUser")
             add_user(test_users['agency_user_2'], "Test User 2", "testUser2")
+            add_user(test_users['editfabs_user'], "Fabs Writer", "fabsWriter",
+                     permission_type=ALL_PERMISSION_TYPES_DICT['editfabs'])
 
             # add new users
             create_user_with_password(test_users["admin_user"], admin_password, Bcrypt(), website_admin=True)

--- a/tests/integration/detachedUploadTests.py
+++ b/tests/integration/detachedUploadTests.py
@@ -90,9 +90,7 @@ class DetachedUploadTests(BaseTestAPI):
 
     def test_upload_detached_file_wrong_permissions_wrong_user(self):
         self.login_user()
-        new_submission_json = {
-            "agency_code": "WRONG"}
-        response = self.app.post_json("/v1/upload_detached_file/", new_submission_json,
+        response = self.app.post_json("/v1/upload_detached_file/", {"agency_code": "WRONG"},
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json['message'], "User does not have permissions to write to that subtier agency")
@@ -117,25 +115,20 @@ class DetachedUploadTests(BaseTestAPI):
 
     def test_upload_detached_file_missing_parameters(self):
         self.login_user(username=self.agency_user_email)
-        update_submission_json = {}
-        response = self.app.post_json("/v1/upload_detached_file/", update_submission_json,
+        response = self.app.post_json("/v1/upload_detached_file/", {},
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], 'Missing required parameter: agency_code or existing_submission_id')
 
     def test_upload_detached_file_incorrect_parameters(self):
         self.login_user(username=self.agency_user_email)
-        update_submission_json = {
-            "existing_submission_id": "-99"}
-        response = self.app.post_json("/v1/upload_detached_file/", update_submission_json,
+        response = self.app.post_json("/v1/upload_detached_file/", {"existing_submission_id": "-99"},
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], 'existing_submission_id must be a valid submission_id')
 
     def test_upload_detached_file_missing_fabs(self):
-        new_submission_json = {
-            "agency_code": "WRONG"}
-        response = self.app.post_json("/v1/upload_detached_file/", new_submission_json,
+        response = self.app.post_json("/v1/upload_detached_file/", {"agency_code": "WRONG"},
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], "fabs: Missing data for required field.")

--- a/tests/integration/detachedUploadTests.py
+++ b/tests/integration/detachedUploadTests.py
@@ -24,9 +24,11 @@ class DetachedUploadTests(BaseTestAPI):
             cls.session = sess
             admin_user = sess.query(User).filter(User.email == cls.test_users['admin_user']).one()
             agency_user = sess.query(User).filter(User.email == cls.test_users['agency_user']).one()
+            editfabs_user = sess.query(User).filter(User.email == cls.test_users['editfabs_user']).one()
             cls.admin_user_id = admin_user.user_id
             cls.agency_user_id = agency_user.user_id
             cls.agency_user_email = agency_user.email
+            cls.editfabs_email = editfabs_user.email
 
             # setup submission/jobs data for test_check_status
             cls.d2_submission = cls.insert_submission(sess, cls.admin_user_id, cgac_code="SYS",
@@ -89,33 +91,33 @@ class DetachedUploadTests(BaseTestAPI):
     def test_upload_detached_file_wrong_permissions_wrong_user(self):
         self.login_user()
         new_submission_json = {
-            "agency_code": "WRONG",
-            "is_quarter": True,
-            "reporting_period_start_date": "07/2015",
-            "reporting_period_end_date": "09/2015"}
+            "agency_code": "WRONG"}
         response = self.app.post_json("/v1/upload_detached_file/", new_submission_json,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json['message'], "User does not have permissions to write to that subtier agency")
 
+    def test_upload_detached_file_right_permissions(self):
+        self.login_user(username=self.editfabs_email)
+        update_submission_json = {
+            "agency_code": '0000',
+            "fabs": "fabs.csv"}
+        response = self.app.post_json("/v1/upload_detached_file/", update_submission_json,
+                                      headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 200)
+
     def test_upload_detached_file_wrong_permissions_right_user(self):
         self.login_user(username=self.agency_user_email)
         update_submission_json = {
             "existing_submission_id": str(self.test_agency_user_submission_id),
-            "fabs": "fabs.csv",
-            "is_quarter": True,
-            "reporting_period_start_date": "10/2015",
-            "reporting_period_end_date": "12/2015"}
+            "fabs": "fabs.csv"}
         response = self.app.post_json("/v1/upload_detached_file/", update_submission_json,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 200)
 
     def test_upload_detached_file_missing_parameters(self):
         self.login_user(username=self.agency_user_email)
-        update_submission_json = {
-            "is_quarter": True,
-            "reporting_period_start_date": "10/2015",
-            "reporting_period_end_date": "12/2015"}
+        update_submission_json = {}
         response = self.app.post_json("/v1/upload_detached_file/", update_submission_json,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
@@ -124,10 +126,7 @@ class DetachedUploadTests(BaseTestAPI):
     def test_upload_detached_file_incorrect_parameters(self):
         self.login_user(username=self.agency_user_email)
         update_submission_json = {
-            "existing_submission_id": "-99",
-            "is_quarter": True,
-            "reporting_period_start_date": "10/2015",
-            "reporting_period_end_date": "12/2015"}
+            "existing_submission_id": "-99"}
         response = self.app.post_json("/v1/upload_detached_file/", update_submission_json,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
@@ -135,8 +134,7 @@ class DetachedUploadTests(BaseTestAPI):
 
     def test_upload_detached_file_missing_fabs(self):
         new_submission_json = {
-            "agency_code": "WRONG",
-            "is_quarter": False}
+            "agency_code": "WRONG"}
         response = self.app.post_json("/v1/upload_detached_file/", new_submission_json,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
@@ -145,7 +143,6 @@ class DetachedUploadTests(BaseTestAPI):
     def test_upload_detached_file_dabs_submission(self):
         new_submission_json = {
             "existing_submission_id": str(self.other_submission),
-            "is_quarter": False,
             "fabs": "test_file.csv"}
         response = self.app.post_json("/v1/upload_detached_file/", new_submission_json,
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
@@ -162,10 +159,7 @@ class DetachedUploadTests(BaseTestAPI):
         self.assertIn("submission_id", resp.json)
 
     def test_api_upload_detached_file_missing_fabs(self):
-        new_submission_json = {
-            "agency_code": "WRONG",
-            "is_quarter": False}
-        response = self.app.post("/v1/upload_detached_file/", new_submission_json,
+        response = self.app.post("/v1/upload_detached_file/", {"agency_code": "WRONG"},
                                  upload_files=[('not_fabs', 'not_fabs.csv',
                                                open('tests/integration/data/fabs.csv', 'rb').read())],
                                  headers={"x-session-id": self.session_id},
@@ -175,11 +169,7 @@ class DetachedUploadTests(BaseTestAPI):
 
     def test_api_upload_detached_file_missing_parameters(self):
         self.login_user(username=self.agency_user_email)
-        update_submission_json = {
-            "is_quarter": True,
-            "reporting_period_start_date": "10/2015",
-            "reporting_period_end_date": "12/2015"}
-        response = self.app.post("/v1/upload_detached_file/", update_submission_json,
+        response = self.app.post("/v1/upload_detached_file/", {},
                                  upload_files=[('fabs', 'fabs.csv',
                                                 open('tests/integration/data/fabs.csv', 'rb').read())],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
@@ -188,12 +178,7 @@ class DetachedUploadTests(BaseTestAPI):
 
     def test_api_upload_detached_file_incorrect_parameters(self):
         self.login_user(username=self.agency_user_email)
-        update_submission_json = {
-            "existing_submission_id": "-99",
-            "is_quarter": True,
-            "reporting_period_start_date": "10/2015",
-            "reporting_period_end_date": "12/2015"}
-        response = self.app.post("/v1/upload_detached_file/", update_submission_json,
+        response = self.app.post("/v1/upload_detached_file/", {"existing_submission_id": "-99"},
                                  upload_files=[('fabs', 'fabs.csv',
                                                 open('tests/integration/data/fabs.csv', 'rb').read())],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
@@ -201,10 +186,7 @@ class DetachedUploadTests(BaseTestAPI):
         self.assertEqual(response.json['message'], 'existing_submission_id must be a valid submission_id')
 
     def test_api_upload_detached_file_dabs_submission(self):
-        new_submission_json = {
-            "existing_submission_id": str(self.other_submission),
-            "is_quarter": False}
-        response = self.app.post("/v1/upload_detached_file/", new_submission_json,
+        response = self.app.post("/v1/upload_detached_file/", {"existing_submission_id": str(self.other_submission)},
                                  upload_files=[('fabs', 'fabs.csv',
                                                 open('tests/integration/data/fabs.csv', 'rb').read())],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)


### PR DESCRIPTION
**High level description:**
Cleaning up upload_detached_file route params and fixing a permissions check bug.

**Technical details:**
Dates, cgac/frec codes, and quarter checks in upload_detached_file are useless because we don't do anything with any of them. Removed them from tests. Fixing a bug where a non-admin user would never be able to upload a detached file (typo)

**Link to JIRA Ticket:**
[DEV-1280](https://federal-spending-transparency.atlassian.net/browse/DEV-1280)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed