### PR TITLE
DEV-1679: split unique key population by year

### DIFF
--- a/dataactcore/scripts/populate_historical_unique_award_keys.py
+++ b/dataactcore/scripts/populate_historical_unique_award_keys.py
@@ -1,4 +1,5 @@
 import logging
+import datetime
 
 from sqlalchemy.sql import func
 
@@ -6,8 +7,8 @@ from dataactcore.interfaces.db import GlobalDB
 from dataactcore.logging import configure_logging
 from dataactcore.models.stagingModels import (DetachedAwardProcurement, DetachedAwardFinancialAssistance,
                                               PublishedAwardFinancialAssistance)
-from dataactcore.models.jobModels import Submission # noqa
-from dataactcore.models.userModel import User # noqa
+from dataactcore.models.jobModels import Submission  # noqa
+from dataactcore.models.userModel import User  # noqa
 from dataactvalidator.health_check import create_app
 
 logger = logging.getLogger(__name__)
@@ -17,51 +18,138 @@ if __name__ == '__main__':
         configure_logging()
         sess = GlobalDB.db().session
 
+        # Make an array of years starting at 2006 and ending at this year (so it can be run at any time)
+        this_year = datetime.datetime.now().year
+        years = []
+        for i in range(2004, this_year+1):
+            years.append(str(i))
+
+        # FPDS awards
         logger.info('Populating unique_award_key for FPDS award records...')
         dap = DetachedAwardProcurement
-        sess.query(dap).filter(dap.pulled_from == 'award').\
+        logger.info('Starting records before {}...'.format(years[0]))
+        sess.query(dap).filter(dap.pulled_from == 'award',
+                               func.cast_as_date(dap.action_date) < '{}-01-01'.format(years[0])).\
             update({dap.unique_award_key: func.concat(func.coalesce(dap.piid, '-none-'), '_',
                                                       func.coalesce(dap.agency_id, '-none-'), '_',
                                                       func.coalesce(dap.parent_award_id, '-none-'), '_',
                                                       func.coalesce(dap.referenced_idv_agency_iden, '-none-'))},
                    synchronize_session=False)
+        sess.commit()
+        for year in years:
+            logger.info('Starting records in {}...'.format(year))
+            sess.query(dap).filter(dap.pulled_from == 'award',
+                                   func.cast_as_date(dap.action_date) >= '{}-01-01'.format(year),
+                                   func.cast_as_date(dap.action_date) <= '{}-12-31'.format(year)).\
+                update({dap.unique_award_key: func.concat(func.coalesce(dap.piid, '-none-'), '_',
+                                                          func.coalesce(dap.agency_id, '-none-'), '_',
+                                                          func.coalesce(dap.parent_award_id, '-none-'), '_',
+                                                          func.coalesce(dap.referenced_idv_agency_iden, '-none-'))},
+                       synchronize_session=False)
+            sess.commit()
+
         logger.info('FPDS award records populated.\n')
 
+        # FPDS IDV
         logger.info('Populating unique_award_key for FPDS IDV records...')
-        sess.query(dap).filter(dap.pulled_from == 'IDV').\
+        logger.info('Starting records before {}...'.format(years[0]))
+        sess.query(dap).filter(dap.pulled_from == 'IDV',
+                               func.cast_as_date(dap.action_date) < '{}-01-01'.format(years[0])).\
             update({dap.unique_award_key: func.concat('IDV_', func.coalesce(dap.piid, '-none-'), '_',
                                                       func.coalesce(dap.agency_id, '-none-'))},
                    synchronize_session=False)
+        sess.commit()
+        for year in years:
+            logger.info('Starting records in {}...'.format(year))
+            sess.query(dap).filter(dap.pulled_from == 'IDV',
+                                   func.cast_as_date(dap.action_date) >= '{}-01-01'.format(year),
+                                   func.cast_as_date(dap.action_date) <= '{}-12-31'.format(year)). \
+                update({dap.unique_award_key: func.concat('IDV_', func.coalesce(dap.piid, '-none-'), '_',
+                                                          func.coalesce(dap.agency_id, '-none-'))},
+                       synchronize_session=False)
+            sess.commit()
         logger.info('FPDS IDV records populated.\n')
 
+        # unpublished FABS record type 1
         logger.info('Populating unique_award_key for unpublished FABS aggregate records...')
         dafa = DetachedAwardFinancialAssistance
