### PR TITLE
DEV-1679: Fix unique_award_key script for DetachedAwardFinancialAssistance records

### DIFF
--- a/dataactcore/scripts/populate_historical_unique_award_keys.py
+++ b/dataactcore/scripts/populate_historical_unique_award_keys.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import datetime
 
@@ -34,22 +35,27 @@ def update_keys(model, model_type, filter_content, update_years, concat_list):
             base_query = base_query.filter(model.record_type != '1')
 
     logger.info('Populating unique_award_key for {} {} records...'.format(model_type, filter_content))
-    logger.info('Starting records before {}...'.format(update_years[0]))
-    base_query.filter(func.cast_as_date(model.action_date) < '{}-01-01'.format(years[0])).\
-        update({model.unique_award_key: concat_list}, synchronize_session=False)
-    sess.commit()
-
-    for year in update_years:
-        logger.info('Starting records in {}...'.format(year))
-        base_query.filter(func.cast_as_date(model.action_date) >= '{}-01-01'.format(year),
-                          func.cast_as_date(model.action_date) <= '{}-12-31'.format(year)). \
+    if update_years:
+        logger.info('Starting records before {}...'.format(update_years[0]))
+        base_query.filter(func.cast_as_date(model.action_date) < '{}-01-01'.format(years[0])).\
             update({model.unique_award_key: concat_list}, synchronize_session=False)
         sess.commit()
 
-    logger.info('Starting records after {}...'.format(years[-1]))
-    base_query.filter(func.cast_as_date(model.action_date) > '{}-12-31'.format(years[-1])). \
-        update({model.unique_award_key: concat_list}, synchronize_session=False)
-    sess.commit()
+        for year in update_years:
+            logger.info('Starting records in {}...'.format(year))
+            base_query.filter(func.cast_as_date(model.action_date) >= '{}-01-01'.format(year),
+                              func.cast_as_date(model.action_date) <= '{}-12-31'.format(year)). \
+                update({model.unique_award_key: concat_list}, synchronize_session=False)
+            sess.commit()
+
+        logger.info('Starting records after {}...'.format(years[-1]))
+        base_query.filter(func.cast_as_date(model.action_date) > '{}-12-31'.format(years[-1])). \
+            update({model.unique_award_key: concat_list}, synchronize_session=False)
+        sess.commit()
+    else:
+        # DetachedAwardFinancialAssistance table may have values that cannot use cast_as_date. The table is smaller
+        # than the rest, so we just update the whole thing at once.
+        base_query.update({model.unique_award_key: concat_list}, synchronize_session=False)
 
     logger.info('{} {} records populated.\n'.format(model_type, filter_content))
 
@@ -57,6 +63,24 @@ if __name__ == '__main__':
     with create_app().app_context():
         configure_logging()
         sess = GlobalDB.db().session
+        parser = argparse.ArgumentParser(description='Update the unique_award_key for the specified tables.')
+        parser.add_argument('-m', '--models', help='Specify which models to update', nargs='+', type=str)
+        parser.add_argument('-t', '--types', help='Specify which types of records to update', nargs='+', type=str)
+        args = parser.parse_args()
+
+        models = ['FPDS', 'unpublishedFABS', 'publishedFABS']
+        if args.models:
+            for model in args.models:
+                if model not in models:
+                    raise Exception('Models must be one of the following: {}'.format(', '.join(models)))
+            models = args.models
+
+        types = ['award', 'IDV', 'AGG', 'NON']
+        if args.types:
+            for model_type in args.types:
+                if model_type not in types:
+                    raise Exception('Types must be one of the following: {}'.format(', '.join(types)))
+            types = args.types
 
         # Make an array of years starting at 2006 and ending at this year (so it can be run at any time)
         this_year = datetime.datetime.now().year
@@ -64,37 +88,51 @@ if __name__ == '__main__':
         for i in range(2004, this_year+1):
             years.append(str(i))
 
-        # FPDS awards
-        dap = DetachedAwardProcurement
-        update_keys(dap, 'FPDS', 'award', years, func.concat(func.coalesce(dap.piid, '-none-'), '_',
-                                                             func.coalesce(dap.agency_id, '-none-'), '_',
-                                                             func.coalesce(dap.parent_award_id, '-none-'), '_',
-                                                             func.coalesce(dap.referenced_idv_agency_iden, '-none-')))
+        # FPDS
+        if 'FPDS' in models:
+            dap = DetachedAwardProcurement
 
-        # FPDS IDV
-        update_keys(dap, 'FPDS', 'IDV', years, func.concat('IDV_', func.coalesce(dap.piid, '-none-'), '_',
-                                                           func.coalesce(dap.agency_id, '-none-')))
+            # awards
+            if 'award' in types:
+                update_keys(dap, 'FPDS', 'award', years, func.concat(
+                    func.coalesce(dap.piid, '-none-'), '_',
+                    func.coalesce(dap.agency_id, '-none-'), '_',
+                    func.coalesce(dap.parent_award_id, '-none-'), '_',
+                    func.coalesce(dap.referenced_idv_agency_iden, '-none-')))
+            # IDV
+            if 'IDV' in types:
+                update_keys(dap, 'FPDS', 'IDV', years, func.concat('IDV_', func.coalesce(dap.piid, '-none-'), '_',
+                                                                   func.coalesce(dap.agency_id, '-none-')))
 
-        # unpublished FABS record type 1
-        dafa = DetachedAwardFinancialAssistance
-        update_keys(dafa, 'unpublished FABS', 'aggregate', years,
-                    func.concat('AGG_', func.coalesce(dafa.uri, '-none-'), '_',
-                                func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-')))
+        # unpublished FABS
+        if 'unpublishedFABS' in models:
+            dafa = DetachedAwardFinancialAssistance
 
-        # unpublished FABS record type not 1
-        update_keys(dafa, 'unpublished FABS', 'non-aggregated', years,
-                    func.concat('NON_', func.coalesce(dafa.fain, '-none-'), '_',
-                                func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-')))
+            # record type 1
+            if 'AGG' in types:
+                update_keys(dafa, 'unpublished FABS', 'aggregate', None,
+                            func.concat('AGG_', func.coalesce(dafa.uri, '-none-'), '_',
+                                        func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-')))
+            # record type not 1
+            if 'NON' in types:
+                update_keys(dafa, 'unpublished FABS', 'non-aggregated', None,
+                            func.concat('NON_', func.coalesce(dafa.fain, '-none-'), '_',
+                                        func.coalesce(dafa.awarding_sub_tier_agency_c, '-none-')))
 
-        # published FABS record type 1
-        pafa = PublishedAwardFinancialAssistance
-        update_keys(pafa, 'published FABS', 'aggregate', years,
-                    func.concat('AGG_', func.coalesce(pafa.uri, '-none-'), '_',
-                                func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-')))
+        # published FABS
+        if 'publishedFABS' in models:
+            pafa = PublishedAwardFinancialAssistance
 
-        # published FABS record type not 1
-        update_keys(pafa, 'published FABS', 'non-aggregated', years,
-                    func.concat('NON_', func.coalesce(pafa.fain, '-none-'), '_',
-                                func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-')))
+            # record type 1
+            if 'AGG' in types:
+                update_keys(pafa, 'published FABS', 'aggregate', years,
+                            func.concat('AGG_', func.coalesce(pafa.uri, '-none-'), '_',
+                                        func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-')))
+
+            # record type not 1
+            if 'NON' in types:
+                update_keys(pafa, 'published', 'non-aggregated', years,
+                            func.concat('NON_', func.coalesce(pafa.fain, '-none-'), '_',
+                                        func.coalesce(pafa.awarding_sub_tier_agency_c, '-none-')))
 
         sess.close()


### PR DESCRIPTION
**High level description:**
The DetachedAwardFinancialAssistance table has bad `action_date`s, so we cannot use `cast_as_date` function. There's no other useful way to separate the table, and it's smaller than the others, so we will just update the whole table at once.

**Technical details:**
Added parameters to the script to allow for starting at different points (to skip the FPDS records that have already run in Dev). Don't separate the DetachedAwardFinancialAssistance table by `action_date`.

**Link to JIRA Ticket:**
[DEV-1679](https://federal-spending-transparency.atlassian.net/browse/DEV-1679)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Merged concurrently with Frontend
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed