### PR TITLE
DEV-1754: Replace Navy, Army, and Air Force agency codes with DOD

### DIFF
--- a/dataactcore/scripts/load_federal_hierarchy.py
+++ b/dataactcore/scripts/load_federal_hierarchy.py
@@ -119,6 +119,9 @@ def pull_offices(sess, filename, update_db, pull_all, updated_date_from):
                     if update_db:
                         agency_code = get_normalized_agency_code(org.get('cgaclist', [{'cgac': None}])[0]['cgac'],
                                                                  org.get('agencycode'))
+                        # TEMPORARILY REPLACE Navy, Army, AND Air Force WITH DOD
+                        if agency_code in ['017', '021', '057']:
+                            agency_code = '097'
                         if not org.get('aacofficecode') or not org.get('agencycode') or not agency_code:
                             # Item from Fed Hierarchy is missing necessary data, ignore it
                             continue


### PR DESCRIPTION
**High level description:**
We replace these `agency_code`s in the SubTier table but did not manually make the change when pulling from the Federal Hierarchy API. This corrects that.

**Technical details:**
Script update.

**Link to JIRA Ticket:**
[DEV-1754](https://federal-spending-transparency.atlassian.net/browse/DEV-1754)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- Merged concurrently with Frontend N/A
- Unit & integration tests updated with relevant test cases N/A
- Frontend impact assessment completed N/A