### PR TITLE
DEV-1357: submission dashboard submission_id filter

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -919,7 +919,7 @@ This route alters a submission's jobs' statuses and then restarts all validation
 * `message` - A message indicating whether or not the action was successful. Any message other than "Success" indicates a failure.
 
 #### POST "/v1/list\_submissions"
-This endpoint lists submissions for all agencies for which the current user is a member of. Optional filters allow for more refined lists
+This endpoint lists submissions for all agencies for which the current user is a member of. Optional filters allow for more refined lists.
 
 ##### Body (JSON)
 

--- a/dataactbroker/file_routes.py
+++ b/dataactbroker/file_routes.py
@@ -70,7 +70,7 @@ def add_file_routes(app, is_local, server_path):
     def submission_error_metrics(submission):
         return get_error_metrics(submission)
 
-    @app.route("/v1/list_submissions/", methods=["GET"])
+    @app.route("/v1/list_submissions/", methods=["POST"])
     @requires_login
     @use_kwargs({
         'page': webargs_fields.Int(missing=1),
@@ -81,10 +81,11 @@ def add_file_routes(app, is_local, server_path):
         'sort': webargs_fields.String(missing='modified'),
         'order': webargs_fields.String(missing='desc'),
         'd2_submission': webargs_fields.Bool(missing=False),
+        'filters': webargs_fields.Dict(keys=webargs_fields.String(), missing={})
     })
-    def list_submissions(page, limit, certified, sort, order, d2_submission):
+    def list_submissions(page, limit, certified, sort, order, d2_submission, filters):
         """ List submission IDs associated with the current user """
-        return list_submissions_handler(page, limit, certified, sort, order, d2_submission)
+        return list_submissions_handler(page, limit, certified, sort, order, d2_submission, filters)
 
     @app.route("/v1/list_certifications/", methods=["POST"])
     @convert_to_submission_id

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -1,9 +1,7 @@
-import calendar
 import boto
 import os
 
 from boto.s3.key import Key
-from datetime import datetime
 from shutil import copy
 
 from dataactbroker.handlers.submission_handler import populate_submission_error_info
@@ -22,6 +20,7 @@ from dataactvalidator.health_check import create_app
 from sqlalchemy import or_
 from tests.unit.dataactcore.factories.job import SubmissionFactory
 from tests.integration.baseTestAPI import BaseTestAPI
+from tests.integration.integration_test_helper import insert_submission
 
 AWARD_FILE_T = ('award_financial', 'award_financial.csv',
                 open('tests/integration/data/awardFinancialValid.csv', 'rb').read())
@@ -56,68 +55,65 @@ class FileTests(BaseTestAPI):
             cls.other_user_id = other_user.user_id
 
             # setup submission/jobs data for test_check_status
-            cls.status_check_submission_id = cls.insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
-                                                                   start_date="10/2015", end_date="12/2015",
-                                                                   is_quarter=True)
+            cls.status_check_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                               start_date="10/2015", end_date="12/2015",
+                                                               is_quarter=True)
 
-            cls.generation_submission_id = cls.insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
-                                                                 start_date="07/2015", end_date="09/2015",
-                                                                 is_quarter=True)
+            cls.generation_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                             start_date="07/2015", end_date="09/2015", is_quarter=True)
 
             cls.setup_file_generation_submission(sess)
 
             cls.jobIdDict = cls.setup_jobs_for_status_check(sess, cls.status_check_submission_id)
 
             # setup submission/jobs data for test_error_report
-            cls.error_report_submission_id = cls.insert_submission(
-                sess, cls.submission_user_id, cgac_code="SYS", start_date="10/2015", end_date="10/2015")
+            cls.error_report_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                               start_date="10/2015", end_date="10/2015")
             cls.setup_jobs_for_reports(sess, cls.error_report_submission_id)
 
             # setup file status data for test_metrics
-            cls.test_metrics_submission_id = cls.insert_submission(
-                sess, cls.submission_user_id, cgac_code="SYS", start_date="08/2015", end_date="08/2015")
+            cls.test_metrics_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                               start_date="08/2015", end_date="08/2015")
             cls.setup_file_data(sess, cls.test_metrics_submission_id)
 
-            cls.row_error_submission_id = cls.insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
-                                                                start_date="10/2015", end_date="12/2015",
-                                                                is_quarter=True, number_of_errors=1)
+            cls.row_error_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                            start_date="10/2015", end_date="12/2015", is_quarter=True,
+                                                            number_of_errors=1)
             cls.setup_submission_with_error(sess, cls.row_error_submission_id)
 
-            cls.test_delete_submission_id = cls.insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
-                                                                  start_date="07/2015", end_date="09/2015",
-                                                                  is_quarter=True)
+            cls.test_delete_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                              start_date="07/2015", end_date="09/2015", is_quarter=True)
             cls.setup_file_generation_submission(sess, submission_id=cls.test_delete_submission_id)
 
-            cls.test_certified_submission_id = cls.insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
-                                                                     start_date="07/2015", end_date="09/2015",
-                                                                     is_quarter=True, number_of_errors=0,
-                                                                     publish_status_id=2)
+            cls.test_certified_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                                 start_date="07/2015", end_date="09/2015",
+                                                                 is_quarter=True, number_of_errors=0,
+                                                                 publish_status_id=2)
 
-            cls.test_updated_submission_id = cls.insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
-                                                                   start_date="07/2016", end_date="09/2016",
-                                                                   is_quarter=True, number_of_errors=0,
-                                                                   publish_status_id=3)
+            cls.test_updated_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                               start_date="07/2016", end_date="09/2016",
+                                                               is_quarter=True, number_of_errors=0,
+                                                               publish_status_id=3)
 
-            cls.test_uncertified_submission_id = cls.insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
-                                                                       start_date="04/2015", end_date="06/2015",
-                                                                       is_quarter=True, number_of_errors=0)
+            cls.test_uncertified_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                                   start_date="04/2015", end_date="06/2015",
+                                                                   is_quarter=True, number_of_errors=0)
 
-            cls.test_revalidate_submission_id = cls.insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
-                                                                      start_date="10/2015", end_date="12/2015",
-                                                                      is_quarter=True, number_of_errors=0)
+            cls.test_revalidate_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                                  start_date="10/2015", end_date="12/2015",
+                                                                  is_quarter=True, number_of_errors=0)
 
-            cls.test_monthly_submission_id = cls.insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
-                                                                   start_date="10/2015", end_date="12/2015",
-                                                                   is_quarter=False, number_of_errors=0)
+            cls.test_monthly_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                               start_date="10/2015", end_date="12/2015",
+                                                               is_quarter=False, number_of_errors=0)
 
-            cls.test_fabs_submission_id = cls.insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
-                                                                start_date="10/2015", end_date="12/2015",
-                                                                is_quarter=False, number_of_errors=0,
-                                                                is_fabs=True)
+            cls.test_fabs_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code="SYS",
+                                                            start_date="10/2015", end_date="12/2015", is_quarter=False,
+                                                            number_of_errors=0, is_fabs=True)
 
