### PR TITLE
DEV-1327: limit uploads to CSV and TXT files

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -158,6 +158,12 @@ class FileHandler:
             raise ResponseException("Must include at least one file for an existing submission",
                                     StatusCode.CLIENT_ERROR)
 
+        # Make sure all files are CSV or TXT files and not something else
+        for file_type in request_params.get('_files'):
+            file = request_params['_files'].get(file_type)
+            if not file.headers['Content-Type'] in ('text/csv', 'text/plain'):
+                raise ResponseException("All submitted files must be CSV or TXT format", StatusCode.CLIENT_ERROR)
+
     def submit(self, sess):
         """ Builds S3 URLs for a set of files and adds all related jobs to job tracker database
 
@@ -417,9 +423,13 @@ class FileHandler:
         if fabs is None:
             return JsonResponse.error(Exception('fabs field must be present and contain a file'),
                                       StatusCode.CLIENT_ERROR)
+
         sess = GlobalDB.db().session
         json_response, submission = None, None
         try:
+            # Make sure they only pass in csv or plain text files
+            if not fabs.headers['Content-Type'] in ('text/csv', 'text/plain'):
+                raise ValueError('FABS files must be CSV or TXT format')
             upload_files = []
             request_params = RequestDictionary.derive(self.request)
             logger.info({

--- a/tests/integration/detachedUploadTests.py
+++ b/tests/integration/detachedUploadTests.py
@@ -149,6 +149,7 @@ class DetachedUploadTests(BaseTestAPI):
         self.assertEqual(response.json['message'], "Existing submission must be a FABS submission")
 
     def test_upload_fabs_file_invalid_format(self):
+        """ Test file submissions for bad file formats (not CSV or TXT) """
         self.login_user(username=self.agency_user_email)
         response = self.app.post("/v1/upload_fabs_file/",
                                  {"existing_submission_id": str(self.test_agency_user_submission_id)},

--- a/tests/integration/detachedUploadTests.py
+++ b/tests/integration/detachedUploadTests.py
@@ -148,6 +148,16 @@ class DetachedUploadTests(BaseTestAPI):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], "Existing submission must be a FABS submission")
 
+    def test_upload_fabs_file_invalid_format(self):
+        self.login_user(username=self.agency_user_email)
+        response = self.app.post("/v1/upload_fabs_file/",
+                                 {"existing_submission_id": str(self.test_agency_user_submission_id)},
+                                 upload_files=[('fabs', 'invalid_file_format.md',
+                                                open('tests/integration/data/invalid_file_format.md', 'rb').read())],
+                                 headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'FABS files must be CSV or TXT format')
+
     @staticmethod
     def insert_submission(sess, submission_user_id, cgac_code=None, start_date=None, end_date=None,
                           is_quarter=False, publish_status_id=1, d2_submission=True):

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -24,6 +24,8 @@ APPROP_FILE_T = ('appropriations', 'appropriations.csv',
                  open('tests/integration/data/appropValid.csv', 'rb').read())
 PA_FILE_T = ('program_activity', 'program_activity.csv',
              open('tests/integration/data/programActivityValid.csv', 'rb').read())
+INVAL_FILE = ('program_activity', 'invalid_file_format.md',
+              open('tests/integration/data/invalid_file_format.md', 'rb').read())
 
 
 class FileTests(BaseTestAPI):
@@ -175,6 +177,15 @@ class FileTests(BaseTestAPI):
             self.assertEqual(submission.reporting_start_date.strftime("%m/%Y"), "04/2016")
             self.assertEqual(submission.reporting_end_date.strftime("%m/%Y"), "06/2016")
             self.assertEqual(submission.publish_status_id, PUBLISH_STATUS_DICT['updated'])
+
+    def test_bad_file_type(self):
+        """ Test file submissions for alphabet months """
+        update_json = {"existing_submission_id": self.status_check_submission_id}
+        update_response = self.app.post("/v1/upload_dabs_files/", update_json,
+                                        upload_files=[INVAL_FILE],
+                                        headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(update_response.status_code, 400)
+        self.assertEqual(update_response.json["message"], "All submitted files must be CSV or TXT format")
 
     def test_bad_quarter(self):
         """ Test file submissions for Q5 """

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -179,7 +179,7 @@ class FileTests(BaseTestAPI):
             self.assertEqual(submission.publish_status_id, PUBLISH_STATUS_DICT['updated'])
 
     def test_bad_file_type(self):
-        """ Test file submissions for alphabet months """
+        """ Test file submissions for bad file formats (not CSV or TXT) """
         update_json = {"existing_submission_id": self.status_check_submission_id}
         update_response = self.app.post("/v1/upload_dabs_files/", update_json,
                                         upload_files=[INVAL_FILE],


### PR DESCRIPTION
**High level description:**
Limits files to CSV and TXT for uploads

**Technical details:**
Headers for files are automatically set by file type so it can be transferred, use those headers to make sure only the file types we want go through.

**Link to JIRA Ticket:**
[DEV-1327](https://federal-spending-transparency.atlassian.net/browse/DEV-1327)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed (Discovered an existing frontend bug because of this, [DEV-1676](https://federal-spending-transparency.atlassian.net/browse/DEV-1676) created to handle it)