### PR TITLE
Hotfix: D generation job marked as "waiting"

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1019,6 +1019,16 @@ class FileHandler:
                job.file_type_id in [FILE_TYPE_DICT["award"], FILE_TYPE_DICT["award_procurement"]]:
                 # file generation handled on backend, mark as ready
                 job.job_status_id = JOB_STATUS_DICT['ready']
+                file_request = sess.query(FileRequest).filter_by(job.job_id).one_or_none()
+                
+                # uncache any related D file requests
+                if file_request:
+                    file_request.is_cached_file = False
+                    if file_request.parent_job_id:
+                        parent_file_request = sess.query(FileRequest).filter_by(job_id=file_request.parent_job_id).\
+                            one_or_none()
+                        if parent_file_request:
+                            parent_file_request.is_cached_file = False
             else:
                 # these are dependent on file D2 validation
                 job.job_status_id = JOB_STATUS_DICT['waiting']

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1020,7 +1020,7 @@ class FileHandler:
                 # file generation handled on backend, mark as ready
                 job.job_status_id = JOB_STATUS_DICT['ready']
                 file_request = sess.query(FileRequest).filter_by(job.job_id).one_or_none()
-                
+
                 # uncache any related D file requests
                 if file_request:
                     file_request.is_cached_file = False

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1015,7 +1015,7 @@ class FileHandler:
 
         # set all jobs to their initial status of either "waiting" or "ready"
         for job in jobs:
-            if job.job_type_id == JOB_TYPE_DICT["upload"] and \
+            if job.job_type_id == JOB_TYPE_DICT["file_upload"] and \
                job.file_type_id in [FILE_TYPE_DICT["award"], FILE_TYPE_DICT["award_procurement"]]:
                 # file generation handled on backend, mark as ready
                 job.job_status_id = JOB_STATUS_DICT['ready']

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1015,7 +1015,13 @@ class FileHandler:
 
         # set all jobs to their initial status of "waiting"
         for job in jobs:
-            job.job_status_id = JOB_STATUS_DICT['waiting']
+            if job.job_type_id == JOB_TYPE_DICT["upload"] and \
+               job.file_type_id in [FILE_TYPE_DICT["award"], FILE_TYPE_DICT["award_procurement"]]:
+                # file generation handled on backend, mark as ready
+                job.job_status_id = JOB_STATUS_DICT['ready']
+            else:
+                # these are dependent on file D2 validation
+                job.job_status_id = JOB_STATUS_DICT['waiting']
 
         # update upload jobs to "running" for files A, B, and C for DABS submissions or for the upload job in FABS
         upload_jobs = [job for job in jobs if job.job_type_id in [JOB_TYPE_DICT['file_upload']] and

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1013,7 +1013,7 @@ class FileHandler:
 
         jobs = sess.query(Job).filter(Job.submission_id == submission.submission_id).all()
 
-        # set all jobs to their initial status of "waiting"
+        # set all jobs to their initial status of either "waiting" or "ready"
         for job in jobs:
             if job.job_type_id == JOB_TYPE_DICT["upload"] and \
                job.file_type_id in [FILE_TYPE_DICT["award"], FILE_TYPE_DICT["award_procurement"]]:

--- a/dataactvalidator/validation_handlers/file_generation_handler.py
+++ b/dataactvalidator/validation_handlers/file_generation_handler.py
@@ -187,7 +187,7 @@ def generate_d_file(sess, job, agency_code, is_local=True, old_filename=None):
                 parent_file_request = parent_request
                 file_request.parent_job_id = parent_file_request.job_id
 
-            sess.commit()
+        sess.commit()
 
         if parent_file_request:
             # parent exists; copy parent data to this job

--- a/dataactvalidator/validation_handlers/file_generation_handler.py
+++ b/dataactvalidator/validation_handlers/file_generation_handler.py
@@ -13,7 +13,7 @@ from dataactcore.interfaces.db import GlobalDB
 from dataactcore.interfaces.function_bag import mark_job_status
 from dataactcore.models.domainModels import ExecutiveCompensation
 from dataactcore.models.jobModels import Job, FileRequest, FPDSUpdate
-from dataactcore.models.lookups import JOB_STATUS_DICT_ID, JOB_TYPE_DICT, FILE_TYPE_DICT_LETTER
+from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_STATUS_DICT_ID, JOB_TYPE_DICT, FILE_TYPE_DICT_LETTER
 from dataactcore.models.stagingModels import AwardFinancialAssistance, AwardProcurement
 from dataactcore.utils import fileD1, fileD2, fileE, fileF
 from dataactcore.utils.jsonResponse import JsonResponse
@@ -154,19 +154,40 @@ def generate_d_file(sess, job, agency_code, is_local=True, old_filename=None):
         parent_file_request = None
         if not exists:
             # attempt to retrieve a parent request
-            parent_query = sess.query(FileRequest).\
+            parent_file_requests = sess.query(FileRequest).\
                 filter(FileRequest.file_type == job.file_type.letter_name, FileRequest.start_date == job.start_date,
                        FileRequest.end_date == job.end_date, FileRequest.agency_code == agency_code,
-                       FileRequest.is_cached_file.is_(True))
+                       FileRequest.is_cached_file.is_(True)).all()
 
