### PR TITLE
DEV-2016: Remove get_protected_files route

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -600,29 +600,6 @@ Possible HTTP Status Codes:
 - 401: Login required
 - 403: Permission denied, user does not have permission to view this submission
 
-
-#### GET "/v1/get_protected_files/"
-This route returns a signed S3 URL for all files available to download on the help page.
-
-Example output:
-
-```json
-{
-    "urls": {
-            "AgencyLabel_to_TerseLabel.xslx": "https://prod-data-act-submission.s3-us-gov-west-1.amazonaws.com:443/rss/AgencyLabel_to_TerseLabel.xslx?Signature=abcdefg......",
-            "File2.extension": "https://......"
-    }
-}
-```
-
-Example output if there are no files available:
-
-```json
-{
-    "urls": {}
-}
-```
-
 #### GET "/v1/get\_obligations/"
 This endpoint gets total obligations and specific obligations.
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -768,17 +768,6 @@ class FileHandler:
         response_dict = {"submission_id": submission_id}
         return JsonResponse.create(StatusCode.OK, response_dict)
 
-    def get_protected_files(self):
-        """ Gets a set of urls to files on S3 on the help page
-
-            Returns:
-                A JsonResponse object with the urls in a list
-        """
-        response = {
-            "urls": self.s3manager.get_file_urls(bucket_name=CONFIG_BROKER["static_files_bucket"],
-                                                 path=CONFIG_BROKER["help_files_path"] + '/')}
-        return JsonResponse.create(StatusCode.OK, response)
-
     def build_file_map(self, file_dict, file_type_list, upload_files, submission):
         """ Build fileNameMap to be used in creating jobs
 

--- a/dataactbroker/routes/file_routes.py
+++ b/dataactbroker/routes/file_routes.py
@@ -103,13 +103,6 @@ def add_file_routes(app, is_local, server_path):
         """ Get the signed URL for the specified file history """
         return file_history_url(submission, certified_files_history_id, is_warning, is_local)
 
-    @app.route("/v1/get_protected_files/", methods=["GET"])
-    @requires_login
-    def get_protected_files():
-        """ Return signed URLs for all help page files """
-        file_manager = FileHandler(request, is_local=is_local, server_path=server_path)
-        return file_manager.get_protected_files()
-
     @app.route("/v1/check_current_page/", methods=["GET"])
     @convert_to_submission_id
     @requires_submission_perms('reader')

--- a/dataactcore/aws/s3Handler.py
+++ b/dataactcore/aws/s3Handler.py
@@ -111,30 +111,6 @@ class S3Handler:
             return 0
 
     @staticmethod
-    def get_file_urls(bucket_name, path):
-        """ Get signed urls for all files in a given bucket prefixed with the provided path
-
-            Args:
-                bucket_name: Name of the bucket to get files form
-                path: prefix for all the files so only those that start with that prefix are selected
-
-            Returns:
-                An array of signed urls keyed by the name of the file
-        """
-        urls = {}
-
-        s3 = boto3.client('s3', region_name=CONFIG_BROKER['aws_region'])
-        response = s3.list_objects_v2(Bucket=bucket_name, Prefix=path)
-        for obj in response.get('Contents', []):
-            if obj['Key'] != path:
-                file_name = obj['Key'][len(path):]
-                url = 'https://' + CONFIG_BROKER['proxy_url'] + '/' + CONFIG_BROKER["help_files_mapping"][1] + '/' +\
-                      file_name
-                urls[file_name] = url
-
-        return urls
-
-    @staticmethod
     def copy_file(original_bucket, new_bucket, original_path, new_path):
         """ Copies a file from one bucket to another.
 

--- a/dataactcore/config.py
+++ b/dataactcore/config.py
@@ -45,7 +45,7 @@ CONFIG_BROKER['path'] = dirname(dirname(abspath(__file__)))
 if CONFIG_BROKER['use_aws'] is True or CONFIG_BROKER['use_aws'] == "true":
     CONFIG_BROKER['local'] = False
     # AWS flag is on, so make sure all needed AWS info is present
-    required_aws_keys = ['aws_bucket', 'aws_region', 'static_files_bucket', 'help_files_path']
+    required_aws_keys = ['aws_bucket', 'aws_region']
     for k in required_aws_keys:
         try:
             CONFIG_BROKER[k]
@@ -54,10 +54,6 @@ if CONFIG_BROKER['use_aws'] is True or CONFIG_BROKER['use_aws'] == "true":
                            format(k))
         if not CONFIG_BROKER[k]:
             raise ValueError('Config error: use_aws is True but {} value is missing'.format(k))
-
-    help_files_path = CONFIG_BROKER["help_files_path"]
-    CONFIG_BROKER["help_files_path"] = "".join([help_files_path, "/"]) if help_files_path[-1] != "/" \
-        else help_files_path
 else:
     CONFIG_BROKER['local'] = True
     CONFIG_BROKER['aws_bucket'] = None

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -103,15 +103,10 @@ broker:
 
     submission_bucket_mapping: [s3-bucket, proxy/here]
     certified_bucket_mapping: [s3-bucket, proxy/here]
-    help_files_mapping: [s3-bucket, proxy/here]
 
     # S3 filenames for SF-133 file, only required if planning to load SF-133 table
     sf_133_folder: config
     sf_133_file: sf_133.csv
-
-    # Static Files Locations
-    static_files_bucket: s3-bucket
-    help_files_path: help-files
 
     # Location that deleted records from the FPDS atom feed are stored
     fpds_delete_bucket: s3-bucket


### PR DESCRIPTION
**High level description:**
Remove the route we no longer use

**Technical details:**
We removed all usage of get_protected_files on the frontend. Removing it from the backend

**Link to JIRA Ticket:**
[DEV-2016](https://federal-spending-transparency.atlassian.net/browse/DEV-2016)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Merged after with [Frontend#987](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/987)
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed