### PR TITLE
Mod/dev 1355 submission dashboard agency filter

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1043,7 +1043,7 @@ This endpoint lists submissions for all agencies for which the current user is a
 ##### Errors
 Possible HTTP Status Codes:
 
-- 400: Invalid types in a filter, missing required parameter
+- 400: Invalid types in a filter, invalid values in a filter, missing required parameter
 - 401: Login required
 
 #### POST "/v1/list_certifications/"

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -936,7 +936,8 @@ This endpoint lists submissions for all agencies for which the current user is a
         "last_modified_range": {
             "start_date": "01/01/2018",
             "end_date": "01/10/2018"
-        }
+        },
+        "agency_codes": ["123", "4567"]
     }
 }
 ```
@@ -964,6 +965,7 @@ This endpoint lists submissions for all agencies for which the current user is a
     - `last_modified_range` - an object containing a start and end date for the last modified date range. Both must be provided if this filter is used.
         - `start_date` - a string indicating the start date for the last modified date range (inclusive) (MM/DD/YYYY)
         - `end_date` - a string indicating the end date for the last modified date range (inclusive) (MM/DD/YYYY)
+    - `agency_codes` - an array of strings containing CGAC and FREC codes
 
 ##### Response (JSON)
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1540,6 +1540,40 @@ def add_list_submission_filters(query, filters):
             query = query.filter(Submission.updated_at >= start_date, Submission.updated_at < end_date)
         elif mod_dates:
             raise ResponseException("last_modified_range filter must be null or an object", StatusCode.CLIENT_ERROR)
+    # Agency code filter
+    if 'agency_codes' in filters:
+        sess = GlobalDB.db().session
+        agency_list = filters['agency_codes']
+        if agency_list and isinstance(agency_list, list):
+            cgac_list = []
+            frec_list = []
+            # Split agencies into frec and cgac lists. If something isn't a length of 3 or 4, it's not valid and should
+            # instantly raise an exception
+            for agency in agency_list:
+                if isinstance(agency, str) and len(agency) == 3:
+                    cgac_list.append(agency)
+                elif isinstance(agency, str) and len(agency) == 4:
+                    frec_list.append(agency)
+                else:
+                    raise ResponseException("All codes in the agency_codes filter must be valid agency codes",
+                                            StatusCode.CLIENT_ERROR)
+            # If the number of CGACs or FRECs returned from a query using the codes doesn't match the length of
+            # each list (ignoring duplicates) then something included wasn't a valid agency
+            cgac_list = set(cgac_list)
+            frec_list = set(frec_list)
+            if sess.query(CGAC).filter(CGAC.cgac_code.in_(cgac_list)).count() != len(cgac_list) or \
+                    sess.query(FREC).filter(FREC.frec_code.in_(frec_list)).count() != len(frec_list):
+                raise ResponseException("All codes in the agency_codes filter must be valid agency codes",
+                                        StatusCode.CLIENT_ERROR)
+            # We only want these filters in here if there's at least one CGAC or FREC to filter on
+            agency_filters = []
+            if len(cgac_list) > 0:
+                agency_filters.append(CGAC.cgac_code.in_(cgac_list))
+            if len(frec_list) > 0:
+                agency_filters.append(FREC.frec_code.in_(frec_list))
+            query = query.filter(or_(*agency_filters))
+        elif agency_list:
+            raise ResponseException("agency_codes filter must be null or an array", StatusCode.CLIENT_ERROR)
     return query
 
 


### PR DESCRIPTION
**High level description:**
Add agency code filter

**Technical details:**
Allow users to filter `list_submissions` by agency code (CGAC or FREC). Fixing the warning about running an `in` on an empty list for `list_submissions`

**Link to JIRA Ticket:**
[DEV-1355](https://federal-spending-transparency.atlassian.net/browse/DEV-1355)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed