### PR TITLE
OPS: Add exit code 2 to the Fed Hierarchy script

### DIFF
--- a/dataactcore/scripts/load_federal_hierarchy.py
+++ b/dataactcore/scripts/load_federal_hierarchy.py
@@ -162,7 +162,7 @@ def pull_offices(sess, filename, update_db, pull_all, updated_date_from):
                 # We have somehow retrieved more records than existed at the beginning of the pull
                 logger.error("Total expected records: {}, Number of records retrieved: {}".format(
                     total_expected_records, entries_processed))
-                sys.exit(1)
+                sys.exit(2)
 
     if update_db:
         sess.commit()

--- a/dataactcore/scripts/load_federal_hierarchy.py
+++ b/dataactcore/scripts/load_federal_hierarchy.py
@@ -223,7 +223,7 @@ def get_normalized_agency_code(agency_code, subtier_code):
 
 
 def get_with_exception_hand(url_string):
-    """ Retrieve data from FPDS, allow for multiple retries and timeouts
+    """ Retrieve data from API, allow for multiple retries and timeouts
 
         Args:
             url_string: URL to make the request to
@@ -248,8 +248,8 @@ def get_with_exception_hand(url_string):
                             .format(retry_sleep_times[exception_retries], request_timeout))
                 time.sleep(retry_sleep_times[exception_retries])
             else:
-                logger.error('Connection to FPDS feed lost, maximum retry attempts exceeded.')
-                sys.exit(1)
+                logger.error('Connection to Federal Hierarchy API lost, maximum retry attempts exceeded.')
+                sys.exit(2)
     return resp
 
 


### PR DESCRIPTION
**High level description:**
Update the exit codes to include a `2` for API-specific issues.

**Technical details:**
Update the exit codes from `3` to `2` where we run into issues with missing responses from the API. Update logging.

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Ops review completed
- Merged concurrently with Frontend N/A
- Unit & integration tests updated with relevant test cases N/A
- Frontend impact assessment completed N/A