### PR TITLE
DEV-1359: submission dashboard last modified date filter

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -933,8 +933,10 @@ This endpoint lists submissions for all agencies for which the current user is a
     "d2_submission": False,
     "filters": {
         "submission_ids": [123, 456],
-        "start_date": "01/01/2018",
-        "end_date": "01/10/2018"
+        "last_modified_range": {
+            "start_date": "01/01/2018",
+            "end_date": "01/10/2018"
+        }
     }
 }
 ```
@@ -959,8 +961,9 @@ This endpoint lists submissions for all agencies for which the current user is a
 - `d2_submission` - **optional** - a boolean indicating if the submissions listed should be FABS or DABS (True for FABS). Defaults to `False` if not provided.
 - `filters` - **optional** - an object containing additional filters to narrow the results returned by the endpoint. Possible filters are:
     - `submission_ids` - an array of integers or strings that limits the submission IDs returned to only the values listed in the array.
-    - `start_date` - **required if `end_date` is included** - a string indicating the start date for the last modified date range (inclusive) (MM/DD/YYYY)
-    - `end_date` - **required if `start_date` is included** - a string indicating the end date for the last modified date range (inclusive) (MM/DD/YYYY)
+    - `last_modified_range` - an object containing a start and end date for the last modified date range. Both must be provided if this filter is used.
+        - `start_date` - a string indicating the start date for the last modified date range (inclusive) (MM/DD/YYYY)
+        - `end_date` - a string indicating the end date for the last modified date range (inclusive) (MM/DD/YYYY)
 
 ##### Response (JSON)
 

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -932,7 +932,9 @@ This endpoint lists submissions for all agencies for which the current user is a
     "order": "desc",
     "d2_submission": False,
     "filters": {
-        "submission_ids": [123, 456]
+        "submission_ids": [123, 456],
+        "start_date": "01/01/2018",
+        "end_date": "01/10/2018"
     }
 }
 ```
@@ -957,6 +959,8 @@ This endpoint lists submissions for all agencies for which the current user is a
 - `d2_submission` - **optional** - a boolean indicating if the submissions listed should be FABS or DABS (True for FABS). Defaults to `False` if not provided.
 - `filters` - **optional** - an object containing additional filters to narrow the results returned by the endpoint. Possible filters are:
     - `submission_ids` - an array of integers or strings that limits the submission IDs returned to only the values listed in the array.
+    - `start_date` - **required if `end_date` is included** - a string indicating the start date for the last modified date range (inclusive) (MM/DD/YYYY)
+    - `end_date` - **required if `start_date` is included** - a string indicating the end date for the last modified date range (inclusive) (MM/DD/YYYY)
 
 ##### Response (JSON)
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -8,7 +8,7 @@ import sqlalchemy as sa
 import threading
 
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 from flask import g, current_app
 from shutil import copyfile
@@ -1506,6 +1506,7 @@ def add_list_submission_filters(query, filters):
         Raises:
             ResponseException - invalid type is provided for one of the filters
     """
+    # Checking for submission ID filter
     if 'submission_ids' in filters:
         sub_list = filters['submission_ids']
         if sub_list and isinstance(sub_list, list):
@@ -1513,6 +1514,21 @@ def add_list_submission_filters(query, filters):
             query = query.filter(Submission.submission_id.in_(sub_list))
         elif sub_list:
             raise ResponseException("submission_ids filter must be null or an array", StatusCode.CLIENT_ERROR)
+    # Date range filter
+    if 'start_date' in filters or 'end_date' in filters:
+        # Must provide both start and end date
+        if 'start_date' not in filters or 'end_date' not in filters:
+            raise ResponseException("If either start_date or end_date is provided in filters, both must be provided",
+                                    StatusCode.CLIENT_ERROR)
+        start_date = filters['start_date']
+        end_date = filters['end_date']
+        # Start and end dates must be in the format MM/DD/YYYY and be
+        if not (StringCleaner.is_date(start_date) and StringCleaner.is_date(end_date)):
+            raise ResponseException("Start or end date cannot be parsed into a date of format MM/DD/YYYY",
+                                    StatusCode.CLIENT_ERROR)
+        # Need to add a day to the end date to make it actually inclusive
+        end_date = (datetime.strptime(end_date, '%m/%d/%Y') + timedelta(days=1)).strftime('%m/%d/%Y')
+        query = query.filter(Submission.updated_at >= start_date, Submission.updated_at < end_date)
     return query
 
 

--- a/tests/integration/integration_test_helper.py
+++ b/tests/integration/integration_test_helper.py
@@ -5,7 +5,8 @@ from dataactcore.models.jobModels import Submission
 
 
 def insert_submission(sess, submission_user_id, cgac_code=None, start_date=None, end_date=None,
-                      is_quarter=False, number_of_errors=0, publish_status_id=1, is_fabs=False):
+                      is_quarter=False, number_of_errors=0, publish_status_id=1, is_fabs=False,
+                      updated_at=datetime.utcnow()):
     """Insert one submission into job tracker and get submission ID back."""
     publishable = True if number_of_errors == 0 else False
     end_date = datetime.strptime(end_date, '%m/%Y')
@@ -16,6 +17,7 @@ def insert_submission(sess, submission_user_id, cgac_code=None, start_date=None,
         '%Y/%m/%d'
     ).date()
     sub = Submission(created_at=datetime.utcnow(),
+                     updated_at=updated_at,
                      user_id=submission_user_id,
                      cgac_code=cgac_code,
                      reporting_start_date=datetime.strptime(start_date, '%m/%Y'),

--- a/tests/integration/list_submission_tests.py
+++ b/tests/integration/list_submission_tests.py
@@ -31,11 +31,13 @@ class ListSubmissionTests(BaseTestAPI):
             cls.non_admin_dabs_sub_id = insert_submission(sess, cls.other_user_id, cgac_code="SYS",
                                                           start_date="10/2015", end_date="12/2015", is_quarter=True,
                                                           is_fabs=False,
-                                                          publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
+                                                          publish_status_id=PUBLISH_STATUS_DICT['unpublished'],
+                                                          updated_at='01/01/2010')
 
             cls.admin_dabs_sub_id = insert_submission(sess, cls.admin_user_id, cgac_code="000", start_date="10/2015",
                                                       end_date="12/2015", is_quarter=True, is_fabs=False,
-                                                      publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
+                                                      publish_status_id=PUBLISH_STATUS_DICT['unpublished'],
+                                                      updated_at='01/01/2012')
 
             cls.certified_dabs_sub_id = insert_submission(sess, cls.admin_user_id, cgac_code="SYS",
                                                           start_date="10/2015", end_date="12/2015", is_quarter=True,
@@ -60,73 +62,72 @@ class ListSubmissionTests(BaseTestAPI):
         super(ListSubmissionTests, self).setUp()
         self.login_admin_user()
 
-    @staticmethod
-    def sub_ids(response):
+    def sub_ids(self, response):
         """ Helper function to parse out the submission ids from an HTTP response. """
-        assert response.status_code == 200
+        self.assertEqual(response.status_code, 200)
         result = response.json
-        assert 'submissions' in result
+        self.assertIn('submissions', result)
         return {sub['submission_id'] for sub in result['submissions']}
 
     def test_list_submissions_dabs_admin(self):
         """ Test with DABS submissions for an admin user. """
         response = self.app.post_json("/v1/list_submissions/", {"certified": "mixed"},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id,
-                                          self.certified_dabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id,
+                                                  self.certified_dabs_sub_id})
 
         response = self.app.post_json("/v1/list_submissions/", {"certified": "false"},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id})
 
         response = self.app.post_json("/v1/list_submissions/", {"certified": "true"},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.certified_dabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.certified_dabs_sub_id})
 
     def test_list_submissions_dabs_non_admin(self):
         """ Test with DABS submissions for a non admin user. """
         self.login_user()
         response = self.app.post_json("/v1/list_submissions/", {"certified": "mixed"},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id})
 
         response = self.app.post_json("/v1/list_submissions/", {"certified": "false"},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.non_admin_dabs_sub_id, self.admin_dabs_sub_id})
 
         response = self.app.post_json("/v1/list_submissions/", {"certified": "true"},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == set()
+        self.assertEqual(self.sub_ids(response), set())
 
     def test_list_submissions_fabs_admin(self):
         """ Test with FABS submissions for an admin user. """
         response = self.app.post_json("/v1/list_submissions/", {"certified": "mixed", "d2_submission": True},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.non_admin_fabs_sub_id, self.admin_fabs_sub_id,
-                                          self.published_fabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.non_admin_fabs_sub_id, self.admin_fabs_sub_id,
+                                                  self.published_fabs_sub_id})
 
         response = self.app.post_json("/v1/list_submissions/", {"certified": "false", "d2_submission": True},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.non_admin_fabs_sub_id, self.admin_fabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.non_admin_fabs_sub_id, self.admin_fabs_sub_id})
 
         response = self.app.post_json("/v1/list_submissions/", {"certified": "true", "d2_submission": True},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.published_fabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.published_fabs_sub_id})
 
     def test_list_submissions_fabs_non_admin(self):
         """ Test with FABS submissions for a non admin user. """
         self.login_user()
         response = self.app.post_json("/v1/list_submissions/", {"certified": "mixed", "d2_submission": True},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.admin_fabs_sub_id, self.published_fabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.admin_fabs_sub_id, self.published_fabs_sub_id})
 
         response = self.app.post_json("/v1/list_submissions/", {"certified": "false", "d2_submission": True},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.admin_fabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.admin_fabs_sub_id})
 
         response = self.app.post_json("/v1/list_submissions/", {"certified": "true", "d2_submission": True},
                                       headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.published_fabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.published_fabs_sub_id})
 
     def test_list_submissions_filter_id(self):
         """ Test listing submissions with a submission_id filter applied. """
@@ -138,15 +139,62 @@ class ListSubmissionTests(BaseTestAPI):
             }
         }
         response = self.app.post_json("/v1/list_submissions/", post_json, headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == {self.non_admin_dabs_sub_id}
+        self.assertEqual(self.sub_ids(response), {self.non_admin_dabs_sub_id})
 
         self.login_user()
         # Not returning a result if the user doesn't have access to the submission
+        post_json["filters"] = {
+            "submission_ids": [self.certified_dabs_sub_id]
+        }
+        response = self.app.post_json("/v1/list_submissions/", post_json, headers={"x-session-id": self.session_id})
+        self.assertEqual(self.sub_ids(response), set())
+
+    def test_list_submissions_filter_date(self):
+        """ Test listing submissions with a start and end date filter applied. """
+        # Listing only submissions that have been updated in the time frame
         post_json = {
             "certified": "mixed",
             "filters": {
-                "submission_ids": [self.certified_dabs_sub_id]
+                "start_date": '12/31/2009',
+                "end_date": '01/30/2010'
             }
         }
         response = self.app.post_json("/v1/list_submissions/", post_json, headers={"x-session-id": self.session_id})
-        assert self.sub_ids(response) == set()
+        self.assertEqual(self.sub_ids(response), {self.non_admin_dabs_sub_id})
+
+        # Time frame with no submission updates
+        post_json["filters"] = {
+            "start_date": '12/31/2010',
+            "end_date": '01/30/2011'
+        }
+        response = self.app.post_json("/v1/list_submissions/", post_json, headers={"x-session-id": self.session_id})
+        self.assertEqual(self.sub_ids(response), set())
+
+        # One day date range (shows inclusivity)
+        post_json["filters"] = {
+            "start_date": '01/01/2010',
+            "end_date": '01/01/2010'
+        }
+        response = self.app.post_json("/v1/list_submissions/", post_json, headers={"x-session-id": self.session_id})
+        self.assertEqual(self.sub_ids(response), {self.non_admin_dabs_sub_id})
+
+        # Breaks if one of the date filters isn't provided and the other is
+        post_json["filters"] = {
+            "start_date": '01/01/2010'
+        }
+        response = self.app.post_json("/v1/list_submissions/", post_json, headers={"x-session-id": self.session_id},
+                                      expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["message"], "If either start_date or end_date is provided in filters, "
+                                                   "both must be provided")
+
+        # Breaks if date isn't valid
+        post_json["filters"] = {
+            "start_date": '30/30/2010',
+            "end_date": '01/01/2010'
+        }
+        response = self.app.post_json("/v1/list_submissions/", post_json, headers={"x-session-id": self.session_id},
+                                      expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["message"], "Start or end date cannot be parsed into a date of format "
+                                                   "MM/DD/YYYY")


### PR DESCRIPTION
**High level description:**
Adding a last modified date filter to `list_submissions` endpoint

**Technical details:**
Adding ability to filter by a last modified date range. **looking for advice** would this be better as a `last_modified_range` array with 2 elements? Opinions much appreciated.

**Link to JIRA Ticket:**
[DEV-1359](https://federal-spending-transparency.atlassian.net/browse/DEV-1359)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed