### PR TITLE
DEV-1809: Allow A files in detached generation endpoints

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1327,6 +1327,7 @@ This route sends a request to the backend to utilize the relevant external APIs 
     "cgac_code": "020",
     "start": "01/01/2016",
     "end": "03/31/2016",
+    "quarter": "Q1/2017",
     "agency_type": "awarding"
 }
 ```
@@ -1336,15 +1337,18 @@ This route sends a request to the backend to utilize the relevant external APIs 
 - `file_type` - **required** - a string indicating the file type to generate. Allowable values are:
     - `D1` - generate a D1 file
     - `D2` - generate a D2 file
-- `cgac_code` - **required** - the cgac of the agency for which to generate the files for
-- `start` - **required** - the start date of the requested date range, in `MM/DD/YYYY` string format
-- `end` - **required** - the end date of the requested date range, in `MM/DD/YYYY` string format
-- `agency_type` - **optional** - a string indicating if the file generated should be based on awarding or funding agency. Defaults to `awarding` if not provided. Only allowed values are:
+    - `A` - generate an A file
+- `cgac_code` - **required if frec\_code not provided** - the cgac of the agency for which to generate the files for
+- `frec_code` - **required if cgac\_code not provided** - the frec of the agency for which to generate the files for
+- `start` - **required for D file generation** - the start date of the requested date range, in `MM/DD/YYYY` string format
+- `end` - **required for D file generation** - the end date of the requested date range, in `MM/DD/YYYY` string format
+- `quarter` - **required for A file generation** - the quarter for which to generate an A file, in `Q#/YYYY` format where # is a number 1-4
+- `agency_type` - **optional** - a string indicating if the file generated should be based on awarding or funding agency. Ignored in A file generation. Defaults to `awarding` if not provided. Only allowed values are:
     - `awarding`
     - `funding`
 
 #### Response (JSON)
-Response will be the same format as those returned from `/v1/check_generation_status` endpoint with the exception that only D1 and D2 files will ever be present, never E or F.
+Response will be the same format as those returned from `/v1/check_generation_status` endpoint with the exception that only D1, D2, and A files will ever be present, never E or F.
 
 #### Errors
 Possible HTTP Status Codes not covered by `check_generation_status` documentation:
@@ -1427,7 +1431,7 @@ This route returns either a signed S3 URL to the generated file or, if the file 
 - `job_id` - **required** - an integer corresponding the job_id for the generation. Provided in the response of the call to `generate_detached_file`
 
 #### Response (JSON)
-Response will be the same format as those returned from `/v1/check_generation_status` endpoint with the exception that only D1 and D2 files will ever be present, never E or F.
+Response will be the same format as those returned from `/v1/check_generation_status` endpoint with the exception that only D1, D2, and A files will ever be present, never E or F.
 
 #### Errors
 Possible HTTP Status Codes:

--- a/dataactbroker/routes/generation_routes.py
+++ b/dataactbroker/routes/generation_routes.py
@@ -65,18 +65,19 @@ def add_generation_routes(app, is_local, server_path):
     @app.route("/v1/generate_detached_file/", methods=["POST"])
     @requires_login
     @use_kwargs({
-        'file_type': webargs_fields.String(required=True, validate=webargs_validate.OneOf(('D1', 'D2'))),
+        'file_type': webargs_fields.String(required=True, validate=webargs_validate.OneOf(('A', 'D1', 'D2'))),
         'cgac_code': webargs_fields.String(),
         'frec_code': webargs_fields.String(),
-        'start': webargs_fields.String(required=True),
-        'end': webargs_fields.String(required=True),
+        'start': webargs_fields.String(),
+        'end': webargs_fields.String(),
+        'quarter': webargs_fields.String(),
         'agency_type': webargs_fields.String(
             missing='awarding',
             validate=webargs_validate.OneOf(('awarding', 'funding'),
                                             error="Must be either awarding or funding if provided")
         )
     })
-    def generate_detached_file(file_type, cgac_code, frec_code, start, end, agency_type):
+    def generate_detached_file(file_type, cgac_code, frec_code, start, end, quarter, agency_type):
         """ Generate a file from external API, independent from a submission
 
             Attributes:
@@ -87,7 +88,8 @@ def add_generation_routes(app, is_local, server_path):
                 end: end date in a string, formatted MM/DD/YYYY
                 agency_type: The type of agency (awarding or funding) to generate the file for
         """
-        return generation_handler.generate_detached_file(file_type, cgac_code, frec_code, start, end, agency_type)
+        return generation_handler.generate_detached_file(file_type, cgac_code, frec_code, start, end, quarter,
+                                                         agency_type)
 
     @app.route("/v1/check_detached_generation_status/", methods=["GET"])
     @requires_login


### PR DESCRIPTION
**High level description:**
Allow detached A file generation (actual functionality not working, endpoints updated).

**Technical details:**
Update endpoints to allow detached A files to be generated, update tests and documentation. Return a temporary "in development" message in case this somehow goes out without the generation and someone tries to use it

**Link to JIRA Ticket:**
[DEV-1809](https://federal-spending-transparency.atlassian.net/browse/DEV-1809)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed