### PR TITLE
removing instances of aws_role

### DIFF
--- a/dataactcore/config.py
+++ b/dataactcore/config.py
@@ -45,7 +45,7 @@ CONFIG_BROKER['path'] = dirname(dirname(abspath(__file__)))
 if CONFIG_BROKER['use_aws'] is True or CONFIG_BROKER['use_aws'] == "true":
     CONFIG_BROKER['local'] = False
     # AWS flag is on, so make sure all needed AWS info is present
-    required_aws_keys = ['aws_bucket', 'aws_role', 'aws_region', 'static_files_bucket', 'help_files_path']
+    required_aws_keys = ['aws_bucket', 'aws_region', 'static_files_bucket', 'help_files_path']
     for k in required_aws_keys:
         try:
             CONFIG_BROKER[k]
@@ -61,7 +61,6 @@ if CONFIG_BROKER['use_aws'] is True or CONFIG_BROKER['use_aws'] == "true":
 else:
     CONFIG_BROKER['local'] = True
     CONFIG_BROKER['aws_bucket'] = None
-    CONFIG_BROKER['aws_role'] = None
     CONFIG_BROKER['aws_region'] = None
 
     # if not using AWS and no error report path specified,

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -95,11 +95,6 @@ broker:
     # value if use_aws is true.
     certified_bucket: s3-bucket
 
-    # Name of the AWS role you're using to upload broker files. Ignored if
-    # use_aws is false. NOTE: the dummy value below MUST be changed to the
-    # correct value if use_aws is true.
-    aws_role: arn:aws-us-gov:iam::id:role/awsrole
-
     # S3 filenames for SF-133 file, only required if planning to load SF-133 table
     sf_133_folder: config
     sf_133_file: sf_133.csv

--- a/dataactcore/local_secrets_example.yml
+++ b/dataactcore/local_secrets_example.yml
@@ -37,11 +37,6 @@ broker:
     # S3 filenames for SF-133 file, only required if planning to load SF-133 table
     sf_133_bucket: s3-bucket
 
-    # Name of the AWS role you're using to upload broker files. Ignored if
-    # use_aws is false. NOTE: the dummy value below MUST be changed to the
-    # correct value if use_aws is true.
-    aws_role: arn:aws-us-gov:iam::id:role/awsrole
-
 db:
 
     # Set your username and password for the db instance

--- a/doc/AWS.md
+++ b/doc/AWS.md
@@ -29,33 +29,6 @@ Assumptions:
 
 ## Set Up AWS Permissions and Credentials
 
-### Create S3 Only Role
-
-When storing files on S3, it is a best practice to use AWS roles with the DATA Act broker. AWS roles provide a safe, automated key management mechanism to access and use AWS resources. At a minimum, this role should be granted Full S3 access permissions.
-
-The DATA Act broker supports the creation of Security Token Service (STS) tokens that limit a user's permissions to only file uploads. To set this up, create an IAM Role on the targeted AWS account. This role should have the following permission JSON, where the `s3-bucket-name` is the name of the S3 bucket created above.
-
-    {
-        "Version": "2016-01-29",
-        "Statement": [
-            {
-                "Sid": "Stmt123456",
-                "Effect": "Allow",
-                "Action": [
-                    "s3:PutObjectAcl"
-                ],
-                "Resource": [
-                    "arn:aws:s3:::s3-bucket-name",
-                    "arn:aws:s3:::s3-bucket-name/*",
-                ]
-            }
-        ]
-    }
-
-In addition to the permission JSON, create a Trust Relationship for the IAM role, allowing the broker to assume the S3 uploading role during token creation.
-
-The `REGION` should be replaced with region of the AWS account and the `ACCOUNT_ID` should be replaced with the AWS account ID.
-
 ### AWS Command Line Interface (CLI) Tools
 
 AWS credentials should be managed by the AWS CLI.


### PR DESCRIPTION
Since inbound API has been implemented, this environment variable is deprecated.