### PR TITLE
DEV-1422: B9 ignore FY17Q2/3

### DIFF
--- a/dataactvalidator/config/sqlrules/b9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/b9_award_financial.sql
@@ -21,8 +21,7 @@ FROM award_financial_b9_{0} AS af
         ON af.submission_id = sub.submission_id
 WHERE af.program_activity_code <> '0000'
     AND UPPER(af.program_activity_name) <> 'UNKNOWN/OTHER'
-    AND NOT ((sub.reporting_fiscal_year, sub.reporting_fiscal_period) IN (('2017', 6), ('2017', 9))
-        AND sub.publish_status_id <> 1)
+    AND (sub.reporting_fiscal_year, sub.reporting_fiscal_period) NOT IN (('2017', 6), ('2017', 9))
     AND NOT EXISTS (
         SELECT 1
         FROM program_activity AS pa

--- a/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
@@ -30,8 +30,7 @@ FROM object_class_program_activity_b9_{0} AS op
         ON op.submission_id = sub.submission_id
 WHERE op.program_activity_code <> '0000'
     AND UPPER(op.program_activity_name) <> 'UNKNOWN/OTHER'
-    AND NOT ((sub.reporting_fiscal_year, sub.reporting_fiscal_period) IN (('2017', 6), ('2017', 9))
-        AND sub.publish_status_id <> 1)
+    AND (sub.reporting_fiscal_year, sub.reporting_fiscal_period) NOT IN (('2017', 6), ('2017', 9))
     AND NOT EXISTS (
         SELECT 1
         FROM program_activity AS pa

--- a/tests/unit/dataactvalidator/test_b9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_b9_award_financial.py
@@ -45,7 +45,7 @@ def test_success_null(database):
     af = AwardFinancialFactory(row_number=1, agency_identifier='test', main_account_code='test',
                                program_activity_name=None, program_activity_code=None)
 
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q2', agency_id='test', allocation_transfer_id='test',
+    pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q4', agency_id='test', allocation_transfer_id='test',
                                 account_number='test')
 
     assert number_of_errors(_FILE, database, models=[af, pa]) == 0
@@ -90,7 +90,7 @@ def test_failure_fiscal_year_quarter(database):
 
 
 def test_success_ignore_recertification(database):
-    """ Testing invalid program_activity, ignored since recertification for FY2017Q2 or FY2017Q3 """
+    """ Testing invalid program_activity, ignored since FY2017Q2 or FY2017Q3 """
 
     populate_publish_status(database)
 
@@ -100,27 +100,17 @@ def test_success_ignore_recertification(database):
     pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q3', agency_id='test2', allocation_transfer_id='test2',
                                 account_number='test2', program_activity_name='test2', program_activity_code='test2')
 
+    # Test with published submission
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=9,
                                    publish_status_id=PUBLISH_STATUS_DICT['published'])
 
     assert number_of_errors(_FILE, database, models=[af, pa], submission=submission) == 0
 
-
-def test_failure_recertification(database):
-    """ Testing invalid program_activity, not ignored since not recertification for FY2017Q2 or FY2017Q3 """
-
-    populate_publish_status(database)
-
-    af = AwardFinancialFactory(row_number=1, submission_id=1, agency_identifier='test',
-                               main_account_code='test', program_activity_name='test', program_activity_code='test')
-
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY17Q3', agency_id='test2', allocation_transfer_id='test2',
-                                account_number='test2', program_activity_name='test2', program_activity_code='test2')
-
-    submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=9,
+    # Test with unpublished submission
+    submission = SubmissionFactory(submission_id=2, reporting_fiscal_year='2017', reporting_fiscal_period=9,
                                    publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
 
-    assert number_of_errors(_FILE, database, models=[af, pa], submission=submission) == 1
+    assert number_of_errors(_FILE, database, models=[af, pa], submission=submission) == 0
 
 
 def test_success_ignore_case(database):

--- a/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b9_object_class_program_activity.py
@@ -78,7 +78,7 @@ def test_failure_fiscal_year_quarter(database):
 
 
 def test_failure_success_ignore_recertification(database):
-    """ Testing invalid program activity, ingored since recertification FY2017 Q2 or Q3 """
+    """ Testing invalid program activity, ingored since FY2017 Q2 or Q3 """
 
     populate_publish_status(database)
 
@@ -91,28 +91,17 @@ def test_failure_success_ignore_recertification(database):
     pa = ProgramActivityFactory(fiscal_year_quarter='FY14Q1', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')
 
+    # Test with published submission
     submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=6,
                                    publish_status_id=PUBLISH_STATUS_DICT['updated'])
 
     assert number_of_errors(_FILE, database, models=[op, pa], submission=submission) == 0
 
-
-def test_failure_not_recertification(database):
-    """ Testing invalid program activity, ingored since not recertification FY2017 Q2 or Q3 """
-
-    populate_publish_status(database)
-
-    op = ObjectClassProgramActivityFactory(row_number=1, submission_id=1, agency_identifier='test2',
-                                           main_account_code='test2', program_activity_name='test2',
-                                           program_activity_code='test2')
-
-    pa = ProgramActivityFactory(fiscal_year_quarter='FY14Q1', agency_id='test', allocation_transfer_id='test',
-                                account_number='test', program_activity_name='test', program_activity_code='test')
-
-    submission = SubmissionFactory(submission_id=1, reporting_fiscal_year='2017', reporting_fiscal_period=6,
+    # Test with unpublished submission
+    submission = SubmissionFactory(submission_id=2, reporting_fiscal_year='2017', reporting_fiscal_period=6,
                                    publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
 
-    assert number_of_errors(_FILE, database, models=[op, pa], submission=submission) == 1
+    assert number_of_errors(_FILE, database, models=[op, pa], submission=submission) == 0
 
 
 def test_success_unknown_value(database):


### PR DESCRIPTION
**High level description:**
Updating rule B9 so it doesn't activate for FY17Q2/3

**Technical details:**
Removing limitation that only recertifications of FY17Q2/3 ignore B9. All submissions in that FY/Q will now ignore the rule

**Link to JIRA Ticket:**
[DEV-1422](https://federal-spending-transparency.atlassian.net/browse/DEV-1422)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- N/A Frontend impact assessment completed