### PR TITLE
DEV-1328: rename submit files route

### DIFF
--- a/APISubmissionGuide.md
+++ b/APISubmissionGuide.md
@@ -21,8 +21,8 @@
 ## DABS Submission Process
 
 ### Upload A, B, C Files
-- Step 1: call `/v1/submit_files/` (POST) to create the submission.
-- For details on its use, click [here](./dataactbroker/README.md#post-v1submit_files)
+- Step 1: call `/v1/upload_dabs_files/` (POST) to create the submission.
+- For details on its use, click [here](./dataactbroker/README.md#post-v1upload_dabs_files)
 
 ### Validate A, B, C Files
 - File-level validation begins automatically on upload completion.
@@ -35,7 +35,7 @@
 - To get a general overview of the number of errors/warnings in the submission, along with all other metadata, `/v1/submission_metadata/` can be called. For details on its use, click [here](./dataactbroker/README.md#get-v1submission_metadata)
 - To get detailed information on each of the jobs and the errors that occurred in each, `/v1/submission_data/` can be called. For details on its use, click [here](./dataactbroker/README.md#get-v1submission_data)
 - If there are any errors and more granular detail is needed, get the error reports by calling `/v1/submission/SUBMISSIONID/report_url/`. For details on its use, click [here](./dataactbroker/README.md#get-v1submissionintsubmission_idreport_url). In this case, `cross_type` should not be used.
-- If a reupload is needed for any of the files, begin again from `submit_files` with these changes:
+- If a reupload is needed for any of the files, begin again from `upload_dabs_files` with these changes:
     - Only pass the keys of the files being updated (e.g. if only appropriations needs a reupload, you will pass `appropriations: "FILENAME"` as an entry in the payload but not the other two.
     - Add the key `existing_submission_id` with the ID of the submission as the content (string).
     - Response will update to not include the IDs and keys for any files that were not resubmitted

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -228,7 +228,7 @@ to security reasons.
 Example Route `/Users/serverdata/test.csv`  for example will return the `test.csv` if the local folder points
 to `/Users/serverdata`.
 
-#### POST "/v1/submit\_files/"
+#### POST "/v1/upload\_dabs\_files/"
 A call to this route should be of content type `"multipart/form-data"`, and, if using curl or a similar service, should use @ notation for the values of the "appropriations", "program_activity" and "award_financial" keys, to indicate the local path to the files to be uploaded. Otherwise, should pass a file-like object.
 
 This route will upload the files, then kick off the validation jobs. It will return the submission_id.
@@ -261,7 +261,7 @@ curl -i -X POST
       -F "appropriations=@/local/path/to/a.csv" 
       -F "award_financial=@/local/path/to/c.csv"  
       -F "program_activity=@/local/path/to/b.csv"
-    /v1/submit_files/
+    /v1/upload_dabs_files/
 ```
 
 #### Example Output:

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -27,13 +27,13 @@ def add_file_routes(app, is_local, server_path):
     """ Create routes related to file submission for flask app """
 
     # Keys for the post route will correspond to the four types of files
-    @app.route("/v1/submit_files/", methods=["POST"])
+    @app.route("/v1/upload_dabs_files/", methods=["POST"])
     @requires_agency_perms('writer')
-    def submit_files():
+    def upload_dabs_files():
         if "multipart/form-data" not in request.headers['Content-Type']:
             return JsonResponse.error(ValueError("Request must be a multipart/form-data type"), StatusCode.CLIENT_ERROR)
         file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
-        return file_manager.validate_submit_files()
+        return file_manager.validate_upload_dabs_files()
 
     @app.route("/v1/check_status/", methods=["GET"])
     @convert_to_submission_id

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -94,9 +94,9 @@ class FileHandler:
         self.server_path = server_path
         self.s3manager = S3Handler()
 
-    def validate_submit_files(self):
-        """ Validate whether the submission can be submitted or not (does the submission exist for this date range
-            already)
+    def validate_upload_dabs_files(self):
+        """ Validate whether the files can be created (if a new submission is being created) or not (does the
+            submission exist for this date range already)
 
             Returns:
                 Results of submit function or a JsonResponse object containing a failure message

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -146,7 +146,7 @@ class FileTests(BaseTestAPI):
                 self.filenames = {"cgac_code": "SYS", "frec_code": None,
                                   "reporting_period_start_date": "01/2001",
                                   "reporting_period_end_date": "03/2001", "is_quarter": True}
-            self.submitFilesResponse = self.app.post("/v1/submit_files/", self.filenames,
+            self.submitFilesResponse = self.app.post("/v1/upload_dabs_files/", self.filenames,
                                                      upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                                      headers={"x-session-id": self.session_id})
             self.updateSubmissionId = self.submitFilesResponse.json["submission_id"]
@@ -160,7 +160,7 @@ class FileTests(BaseTestAPI):
         self.assertIn('submission_id', response.json)
 
     def test_update_submission(self):
-        """ Test submit_files with an existing submission ID """
+        """ Test upload_dabs_files with an existing submission ID """
         self.call_file_submission()
         # note: this is a quarterly test submission, so updated dates must still reflect a quarter
         file_path = "updated.csv" if CONFIG_BROKER["use_aws"] else os.path.join(CONFIG_BROKER["broker_files"],
@@ -176,7 +176,7 @@ class FileTests(BaseTestAPI):
             update_submission = sess.query(Submission).filter(Submission.submission_id == self.updateSubmissionId).one()
             update_submission.publish_status_id = PUBLISH_STATUS_DICT['published']
             sess.commit()
-            update_response = self.app.post("/v1/submit_files/", update_json,
+            update_response = self.app.post("/v1/upload_dabs_files/", update_json,
                                             upload_files=[('award_financial', file_path,
                                                            open('tests/integration/data/awardFinancialValid.csv',
                                                                 'rb').read())],
@@ -198,7 +198,7 @@ class FileTests(BaseTestAPI):
             "is_quarter": True,
             "reporting_period_start_date": "12/2016",
             "reporting_period_end_date": "13/2016"}
-        update_response = self.app.post("/v1/submit_files/", update_json,
+        update_response = self.app.post("/v1/upload_dabs_files/", update_json,
                                         upload_files=[AWARD_FILE_T],
                                         headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(update_response.status_code, 400)
@@ -211,7 +211,7 @@ class FileTests(BaseTestAPI):
             "existing_submission_id": self.status_check_submission_id,
             "reporting_period_start_date": "AB/2016",
             "reporting_period_end_date": "CD/2016"}
-        update_response = self.app.post("/v1/submit_files/", update_json,
+        update_response = self.app.post("/v1/upload_dabs_files/", update_json,
                                         upload_files=[AWARD_FILE_T],
                                         headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(update_response.status_code, 400)
@@ -224,7 +224,7 @@ class FileTests(BaseTestAPI):
             "is_quarter": True,
             "reporting_period_start_date": "Q1/ABCD",
             "reporting_period_end_date": "Q2/2016"}
-        update_response = self.app.post("/v1/submit_files/", update_json,
+        update_response = self.app.post("/v1/upload_dabs_files/", update_json,
                                         upload_files=[AWARD_FILE_T],
                                         headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(update_response.status_code, 400)
@@ -237,7 +237,7 @@ class FileTests(BaseTestAPI):
             "is_quarter": True,
             "reporting_period_start_date": "07/2015",
             "reporting_period_end_date": "09/2015"}
-        response = self.app.post("/v1/submit_files/", update_json,
+        response = self.app.post("/v1/upload_dabs_files/", update_json,
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.json['message'], "A submission with the same period already exists.")
@@ -249,7 +249,7 @@ class FileTests(BaseTestAPI):
             "is_quarter": True,
             "reporting_period_start_date": "07/2015",
             "reporting_period_end_date": "09/2015"}
-        response = self.app.post("/v1/submit_files/", update_json,
+        response = self.app.post("/v1/upload_dabs_files/", update_json,
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
@@ -262,7 +262,7 @@ class FileTests(BaseTestAPI):
             "is_quarter": True,
             "reporting_period_start_date": "07/2015",
             "reporting_period_end_date": "09/2015"}
-        response = self.app.post("/v1/submit_files/", update_json,
+        response = self.app.post("/v1/upload_dabs_files/", update_json,
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
@@ -275,7 +275,7 @@ class FileTests(BaseTestAPI):
             "is_quarter": True,
             "reporting_period_start_date": "07/2015",
             "reporting_period_end_date": "09/2015"}
-        response = self.app.post("/v1/submit_files/", update_json,
+        response = self.app.post("/v1/upload_dabs_files/", update_json,
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], "Request must be a multipart/form-data type")
@@ -288,7 +288,7 @@ class FileTests(BaseTestAPI):
             "is_quarter": True,
             "reporting_period_start_date": "07/2015",
             "reporting_period_end_date": "09/2015"}
-        response = self.app.post("/v1/submit_files/", new_submission_json,
+        response = self.app.post("/v1/upload_dabs_files/", new_submission_json,
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 403)
@@ -301,7 +301,7 @@ class FileTests(BaseTestAPI):
             "is_quarter": True,
             "reporting_period_start_date": "10/2015",
             "reporting_period_end_date": "12/2015"}
-        response = self.app.post("/v1/submit_files/", update_submission_json,
+        response = self.app.post("/v1/upload_dabs_files/", update_submission_json,
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 200)
@@ -312,7 +312,7 @@ class FileTests(BaseTestAPI):
             "is_quarter": True,
             "reporting_period_start_date": "10/2015",
             "reporting_period_end_date": "12/2015"}
-        response = self.app.post("/v1/submit_files/", update_submission_json,
+        response = self.app.post("/v1/upload_dabs_files/", update_submission_json,
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
@@ -326,7 +326,7 @@ class FileTests(BaseTestAPI):
             "is_quarter": True,
             "reporting_period_start_date": "10/2015",
             "reporting_period_end_date": "12/2015"}
-        response = self.app.post("/v1/submit_files/", update_submission_json,
+        response = self.app.post("/v1/upload_dabs_files/", update_submission_json,
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
@@ -1133,7 +1133,7 @@ class FileTests(BaseTestAPI):
         update_json = {"existing_submission_id": submission.submission_id,
                        "reporting_period_start_date": "04/2016",
                        "reporting_period_end_date": "06/2016"}
-        update_response = self.app.post("/v1/submit_files/", update_json,
+        update_response = self.app.post("/v1/upload_dabs_files/", update_json,
                                         upload_files=[APPROP_FILE_T],
                                         headers={"x-session-id": self.session_id})
         # Need to commit for it to take within this session for some reason


### PR DESCRIPTION
**High level description:**
Renaming `submit_files` to `upload_dabs_files` for better clarity.

**Technical details:**
Renaming `submit_files` to `upload_dabs_files` so API users can understand what the route does better.

**Link to JIRA Ticket:**
[DEV-1328](https://federal-spending-transparency.atlassian.net/browse/DEV-1328)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Merged concurrently with [Frontend#912](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/912)
- Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed