### PR TITLE
DEV-1639: Always return error message in JSONResponse

### DIFF
--- a/dataactcore/utils/jsonResponse.py
+++ b/dataactcore/utils/jsonResponse.py
@@ -45,8 +45,8 @@ class JsonResponse:
 
         trace = traceback.extract_tb(exception.__traceback__, 10)
         logger.exception('Route Error')
+        response_dict["message"] = str(exception)
         if JsonResponse.debugMode:
-            response_dict["message"] = str(exception)
             response_dict["errorType"] = str(type(exception))
             if isinstance(exception, ResponseException) and exception.wrappedException:
                 response_dict["wrappedType"] = str(type(exception.wrappedException))
@@ -54,5 +54,4 @@ class JsonResponse:
             response_dict["trace"] = [str(entry) for entry in trace]
             return JsonResponse.create(error_code, response_dict)
         else:
-            response_dict["message"] = "An error has occurred"
             return JsonResponse.create(error_code, response_dict)


### PR DESCRIPTION
**High level description:**
Always show the error message returned, even in production

**Technical details:**
Update the JSONResponse class to always return the error message provided, even in production, so it can be useful.

**Link to JIRA Ticket:**
[DEV-1639](https://federal-spending-transparency.atlassian.net/browse/DEV-1639)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Frontend impact assessment completed