-            # filter D1 FileRequests by the date of the last FPDS pull
-            if job.file_type.letter_name == 'D1':
-                parent_query = parent_query.filter(FileRequest.request_date >= fpds_date)
+            # there will, very rarely, be more than one value in parent_file_requests
+            for parent_request in parent_file_requests:
+                valid_cached_job_statuses = [JOB_STATUS_DICT["running"], JOB_STATUS_DICT["finished"]]
+                parent_job = sess.query(Job).filter(job_id=parent_request.job_id).one_or_none()
 
-            # mark FileRequest with parent job_id
-            parent_file_request = parent_query.one_or_none()
-            file_request.parent_job_id = parent_file_request.job_id if parent_file_request else None
-        sess.commit()
+                # check that D1 FileRequests are newer than the last FPDS pull
+                invalid_d1 = parent_request.file_type == 'D1' and parent_request.request_date < fpds_date
+
+                # check FileRequest hasn't expired and Job status is valid
+                invalid_job = not parent_job or parent_job.job_status_id not in valid_cached_job_statuses
+
+                # check that this parent_request is newer than any previous valid requests
+                is_older_request = parent_file_request and parent_request.updated_at <= parent_file_request.updated_at
+
+                # if this parent_request is not a valid cached FileRequest
+                if invalid_d1 or invalid_job or is_older_request:
+                    # uncache FileRequest
+                    parent_request.is_cached_file = False
+                    continue
+
+                # uncache outdated parent FileRequests
+                if parent_file_request:
+                    parent_file_request.is_cached_file = False
+
+                # mark FileRequest with parent job_id
+                parent_file_request = parent_request
+                file_request.parent_job_id = parent_file_request.job_id
+
+            sess.commit()
 
         if parent_file_request:
             # parent exists; copy parent data to this job

--- a/dataactvalidator/validation_handlers/file_generation_handler.py
+++ b/dataactvalidator/validation_handlers/file_generation_handler.py
@@ -162,7 +162,7 @@ def generate_d_file(sess, job, agency_code, is_local=True, old_filename=None):
             # there will, very rarely, be more than one value in parent_file_requests
             for parent_request in parent_file_requests:
                 valid_cached_job_statuses = [JOB_STATUS_DICT["running"], JOB_STATUS_DICT["finished"]]
-                parent_job = sess.query(Job).filter(job_id=parent_request.job_id).one_or_none()
+                parent_job = sess.query(Job).filter_by(job_id=parent_request.job_id).one_or_none()
 
                 # check that D1 FileRequests are newer than the last FPDS pull
                 invalid_d1 = parent_request.file_type == 'D1' and parent_request.request_date < fpds_date

--- a/dataactvalidator/validation_handlers/file_generation_manager.py
+++ b/dataactvalidator/validation_handlers/file_generation_manager.py
@@ -68,6 +68,7 @@ class FileGenerationManager:
                 job.filename = "".join([CONFIG_BROKER['broker_files'], job.original_filename])
             else:
                 job.filename = "".join([str(job.submission_id), "/", job.original_filename])
+            sess.commit()
 
             # Generate the file and upload to S3
             if job.file_type.letter_name in ['D1', 'D2']:


### PR DESCRIPTION
**High level description:**
D file generations are stuck for users who had to revalidate their submissions.

**Technical details:**
`restart_validation()` updated all jobs to the file status of "waiting", which is not a status that D file generation should ever be in. This caused all D file generations affected by the revalidation to never generate. Also allow for uncaching of currently cached files based on job status and other factors.

**Link to JIRA Ticket:**
[DEV-1406](https://federal-spending-transparency.atlassian.net/browse/DEV-1406)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases N/A
- Frontend impact assessment completed N/A