-        sess.query(dafa).filter(dafa.record_type == '1').\
+        logger.info('Starting records before {}...'.format(years[0]))
+        sess.query(dafa).filter(dafa.record_type == '1',
+                                func.cast_as_date(dafa.action_date) < '{}-01-01'.format(years[0])).\
             update({dafa.unique_award_key: func.concat('AGG_', func.coalesce(dafa.uri, '-none-'), '_',
                                                        func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-'))},
                    synchronize_session=False)
+        sess.commit()
+        for year in years:
+            logger.info('Starting records in {}...'.format(year))
+            sess.query(dafa).filter(dafa.record_type == '1',
+                                    func.cast_as_date(dafa.action_date) >= '{}-01-01'.format(year),
+                                    func.cast_as_date(dafa.action_date) <= '{}-12-31'.format(year)). \
+                update({dafa.unique_award_key: func.concat('AGG_', func.coalesce(dafa.uri, '-none-'), '_',
+                                                           func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-'))},
+                       synchronize_session=False)
+            sess.commit()
         logger.info('Unpublished FABS aggregate records populated.\n')
 
+        # unpublished FABS record type not 1
         logger.info('Populating unique_award_key for unpublished FABS non-aggregated records...')
-        sess.query(dafa).filter(dafa.record_type != '1').\
+        logger.info('Starting records before {}...'.format(years[0]))
+        sess.query(dafa).filter(dafa.record_type != '1',
+                                func.cast_as_date(dafa.action_date) < '{}-01-01'.format(years[0])).\
             update({dafa.unique_award_key: func.concat('NON_', func.coalesce(dafa.fain, '-none-'), '_',
                                                        func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-'))},
                    synchronize_session=False)
+        sess.commit()
+        for year in years:
+            logger.info('Starting records in {}...'.format(year))
+            sess.query(dafa).filter(dafa.record_type != '1',
+                                    func.cast_as_date(dafa.action_date) >= '{}-01-01'.format(year),
+                                    func.cast_as_date(dafa.action_date) <= '{}-12-31'.format(year)). \
+                update({dafa.unique_award_key: func.concat('NON_', func.coalesce(dafa.fain, '-none-'), '_',
+                                                           func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-'))},
+                       synchronize_session=False)
+            sess.commit()
         logger.info('Unpublished FABS non-aggregated records populated.\n')
 
+        # published FABS record type 1
         logger.info('Populating unique_award_key for published FABS aggregate records...')
         pafa = PublishedAwardFinancialAssistance
-        sess.query(pafa).filter(pafa.record_type == '1').\
+        logger.info('Starting records before {}...'.format(years[0]))
+        sess.query(pafa).filter(pafa.record_type == '1',
+                                func.cast_as_date(pafa.action_date) < '{}-01-01'.format(years[0])).\
             update({pafa.unique_award_key: func.concat('AGG_', func.coalesce(pafa.uri, '-none-'), '_',
                                                        func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-'))},
                    synchronize_session=False)
+        sess.commit()
+        for year in years:
+            logger.info('Starting records in {}...'.format(year))
+            sess.query(pafa).filter(pafa.record_type == '1',
+                                    func.cast_as_date(pafa.action_date) >= '{}-01-01'.format(year),
+                                    func.cast_as_date(pafa.action_date) <= '{}-12-31'.format(year)). \
+                update({pafa.unique_award_key: func.concat('AGG_', func.coalesce(pafa.uri, '-none-'), '_',
+                                                           func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-'))},
+                       synchronize_session=False)
+            sess.commit()
         logger.info('Published FABS aggregate records populated.\n')
 
+        # published FABS record type not 1
         logger.info('Populating unique_award_key for published FABS non-aggregated records...')
-        sess.query(pafa).filter(pafa.record_type != '1').\
+        logger.info('Starting records before {}...'.format(years[0]))
+        sess.query(pafa).filter(pafa.record_type != '1',
+                                func.cast_as_date(pafa.action_date) < '{}-01-01'.format(years[0])).\
             update({pafa.unique_award_key: func.concat('NON_', func.coalesce(pafa.fain, '-none-'), '_',
                                                        func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-'))},
                    synchronize_session=False)
+        sess.commit()
+        for year in years:
+            logger.info('Starting records in {}...'.format(year))
+            sess.query(pafa).filter(pafa.record_type != '1',
+                                    func.cast_as_date(pafa.action_date) >= '{}-01-01'.format(year),
+                                    func.cast_as_date(pafa.action_date) <= '{}-12-31'.format(year)). \
+                update({pafa.unique_award_key: func.concat('NON_', func.coalesce(pafa.fain, '-none-'), '_',
+                                                           func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-'))},
+                       synchronize_session=False)
+            sess.commit()
         logger.info('Published FABS non-aggregated records populated.\n')
 
         sess.close()

--- a/dataactcore/scripts/populate_historical_unique_award_keys.py
+++ b/dataactcore/scripts/populate_historical_unique_award_keys.py
@@ -13,6 +13,41 @@ from dataactvalidator.health_check import create_app
 
 logger = logging.getLogger(__name__)
 
+
+def update_keys(model, model_type, filter_content, update_years, concat_list):
+    """ Run through the loop to update award keys for the given table.
+
+        Args:
+            model: the table model to be used
+            model_type: whether the table being updated is FABS or FPDS
+            filter_content: what we want in the base filter
+            update_years: an array of years to work with
+            concat_list: the concatenation to update with
+    """
+    base_query = sess.query(model)
+    if model_type == 'FPDS':
+        base_query = base_query.filter(model.pulled_from == filter_content)
+    else:
+        if filter_content == 'aggregate':
+            base_query = base_query.filter(model.record_type == '1')
+        else:
+            base_query = base_query.filter(model.record_type != '1')
+
+    logger.info('Populating unique_award_key for {} {} records...'.format(model_type, filter_content))
+    logger.info('Starting records before {}...'.format(update_years[0]))
+    base_query.filter(func.cast_as_date(model.action_date) < '{}-01-01'.format(years[0])).\
+        update({model.unique_award_key: concat_list}, synchronize_session=False)
+    sess.commit()
+
+    for year in update_years:
+        logger.info('Starting records in {}...'.format(year))
+        base_query.filter(func.cast_as_date(model.action_date) >= '{}-01-01'.format(year),
+                          func.cast_as_date(model.action_date) <= '{}-12-31'.format(year)). \
+            update({model.unique_award_key: concat_list}, synchronize_session=False)
+        sess.commit()
+
+    logger.info('{} {} records populated.\n'.format(model_type, filter_content))
+
 if __name__ == '__main__':
     with create_app().app_context():
         configure_logging()
@@ -25,131 +60,36 @@ if __name__ == '__main__':
             years.append(str(i))
 
         # FPDS awards
-        logger.info('Populating unique_award_key for FPDS award records...')
         dap = DetachedAwardProcurement
-        logger.info('Starting records before {}...'.format(years[0]))
-        sess.query(dap).filter(dap.pulled_from == 'award',
-                               func.cast_as_date(dap.action_date) < '{}-01-01'.format(years[0])).\
-            update({dap.unique_award_key: func.concat(func.coalesce(dap.piid, '-none-'), '_',
-                                                      func.coalesce(dap.agency_id, '-none-'), '_',
-                                                      func.coalesce(dap.parent_award_id, '-none-'), '_',
-                                                      func.coalesce(dap.referenced_idv_agency_iden, '-none-'))},
-                   synchronize_session=False)
-        sess.commit()
-        for year in years:
-            logger.info('Starting records in {}...'.format(year))
-            sess.query(dap).filter(dap.pulled_from == 'award',
-                                   func.cast_as_date(dap.action_date) >= '{}-01-01'.format(year),
-                                   func.cast_as_date(dap.action_date) <= '{}-12-31'.format(year)).\
-                update({dap.unique_award_key: func.concat(func.coalesce(dap.piid, '-none-'), '_',
-                                                          func.coalesce(dap.agency_id, '-none-'), '_',
-                                                          func.coalesce(dap.parent_award_id, '-none-'), '_',
-                                                          func.coalesce(dap.referenced_idv_agency_iden, '-none-'))},
-                       synchronize_session=False)
-            sess.commit()
-
-        logger.info('FPDS award records populated.\n')
+        update_keys(dap, 'FPDS', 'award', years, func.concat(func.coalesce(dap.piid, '-none-'), '_',
+                                                             func.coalesce(dap.agency_id, '-none-'), '_',
+                                                             func.coalesce(dap.parent_award_id, '-none-'), '_',
+                                                             func.coalesce(dap.referenced_idv_agency_iden, '-none-')))
 
         # FPDS IDV
-        logger.info('Populating unique_award_key for FPDS IDV records...')
-        logger.info('Starting records before {}...'.format(years[0]))
-        sess.query(dap).filter(dap.pulled_from == 'IDV',
-                               func.cast_as_date(dap.action_date) < '{}-01-01'.format(years[0])).\
-            update({dap.unique_award_key: func.concat('IDV_', func.coalesce(dap.piid, '-none-'), '_',
-                                                      func.coalesce(dap.agency_id, '-none-'))},
-                   synchronize_session=False)
-        sess.commit()
-        for year in years:
-            logger.info('Starting records in {}...'.format(year))
-            sess.query(dap).filter(dap.pulled_from == 'IDV',
-                                   func.cast_as_date(dap.action_date) >= '{}-01-01'.format(year),
-                                   func.cast_as_date(dap.action_date) <= '{}-12-31'.format(year)). \
-                update({dap.unique_award_key: func.concat('IDV_', func.coalesce(dap.piid, '-none-'), '_',
-                                                          func.coalesce(dap.agency_id, '-none-'))},
-                       synchronize_session=False)
-            sess.commit()
-        logger.info('FPDS IDV records populated.\n')
+        update_keys(dap, 'FPDS', 'IDV', years, func.concat('IDV_', func.coalesce(dap.piid, '-none-'), '_',
+                                                           func.coalesce(dap.agency_id, '-none-')))
 
         # unpublished FABS record type 1
-        logger.info('Populating unique_award_key for unpublished FABS aggregate records...')
         dafa = DetachedAwardFinancialAssistance
-        logger.info('Starting records before {}...'.format(years[0]))
-        sess.query(dafa).filter(dafa.record_type == '1',
-                                func.cast_as_date(dafa.action_date) < '{}-01-01'.format(years[0])).\
-            update({dafa.unique_award_key: func.concat('AGG_', func.coalesce(dafa.uri, '-none-'), '_',
-                                                       func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-'))},
-                   synchronize_session=False)
-        sess.commit()
-        for year in years:
-            logger.info('Starting records in {}...'.format(year))
-            sess.query(dafa).filter(dafa.record_type == '1',
-                                    func.cast_as_date(dafa.action_date) >= '{}-01-01'.format(year),
-                                    func.cast_as_date(dafa.action_date) <= '{}-12-31'.format(year)). \
-                update({dafa.unique_award_key: func.concat('AGG_', func.coalesce(dafa.uri, '-none-'), '_',
-                                                           func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-'))},
-                       synchronize_session=False)
-            sess.commit()
-        logger.info('Unpublished FABS aggregate records populated.\n')
+        update_keys(dafa, 'unpublished FABS', 'aggregate', years,
+                    func.concat('AGG_', func.coalesce(dafa.uri, '-none-'), '_',
+                                func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-')))
 
         # unpublished FABS record type not 1
-        logger.info('Populating unique_award_key for unpublished FABS non-aggregated records...')
-        logger.info('Starting records before {}...'.format(years[0]))
-        sess.query(dafa).filter(dafa.record_type != '1',
-                                func.cast_as_date(dafa.action_date) < '{}-01-01'.format(years[0])).\
-            update({dafa.unique_award_key: func.concat('NON_', func.coalesce(dafa.fain, '-none-'), '_',
-                                                       func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-'))},
-                   synchronize_session=False)
-        sess.commit()
-        for year in years:
-            logger.info('Starting records in {}...'.format(year))
-            sess.query(dafa).filter(dafa.record_type != '1',
-                                    func.cast_as_date(dafa.action_date) >= '{}-01-01'.format(year),
-                                    func.cast_as_date(dafa.action_date) <= '{}-12-31'.format(year)). \
-                update({dafa.unique_award_key: func.concat('NON_', func.coalesce(dafa.fain, '-none-'), '_',
-                                                           func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-'))},
-                       synchronize_session=False)
-            sess.commit()
-        logger.info('Unpublished FABS non-aggregated records populated.\n')
+        update_keys(dafa, 'unpublished FABS', 'non-aggregated', years,
+                    func.concat('NON_', func.coalesce(dafa.fain, '-none-'), '_',
+                                func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-')))
 
         # published FABS record type 1
-        logger.info('Populating unique_award_key for published FABS aggregate records...')
         pafa = PublishedAwardFinancialAssistance
-        logger.info('Starting records before {}...'.format(years[0]))
-        sess.query(pafa).filter(pafa.record_type == '1',
-                                func.cast_as_date(pafa.action_date) < '{}-01-01'.format(years[0])).\
-            update({pafa.unique_award_key: func.concat('AGG_', func.coalesce(pafa.uri, '-none-'), '_',
-                                                       func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-'))},
-                   synchronize_session=False)
-        sess.commit()
-        for year in years:
-            logger.info('Starting records in {}...'.format(year))
-            sess.query(pafa).filter(pafa.record_type == '1',
-                                    func.cast_as_date(pafa.action_date) >= '{}-01-01'.format(year),
-                                    func.cast_as_date(pafa.action_date) <= '{}-12-31'.format(year)). \
-                update({pafa.unique_award_key: func.concat('AGG_', func.coalesce(pafa.uri, '-none-'), '_',
-                                                           func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-'))},
-                       synchronize_session=False)
-            sess.commit()
-        logger.info('Published FABS aggregate records populated.\n')
+        update_keys(pafa, 'published FABS', 'aggregate', years,
+                    func.concat('AGG_', func.coalesce(pafa.uri, '-none-'), '_',
+                                func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-')))
 
         # published FABS record type not 1
-        logger.info('Populating unique_award_key for published FABS non-aggregated records...')
-        logger.info('Starting records before {}...'.format(years[0]))
-        sess.query(pafa).filter(pafa.record_type != '1',
-                                func.cast_as_date(pafa.action_date) < '{}-01-01'.format(years[0])).\
-            update({pafa.unique_award_key: func.concat('NON_', func.coalesce(pafa.fain, '-none-'), '_',
-                                                       func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-'))},
-                   synchronize_session=False)
-        sess.commit()
-        for year in years:
-            logger.info('Starting records in {}...'.format(year))
-            sess.query(pafa).filter(pafa.record_type != '1',
-                                    func.cast_as_date(pafa.action_date) >= '{}-01-01'.format(year),
-                                    func.cast_as_date(pafa.action_date) <= '{}-12-31'.format(year)). \
-                update({pafa.unique_award_key: func.concat('NON_', func.coalesce(pafa.fain, '-none-'), '_',
-                                                           func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-'))},
-                       synchronize_session=False)
-            sess.commit()
-        logger.info('Published FABS non-aggregated records populated.\n')
+        update_keys(pafa, 'published FABS', 'non-aggregated', years,
+                    func.concat('NON_', func.coalesce(pafa.fain, '-none-'), '_',
+                                func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-')))
 
         sess.close()

--- a/dataactcore/scripts/populate_historical_unique_award_keys.py
+++ b/dataactcore/scripts/populate_historical_unique_award_keys.py
@@ -46,6 +46,11 @@ def update_keys(model, model_type, filter_content, update_years, concat_list):
             update({model.unique_award_key: concat_list}, synchronize_session=False)
         sess.commit()
 
+    logger.info('Starting records after {}...'.format(years[-1]))
+    base_query.filter(func.cast_as_date(model.action_date) > '{}-12-31'.format(years[-1])). \
+        update({model.unique_award_key: concat_list}, synchronize_session=False)
+    sess.commit()
+
     logger.info('{} {} records populated.\n'.format(model_type, filter_content))
 
 if __name__ == '__main__':

--- a/dataactvalidator/validation_handlers/validator.py
+++ b/dataactvalidator/validation_handlers/validator.py
@@ -24,7 +24,7 @@ class Validator(object):
     tableAbbreviations = {"appropriations": "approp", "award_financial_assistance": "afa", "award_financial": "af",
                           "object_class_program_activity": "op", "appropriation": "approp"}
     # Set of metadata fields that should not be directly validated
-    META_FIELDS = ["row_number", "afa_generated_unique"]
+    META_FIELDS = ["row_number", "afa_generated_unique", "unique_award_key"]
 
     @classmethod
     def validate(cls, record, csv_schema, fabs_record=False, required_labels=None, type_labels=None):


### PR DESCRIPTION
**High level description:**
Fixing the script and an error the updates for it created and splitting it up so it does smaller sections of the data at a time.

**Technical details:**
Actually committing in the script and updating the validator so it doesn't throw a key error with the new key. Splitting the updates in the script into one year at a time so there is less data being processed at once and the DB doesn't stall

**Link to JIRA Ticket:**
[DEV-1679](https://federal-spending-transparency.atlassian.net/browse/DEV-1679)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed