### PR TITLE
DEV-1609: Update session timeout

### DIFF
--- a/dataactbroker/handlers/aws/session.py
+++ b/dataactbroker/handlers/aws/session.py
@@ -3,6 +3,8 @@ from uuid import uuid4
 from datetime import datetime, timedelta
 from flask.sessions import SessionInterface, SessionMixin
 from flask_login import _create_identifier
+
+from dataactcore.config import CONFIG_BROKER
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.models.userModel import SessionMap
 
@@ -114,7 +116,7 @@ class UserSessionInterface(SessionInterface):
                 # Make sure next route call does not get counted as session check
                 session["session_check"] = False
             else:
-                expiration = datetime.utcnow() + timedelta(seconds=SessionTable.TIME_OUT_LIMIT)
+                expiration = datetime.utcnow() + timedelta(seconds=CONFIG_BROKER['session_timeout'])
         if "_uid" not in session:
             LoginSession.reset_id(session)
         SessionTable.new_session(session["sid"], session, expiration)
@@ -125,13 +127,7 @@ class UserSessionInterface(SessionInterface):
 
 
 class SessionTable:
-    """ Provides helper functions for session management
-
-        Constants :
-            TIME_OUT_LIMIT: The limit (in seconds) for the session before it times out
-    """
-    TIME_OUT_LIMIT = 1800
-
+    """ Provides helper functions for session management """
     @staticmethod
     def clear_sessions():
         """ Removes old sessions that are expired """

--- a/dataactbroker/handlers/aws/session.py
+++ b/dataactbroker/handlers/aws/session.py
@@ -64,10 +64,6 @@ class UserSession(dict, SessionMixin):
 class UserSessionInterface(SessionInterface):
     """ Class That implements the SessionInterface and uses SessionTable to store data """
 
-    SESSION_CLEAR_COUNT_LIMIT = 10
-
-    CountLimit = 1
-
     def __init__(self):
         """ Initializes the UserSessionInterface """
         return
@@ -122,10 +118,7 @@ class UserSessionInterface(SessionInterface):
         if "_uid" not in session:
             LoginSession.reset_id(session)
         SessionTable.new_session(session["sid"], session, expiration)
-        UserSessionInterface.CountLimit += 1
-        if UserSessionInterface.CountLimit % UserSessionInterface.SESSION_CLEAR_COUNT_LIMIT == 0:
-            SessionTable.clear_sessions()
-            UserSessionInterface.CountLimit = 1
+        SessionTable.clear_sessions()
 
         # Return session ID as header x-session-id
         response.headers["x-session-id"] = session["sid"]
@@ -137,7 +130,7 @@ class SessionTable:
         Constants :
             TIME_OUT_LIMIT: The limit (in seconds) for the session before it times out
     """
-    TIME_OUT_LIMIT = 604800
+    TIME_OUT_LIMIT = 1800
 
     @staticmethod
     def clear_sessions():

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -120,6 +120,9 @@ broker:
     cas_service_url: https://cas.service.url
     parent_group: sample
 
+    # Session timeout, in seconds
+    session_timeout: 1800
+
 services:
     debug: true
 


### PR DESCRIPTION
**High level description:**
At some point several years ago, the Broker session timeout was changed to 7 days. We want it to be 30 minutes.

**Technical details:**
Replaced the session timeout with a configuration variable that we can change for environments without a deploy. Also removed the loop that could allow a user to click more even when they should've been logged off.

**Link to JIRA Ticket:**
[DEV-1609](https://federal-spending-transparency.atlassian.net/browse/DEV-1609)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Merged concurrently with Frontend N/A
- Unit & integration tests updated with relevant test cases N/A
- Frontend impact assessment completed N/A