### PR TITLE
DEV-1880: Script to backfill Federal Hierarchy office name derivations

### DIFF
--- a/dataactcore/scripts/raw_sql/backfill_awarding_office_names_q12019.sql
+++ b/dataactcore/scripts/raw_sql/backfill_awarding_office_names_q12019.sql
@@ -2,6 +2,6 @@ UPDATE published_award_financial_assistance AS pafa
 SET awarding_office_name = office.office_name
 FROM office
 WHERE pafa.awarding_office_code = office.office_code
-  AND cast_as_date(pafa.action_date) >= '2018/10/01' AND cast_as_date(pafa.action_date) < '2018/01/01'
+  AND cast_as_date(pafa.action_date) >= '2018/10/01'
   AND pafa.awarding_office_name IS NULL
   AND pafa.awarding_office_code IS NOT NULL;

--- a/dataactcore/scripts/raw_sql/backfill_awarding_office_names_q12019.sql
+++ b/dataactcore/scripts/raw_sql/backfill_awarding_office_names_q12019.sql
@@ -1,0 +1,7 @@
+UPDATE published_award_financial_assistance AS pafa
+SET awarding_office_name = office.office_name
+FROM office
+WHERE pafa.awarding_office_code = office.office_code
+  AND cast_as_date(pafa.action_date) >= '2018/10/01' AND cast_as_date(pafa.action_date) < '2018/01/01'
+  AND pafa.awarding_office_name IS NULL
+  AND pafa.awarding_office_code IS NOT NULL;

--- a/dataactcore/scripts/raw_sql/backfill_funding_office_names_q12019.sql
+++ b/dataactcore/scripts/raw_sql/backfill_funding_office_names_q12019.sql
@@ -1,0 +1,7 @@
+UPDATE published_award_financial_assistance AS pafa
+SET funding_office_name = office.office_name
+FROM office
+WHERE pafa.funding_office_code = office.office_code
+  AND cast_as_date(pafa.action_date) >= '2018/10/01' AND cast_as_date(pafa.action_date) < '2018/01/01'
+  AND pafa.funding_office_name IS NULL
+  AND pafa.funding_office_code IS NOT NULL;

--- a/dataactcore/scripts/raw_sql/backfill_funding_office_names_q12019.sql
+++ b/dataactcore/scripts/raw_sql/backfill_funding_office_names_q12019.sql
@@ -2,6 +2,6 @@ UPDATE published_award_financial_assistance AS pafa
 SET funding_office_name = office.office_name
 FROM office
 WHERE pafa.funding_office_code = office.office_code
-  AND cast_as_date(pafa.action_date) >= '2018/10/01' AND cast_as_date(pafa.action_date) < '2018/01/01'
+  AND cast_as_date(pafa.action_date) >= '2018/10/01'
   AND pafa.funding_office_name IS NULL
   AND pafa.funding_office_code IS NOT NULL;

--- a/dataactcore/scripts/run_sql.py
+++ b/dataactcore/scripts/run_sql.py
@@ -1,0 +1,35 @@
+import argparse
+import logging
+
+from dataactcore.interfaces.db import GlobalDB
+from dataactvalidator.health_check import create_app
+
+logger = logging.getLogger(__name__)
+
+
+if __name__ == '__main__':
+    """ Parse a SQL file and run it against the database
+
+        Params:
+            -f: List of files to run, one at a time, in the order given.
+    """
+    parser = argparse.ArgumentParser(description='Runs SQL directly, pulled from a file.')
+    parser.add_argument('-f', '--files', action="append", nargs="+", help='List of space-separated SQL filepaths.')
+    args = parser.parse_args()
+
+    if not args.files or len(args.files) < 1:
+        raise Exception('At least one filepath to a SQL file must be included.')
+
+    with create_app().app_context():
+        for filepath in args.files[0]:
+            with open(filepath, 'r') as file:
+                sql = file.read()
+                logger.info('Running SQL:')
+                logger.info(sql)
+
+                sql = sql.replace('\n', ' ')
+                sess = GlobalDB.db().session
+                sess.execute(sql)
+                sess.commit()
+
+                logger.info('SQL completed\n')


### PR DESCRIPTION
**High level description:**
Script created to backfill `awarding_office_name` and `funding_office_name` from their office codes in FY2019Q1 FABS data.

**Technical details:**
Created the `run_sql.py` script for reusability. Added two SQL files, one for each reported office type.

**Link to JIRA Ticket:**
[DEV-1880](https://federal-spending-transparency.atlassian.net/browse/DEV-1880)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [ ] Tested on Sandbox
- Merged concurrently with Frontend N/A
- Unit & integration tests updated with relevant test cases N/A
- Frontend impact assessment completed N/A