-            cls.test_other_user_submission_id = cls.insert_submission(sess, cls.other_user_id, cgac_code="NOT",
-                                                                      start_date="10/2015", end_date="12/2015",
-                                                                      is_quarter=True, number_of_errors=0)
+            cls.test_other_user_submission_id = insert_submission(sess, cls.other_user_id, cgac_code="NOT",
+                                                                  start_date="10/2015", end_date="12/2015",
+                                                                  is_quarter=True, number_of_errors=0)
             for job_type in ['file_upload', 'csv_record_validation']:
                 for file_type in ['appropriations', 'program_activity', 'award_financial']:
                     cls.insert_job(sess, FILE_TYPE_DICT[file_type], FILE_STATUS_DICT['complete'],
@@ -1144,32 +1140,6 @@ class FileTests(BaseTestAPI):
         # good way to make sure D file generation fails so we have to use a different job)
         cross_job = self.session.query(Job).filter(Job.job_id == job_4.job_id).one()
         self.assertEqual(cross_job.job_status_id, JOB_STATUS_DICT['waiting'])
-
-    @staticmethod
-    def insert_submission(sess, submission_user_id, cgac_code=None, start_date=None, end_date=None,
-                          is_quarter=False, number_of_errors=0, publish_status_id=1, is_fabs=False):
-        """Insert one submission into job tracker and get submission ID back."""
-        publishable = True if number_of_errors == 0 else False
-        end_date = datetime.strptime(end_date, '%m/%Y')
-        end_date = datetime.strptime(
-                        str(end_date.year) + '/' +
-                        str(end_date.month) + '/' +
-                        str(calendar.monthrange(end_date.year, end_date.month)[1]),
-                        '%Y/%m/%d'
-                    ).date()
-        sub = Submission(created_at=datetime.utcnow(),
-                         user_id=submission_user_id,
-                         cgac_code=cgac_code,
-                         reporting_start_date=datetime.strptime(start_date, '%m/%Y'),
-                         reporting_end_date=end_date,
-                         is_quarter_format=is_quarter,
-                         number_of_errors=number_of_errors,
-                         publish_status_id=publish_status_id,
-                         publishable=publishable,
-                         d2_submission=is_fabs)
-        sess.add(sub)
-        sess.commit()
-        return sub.submission_id
 
     @staticmethod
     def insert_job(sess, filetype, status, type_id, submission, job_id=None, filename=None,

--- a/tests/integration/integration_test_helper.py
+++ b/tests/integration/integration_test_helper.py
@@ -1,0 +1,30 @@
+import calendar
+from datetime import datetime
+
+from dataactcore.models.jobModels import Submission
+
+
+def insert_submission(sess, submission_user_id, cgac_code=None, start_date=None, end_date=None,
+                      is_quarter=False, number_of_errors=0, publish_status_id=1, is_fabs=False):
+    """Insert one submission into job tracker and get submission ID back."""
+    publishable = True if number_of_errors == 0 else False
+    end_date = datetime.strptime(end_date, '%m/%Y')
+    end_date = datetime.strptime(
+        str(end_date.year) + '/' +
+        str(end_date.month) + '/' +
+        str(calendar.monthrange(end_date.year, end_date.month)[1]),
+        '%Y/%m/%d'
+    ).date()
+    sub = Submission(created_at=datetime.utcnow(),
+                     user_id=submission_user_id,
+                     cgac_code=cgac_code,
+                     reporting_start_date=datetime.strptime(start_date, '%m/%Y'),
+                     reporting_end_date=end_date,
+                     is_quarter_format=is_quarter,
+                     number_of_errors=number_of_errors,
+                     publish_status_id=publish_status_id,
+                     publishable=publishable,
+                     d2_submission=is_fabs)
+    sess.add(sub)
+    sess.commit()
+    return sub.submission_id

--- a/tests/integration/list_submission_tests.py
+++ b/tests/integration/list_submission_tests.py
@@ -1,0 +1,154 @@
+from dataactcore.interfaces.db import GlobalDB
+from dataactcore.models.userModel import User
+from dataactcore.models.lookups import PUBLISH_STATUS_DICT
+
+from dataactvalidator.health_check import create_app
+
+from tests.integration.baseTestAPI import BaseTestAPI
+from tests.integration.integration_test_helper import insert_submission
+
+
+class ListSubmissionTests(BaseTestAPI):
+    """ Test list submissions endpoint """
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up class-wide resources (test data)"""
+        super(ListSubmissionTests, cls).setUpClass()
+        # TODO: refactor into a pytest fixture
+
+        with create_app().app_context():
+            # get an admin and non-admin user
+            sess = GlobalDB.db().session
+            cls.session = sess
+            admin_user = sess.query(User).filter(User.email == cls.test_users['admin_user']).one()
+            cls.admin_user_id = admin_user.user_id
+
+            other_user = sess.query(User).filter(User.email == cls.test_users['agency_user']).one()
+            cls.other_user_email = other_user.email
+            cls.other_user_id = other_user.user_id
+
+            # set up submissions for dabs
+            cls.non_admin_dabs_sub_id = insert_submission(sess, cls.other_user_id, cgac_code="SYS",
+                                                          start_date="10/2015", end_date="12/2015", is_quarter=True,
+                                                          is_fabs=False,
+                                                          publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
+
+            cls.admin_dabs_sub_id = insert_submission(sess, cls.admin_user_id, cgac_code="000", start_date="10/2015",
+                                                      end_date="12/2015", is_quarter=True, is_fabs=False,
+                                                      publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
+
+            cls.certified_dabs_sub_id = insert_submission(sess, cls.admin_user_id, cgac_code="SYS",
+                                                          start_date="10/2015", end_date="12/2015", is_quarter=True,
+                                                          is_fabs=False,
+                                                          publish_status_id=PUBLISH_STATUS_DICT['published'])
+
+            # set up submissions for dabs
+            cls.non_admin_fabs_sub_id = insert_submission(sess, cls.admin_user_id, cgac_code="SYS",
+                                                          start_date="10/2015", end_date="12/2015", is_fabs=True,
+                                                          publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
+
+            cls.admin_fabs_sub_id = insert_submission(sess, cls.other_user_id, cgac_code="000", start_date="10/2015",
+                                                      end_date="12/2015", is_fabs=True,
+                                                      publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
+
+            cls.published_fabs_sub_id = insert_submission(sess, cls.other_user_id, cgac_code="000",
+                                                          start_date="10/2015", end_date="12/2015", is_fabs=True,
+                                                          publish_status_id=PUBLISH_STATUS_DICT['published'])
+
+    def setUp(self):
+        """Test set-up."""
+        super(ListSubmissionTests, self).setUp()
+        self.login_admin_user()
+
+    @staticmethod
+    def sub_ids(response):
+        """Helper function to parse out the submission ids from an HTTP
+        response"""
+        assert response.status_code == 200
+        result = response.json
+        assert 'submissions' in result
+        return {sub['submission_id'] for sub in result['submissions']}
+
+    def test_list_submissions_dabs_admin(self):
+        """ Test with DABS submissions for an admin user. """
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "mixed"},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id,
+                                          self.certified_dabs_sub_id}
+
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "false"},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id}
+
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "true"},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.certified_dabs_sub_id}
+
+    def test_list_submissions_dabs_non_admin(self):
+        """ Test with DABS submissions for a non admin user. """
+        self.login_user()
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "mixed"},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id}
+
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "false"},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id}
+
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "true"},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == set()
+
+    def test_list_submissions_fabs_admin(self):
+        """ Test with FABS submissions for an admin user. """
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "mixed", "d2_submission": True},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.non_admin_fabs_sub_id, self.admin_fabs_sub_id,
+                                          self.published_fabs_sub_id}
+
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "false", "d2_submission": True},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.non_admin_fabs_sub_id, self.admin_fabs_sub_id}
+
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "true", "d2_submission": True},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.published_fabs_sub_id}
+
+    def test_list_submissions_fabs_non_admin(self):
+        """ Test with FABS submissions for a non admin user. """
+        self.login_user()
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "mixed", "d2_submission": True},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.admin_fabs_sub_id, self.published_fabs_sub_id}
+
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "false", "d2_submission": True},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.admin_fabs_sub_id}
+
+        response = self.app.post_json("/v1/list_submissions/", {"certified": "true", "d2_submission": True},
+                                      headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.published_fabs_sub_id}
+
+    def test_list_submissions_filter_id(self):
+        """ Test listing submissions with a submission_id filter applied """
+        # Listing only the relevant submissions, even when an ID is provided that can't be reached
+        post_json = {
+            "certified": "mixed",
+            "filters": {
+                "submission_ids": [self.non_admin_dabs_sub_id, self.admin_fabs_sub_id]
+            }
+        }
+        response = self.app.post_json("/v1/list_submissions/", post_json, headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == {self.non_admin_dabs_sub_id}
+
+        self.login_user()
+        # Not returning a result if the user doesn't have access to the submission
+        post_json = {
+            "certified": "mixed",
+            "filters": {
+                "submission_ids": [self.certified_dabs_sub_id]
+            }
+        }
+        response = self.app.post_json("/v1/list_submissions/", post_json, headers={"x-session-id": self.session_id})
+        assert self.sub_ids(response) == set()

--- a/tests/integration/list_submission_tests.py
+++ b/tests/integration/list_submission_tests.py
@@ -25,7 +25,6 @@ class ListSubmissionTests(BaseTestAPI):
             cls.admin_user_id = admin_user.user_id
 
             other_user = sess.query(User).filter(User.email == cls.test_users['agency_user']).one()
-            cls.other_user_email = other_user.email
             cls.other_user_id = other_user.user_id
 
             # set up submissions for dabs
@@ -57,14 +56,13 @@ class ListSubmissionTests(BaseTestAPI):
                                                           publish_status_id=PUBLISH_STATUS_DICT['published'])
 
     def setUp(self):
-        """Test set-up."""
+        """ Test set-up. """
         super(ListSubmissionTests, self).setUp()
         self.login_admin_user()
 
     @staticmethod
     def sub_ids(response):
-        """Helper function to parse out the submission ids from an HTTP
-        response"""
+        """ Helper function to parse out the submission ids from an HTTP response. """
         assert response.status_code == 200
         result = response.json
         assert 'submissions' in result
@@ -131,7 +129,7 @@ class ListSubmissionTests(BaseTestAPI):
         assert self.sub_ids(response) == {self.published_fabs_sub_id}
 
     def test_list_submissions_filter_id(self):
-        """ Test listing submissions with a submission_id filter applied """
+        """ Test listing submissions with a submission_id filter applied. """
         # Listing only the relevant submissions, even when an ID is provided that can't be reached
         post_json = {
             "certified": "mixed",

--- a/tests/unit/dataactbroker/test_file_routes.py
+++ b/tests/unit/dataactbroker/test_file_routes.py
@@ -5,7 +5,7 @@ from flask import g
 import pytest
 
 from dataactbroker import file_routes
-from dataactcore.models.lookups import PUBLISH_STATUS_DICT, JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
+from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
 from tests.unit.dataactcore.factories.domain import CGACFactory
 from tests.unit.dataactcore.factories.job import (JobFactory, SubmissionFactory, SubmissionWindowFactory,
                                                   ApplicationTypeFactory)
@@ -17,64 +17,6 @@ from datetime import datetime, timedelta
 def file_app(test_app):
     file_routes.add_file_routes(test_app.application, Mock(), Mock())
     yield test_app
-
-
-def sub_ids(response):
-    """Helper function to parse out the submission ids from an HTTP
-    response"""
-    assert response.status_code == 200
-    result = json.loads(response.data.decode('UTF-8'))
-    assert 'submissions' in result
-    return {sub['submission_id'] for sub in result['submissions']}
-
-
-@pytest.mark.usefixtures("user_constants")
-@pytest.mark.usefixtures("job_constants")
-def test_list_submissions(file_app, database):
-    """Test listing user's submissions. The expected values here correspond to
-    the number of submissions within the agency of the user that is logged in
-    """
-    cgacs = [CGACFactory() for _ in range(5)]
-    user1 = UserFactory.with_cgacs(cgacs[0], cgacs[1])
-    user2 = UserFactory.with_cgacs(cgacs[2])
-    user3 = UserFactory.with_cgacs(*cgacs)
-    database.session.add_all(cgacs + [user1, user2, user3])
-    database.session.commit()
-
-    submissions = [     # one submission per CGAC
-        SubmissionFactory(cgac_code=cgac.cgac_code, publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
-        for cgac in cgacs
-    ]
-    database.session.add_all(submissions)
-
-    g.user = user1
-    response = file_app.get("/v1/list_submissions/?certified=mixed")
-    assert sub_ids(response) == {sub.submission_id for sub in submissions[:2]}
-
-    response = file_app.get("/v1/list_submissions/?certified=false")
-    assert sub_ids(response) == {sub.submission_id for sub in submissions[:2]}
-
-    response = file_app.get("/v1/list_submissions/?certified=true")
-    assert sub_ids(response) == set()
-
-    submissions[0].publish_status_id = PUBLISH_STATUS_DICT['published']
-    database.session.commit()
-    response = file_app.get("/v1/list_submissions/?certified=true")
-    assert sub_ids(response) == {submissions[0].submission_id}
-
-    g.user = user2
-    response = file_app.get("/v1/list_submissions/?certified=mixed")
-    assert sub_ids(response) == {submissions[2].submission_id}
-
-    g.user = user3
-    submissions[3].d2_submission = True
-    submissions[4].d2_submission = True
-    database.session.commit()
-    response = file_app.get("/v1/list_submissions/?certified=mixed&d2_submission=true")
-    assert sub_ids(response) == {sub.submission_id for sub in submissions[3:]}
-
-    response = file_app.get("/v1/list_submissions/?certified=mixed")
-    assert sub_ids(response) == {sub.submission_id for sub in submissions[:3]}
 
 
 def test_is_period(file_app, database):


### PR DESCRIPTION
**High level description:**
Allow users to filter by submission ID when using list_submissions

**Technical details:**
Add a filter object for filtering list_submissions. Currently only contains submission_id but can be expanded to more. Update list_submissions to a POST for cleaner/easier sending of the filters object.

**Link to JIRA Ticket:**
[DEV-1357](https://federal-spending-transparency.atlassian.net/browse/DEV-1357)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [ ] Merged concurrently with [Frontend#917](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/917)
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed