### PR TITLE
Hotfix: Use counts instead of counting the length of the array for get_fabs_meta

### DIFF
--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -611,8 +611,8 @@ def get_fabs_meta(submission_id):
             published_file = file_path
 
     return {
-        'valid_rows': len(valid_rows.all()),
-        'total_rows': len(total_rows.all()),
+        'valid_rows': valid_rows.count(),
+        'total_rows': total_rows.count(),
         'publish_date': publish_date.strftime('%-I:%M%p %m/%d/%Y') if publish_date else None,
         'published_file': published_file
     }


### PR DESCRIPTION
**High level description:**
Retrieving the FABS metadata was taking up all the API memory, because we were pulling in all the records just to get the FABS record count. We just want to get the `count()`.

**Technical details:**
Replace `len(rows.all())` with `rows.count()` in the `get_fabs_meta` function.

**Link to JIRA Ticket:**
[DEV-1866](https://federal-spending-transparency.atlassian.net/browse/DEV-1866)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- Merged concurrently with Frontend N/A
- Unit & integration tests updated with relevant test cases N/A
- Frontend impact assessment completed N/A