### PR TITLE
DEV-1329: rename upload detached file route

### DIFF
--- a/APISubmissionGuide.md
+++ b/APISubmissionGuide.md
@@ -70,8 +70,8 @@
 ## FABS Submission Process
 
 ### Upload FABS File
-- Call `/v1/upload_detached_file/`
-- For details on its use, click [here](./dataactbroker/README.md#post-v1upload_detached_file)
+- Call `/v1/upload_fabs_file/`
+- For details on its use, click [here](./dataactbroker/README.md#post-v1upload_fabs_file)
 
 ### Validate FABS File
 - Validations are automatically started once the upload completes.
@@ -81,8 +81,8 @@
 - To get a general overview of the number of errors/warnings in the submission, along with all other metadata, `/v1/submission_metadata/` can be called. For details on its use, click [here](./dataactbroker/README.md#get-v1submission_metadata)
 - To get detailed information on the validation job and the errors that occurred in it, `/v1/submission_data/` can be called. For details on its use, click [here](./dataactbroker/README.md#get-v1submission_data)
 - If there are any errors and more granular detail is needed, get the error reports by calling `/v1/submission/SUBMISSIONID/report_url/`. For details on its use, click [here](./dataactbroker/README.md#get-v1submissionintsubmission_idreport_url). In this case, `cross_type` should not be used.
-- If a reupload is needed, begin again from `upload_detached_file` with these changes:
-    - `upload_detached_file` Payload:
+- If a reupload is needed, begin again from `upload_fabs_file` with these changes:
+    - `upload_fabs_file` Payload:
         - `fabs`: string, name of file being uploaded
         - `existing_submission_id`: string, ID of the submission
 - If for any reason the uploaded file needs to be redownloaded, use the `get_file_url` route to get the signed url for it. For details on its use, click [here](./dataactbroker/README.md#get-v1get_file_url)

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -272,7 +272,7 @@ curl -i -X POST
 }
 ```
 
-#### POST "/v1/upload\_detached\_file/"
+#### POST "/v1/upload\_fabs\_file/"
 A call to this route should be of content type `"multipart/form-data"`, and, if using curl or a similar service, should use @ notation for the value of the "fabs" key, to indicate the local path to the file to be uploaded. Otherwise, should pass a file-like object.
 
 This route will upload the file, then kick off the validation jobs. It will return the submission id.
@@ -292,7 +292,7 @@ This route will upload the file, then kick off the validation jobs. It will retu
       -H "Content-Type: multipart/form-data"
       -F 'agency_code=2000'
       -F "fabs=@/local/path/to/fabs.csv"
-    /v1/upload_detached_file/
+    /v1/upload_fabs_file/
 ```
 
 #### Example output:

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -176,9 +176,9 @@ def add_file_routes(app, is_local, server_path):
         """ Return metadata of FABS submission """
         return JsonResponse.create(StatusCode.OK, get_fabs_meta(submission.submission_id))
 
-    @app.route("/v1/upload_detached_file/", methods=["POST"])
+    @app.route("/v1/upload_fabs_file/", methods=["POST"])
     @requires_sub_agency_perms('editfabs')
-    def upload_detached_file():
+    def upload_fabs_file():
         if "multipart/form-data" not in request.headers['Content-Type']:
             return JsonResponse.error(ValueError("Request must be a multipart/form-data type"), StatusCode.CLIENT_ERROR)
         params = RequestDictionary.derive(request)

--- a/tests/integration/detachedUploadTests.py
+++ b/tests/integration/detachedUploadTests.py
@@ -88,16 +88,16 @@ class DetachedUploadTests(BaseTestAPI):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json["message"], "Submission is not a FABS submission")
 
-    def test_upload_detached_file_wrong_permissions_wrong_user(self):
+    def test_upload_fabs_file_wrong_permissions_wrong_user(self):
         self.login_user()
-        response = self.app.post_json("/v1/upload_detached_file/", {"agency_code": "WRONG"},
+        response = self.app.post_json("/v1/upload_fabs_file/", {"agency_code": "WRONG"},
                                       headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json['message'], "User does not have permissions to write to that subtier agency")
 
-    def test_upload_detached_file_wrong_permissions_right_user(self):
+    def test_upload_fabs_file_wrong_permissions_right_user(self):
         self.login_user(username=self.agency_user_email)
-        response = self.app.post("/v1/upload_detached_file/",
+        response = self.app.post("/v1/upload_fabs_file/",
                                  {"existing_submission_id": str(self.test_agency_user_submission_id)},
                                  upload_files=[('fabs', 'fabs.csv',
                                                 open('tests/integration/data/fabs.csv', 'rb').read())],
@@ -105,7 +105,7 @@ class DetachedUploadTests(BaseTestAPI):
         self.assertEqual(response.status_code, 200)
 
     def test_successful_file_upload(self):
-        resp = self.app.post("/v1/upload_detached_file/",
+        resp = self.app.post("/v1/upload_fabs_file/",
                              {"agency_code": "WRONG"},
                              upload_files=[('fabs', 'fabs.csv',
                                             open('tests/integration/data/fabs.csv', 'rb').read())],
@@ -113,8 +113,8 @@ class DetachedUploadTests(BaseTestAPI):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("submission_id", resp.json)
 
-    def test_upload_detached_file_missing_fabs(self):
-        response = self.app.post("/v1/upload_detached_file/", {"agency_code": "WRONG"},
+    def test_upload_fabs_file_missing_fabs(self):
+        response = self.app.post("/v1/upload_fabs_file/", {"agency_code": "WRONG"},
                                  upload_files=[('not_fabs', 'not_fabs.csv',
                                                open('tests/integration/data/fabs.csv', 'rb').read())],
                                  headers={"x-session-id": self.session_id},
@@ -122,26 +122,26 @@ class DetachedUploadTests(BaseTestAPI):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], "fabs field must be present and contain a file")
 
-    def test_upload_detached_file_missing_parameters(self):
+    def test_upload_fabs_file_missing_parameters(self):
         self.login_user(username=self.agency_user_email)
-        response = self.app.post("/v1/upload_detached_file/", {},
+        response = self.app.post("/v1/upload_fabs_file/", {},
                                  upload_files=[('fabs', 'fabs.csv',
                                                 open('tests/integration/data/fabs.csv', 'rb').read())],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], 'Missing required parameter: agency_code or existing_submission_id')
 
-    def test_upload_detached_file_incorrect_parameters(self):
+    def test_upload_fabs_file_incorrect_parameters(self):
         self.login_user(username=self.agency_user_email)
-        response = self.app.post("/v1/upload_detached_file/", {"existing_submission_id": "-99"},
+        response = self.app.post("/v1/upload_fabs_file/", {"existing_submission_id": "-99"},
                                  upload_files=[('fabs', 'fabs.csv',
                                                 open('tests/integration/data/fabs.csv', 'rb').read())],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], 'existing_submission_id must be a valid submission_id')
 
-    def test_upload_detached_file_dabs_submission(self):
-        response = self.app.post("/v1/upload_detached_file/", {"existing_submission_id": str(self.other_submission)},
+    def test_upload_fabs_file_dabs_submission(self):
+        response = self.app.post("/v1/upload_fabs_file/", {"existing_submission_id": str(self.other_submission)},
                                  upload_files=[('fabs', 'fabs.csv',
                                                 open('tests/integration/data/fabs.csv', 'rb').read())],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)


### PR DESCRIPTION
**High level description:**
Renaming `upload_detached_file` to `upload_fabs_files` for better clarity.

**Technical details:**
Renaming `upload_detached_file` to `upload_fabs_files` so API users can understand what the route does better.

**Link to JIRA Ticket:**
[DEV-1329](https://federal-spending-transparency.atlassian.net/browse/DEV-1329)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Merged concurrently with [Frontend#913](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/913)
- Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed