### PR TITLE
DEV-1404: submission certification error

### DIFF
--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -588,4 +588,5 @@ def certify_dabs_submission(submission, file_manager):
         submission.certifying_user_id = current_user_id
         submission.publish_status_id = PUBLISH_STATUS_DICT['published']
         sess.commit()
-        print(submission.__dict__)
+
+    return response


### PR DESCRIPTION
**High level description:**
Stopping DABS submission certification from throwing an error

**Technical details:**
`certify_submission` route was not returning anything at the end, which resulted in an error being thrown and the submission seeming to fail to publish despite all prior steps succeeding. Returning something at the end now.

**Link to JIRA Ticket:**
[DEV-1404](https://federal-spending-transparency.atlassian.net/browse/DEV-1404)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- Unit & integration tests updated with relevant test cases N/A
- [x] Frontend impact assessment completed