### PR TITLE
Fix: FPDS loader count mismatch fix

### DIFF
--- a/dataactcore/scripts/pullFPDSData.py
+++ b/dataactcore/scripts/pullFPDSData.py
@@ -1381,7 +1381,7 @@ def get_data(contract_type, award_type, now, sess, sub_tier_list, county_by_name
             # ensure we loaded the number of records we expected to, otherwise we'll need to reload
             if entries_processed != total_expected_records:
                 raise Exception("Records retrieved != Total expected records\nExpected: {}\nRetrieved: {}"
-                                .format(total_expected_records, len(entries_processed)))
+                                .format(total_expected_records, entries_processed))
             else:
                 break
         else:


### PR DESCRIPTION
**High level description:**
When our count of records does not match the count we retrieved at the beginning of a pull, we exit gracefully. This feature has a slight bug in the log.

**Technical details:**
Because `entries_processed` is an integer, we should never attempt to get the length of it. Just use the variable itself.

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- Merged concurrently with Frontend N/A
- Unit & integration tests updated with relevant test cases N/A
- Frontend impact assessment completed N/A