### PR TITLE
Fix: DUNS Script Deactivations

### DIFF
--- a/dataactcore/utils/duns.py
+++ b/dataactcore/utils/duns.py
@@ -222,7 +222,8 @@ def parse_sam_file(file_path, sess, monthly=False, benchmarks=False, table=DUNS,
                     csv_data = csv_data.assign(deactivation_date=pd.Series([np.nan], name='deactivation_date')
                                                if monthly else csv_data["sam_extract_code"].apply(lambda_func))
                     # convert business types string to array
-                    bt_func = (lambda bt_raw: pd.Series([[str(code) for code in str(bt_raw).split('~')]]))
+                    bt_func = (lambda bt_raw: pd.Series([[str(code) for code in str(bt_raw).split('~')
+                                                          if isinstance(bt_raw, str)]]))
                     csv_data = csv_data.assign(business_types_codes=csv_data["business_types_raw"].apply(bt_func))
                     del csv_data["business_types_raw"]
                     # removing rows where DUNS number isn't even provided

--- a/dataactcore/utils/duns.py
+++ b/dataactcore/utils/duns.py
@@ -109,7 +109,8 @@ def update_duns(models, new_data, benchmarks=False, table=DUNS):
         if awardee_or_recipient_uniqu not in models:
             models[awardee_or_recipient_uniqu] = table()
         for field, value in row.items():
-            setattr(models[awardee_or_recipient_uniqu], field, value)
+            if value:
+                setattr(models[awardee_or_recipient_uniqu], field, value)
     if benchmarks:
         logger.info("Updating duns took {} seconds".format(time.time() - update_duns_start))
 


### PR DESCRIPTION
**High level description:**
Preventing deactivation records to overwrite populated DUNS records with blank values.

**Technical details:**
* Any blank values will not be updated in the DUNS table.
* Blank Business Categories (incoming as `NaN`) would simply be an empty list.

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed