### PR TITLE
DEV-2017: Add agency_type to generated D filenames

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -47,6 +47,7 @@ from dataactcore.utils.statusCode import StatusCode
 from dataactcore.utils.stringCleaner import StringCleaner
 
 from dataactvalidator.filestreaming.csv_selection import write_query_to_file
+from dataactvalidator.validation_handlers.file_generation_manager import GEN_FILENAMES
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +76,7 @@ class FileHandler:
     # 1024 sounds like a good chunk size, we can change if needed
     CHUNK_SIZE = 1024
     FILE_TYPES = ["appropriations", "award_financial", "program_activity"]
-    EXTERNAL_FILE_TYPES = ["award", "award_procurement", "executive_compensation", "sub_award"]
+    EXTERNAL_FILE_TYPES = ["D2", "D1", "E", "F"]
     VALIDATOR_RESPONSE_FILE = "validatorResponse"
 
     UploadFile = namedtuple('UploadFile', ['file_type', 'upload_name', 'file_name', 'file_letter'])
@@ -237,20 +238,20 @@ class FileHandler:
             if not existing_submission:
                 # don't add external files to existing submission
                 for ext_file_type in FileHandler.EXTERNAL_FILE_TYPES:
-                    filename = CONFIG_BROKER["".join([ext_file_type, "_file_name"])]
-
+                    filename = GEN_FILENAMES[ext_file_type]
+                    if ext_file_type in ['D1', 'D2']:
+                        filename = filename.format('awarding')  # default to using awarding agency
                     if not self.is_local:
-                        upload_name = "{}/{}".format(
-                            submission.submission_id,
-                            S3Handler.get_timestamped_filename(filename)
-                        )
+                        upload_name = "{}/{}".format(submission.submission_id,
+                                                     S3Handler.get_timestamped_filename(filename))
                     else:
                         upload_name = filename
+
                     upload_files.append(FileHandler.UploadFile(
-                        file_type=ext_file_type,
+                        file_type=FILE_TYPE_DICT_LETTER_NAME[ext_file_type],
                         upload_name=upload_name,
                         file_name=filename,
-                        file_letter=FILE_TYPE_DICT_LETTER[FILE_TYPE_DICT[ext_file_type]]
+                        file_letter=ext_file_type
                     ))
 
             # Add jobs or update existing ones

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -47,10 +47,10 @@ broker:
 
     # File E
     awardee_attributes_file_name: awardee_data.csv
-    executive_compensation_file_name: executive_compensation_data.csv
+    e_file_name: executive_compensation_data.csv
 
     # File F
-    sub_award_file_name: sub_award_data.csv
+    f_file_name: sub_award_data.csv
 
     ## AWS Configuration Settings ##
 

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -37,11 +37,11 @@ broker:
     # The folder within dataactvalidator/config where USPS zip4 files are stored
     zip_folder: zips
 
-    # File A, D1, and D2 filenames
-    # Uses "{}" because it requires string formatting to insert query parameters
-    appropriations_file_name: appropriations_data.csv
-    award_procurement_file_name: d1_{}agency_data.csv
-    award_file_name: d2_{}agency_data.csv
+    # File A, D1, and D2 generation
+    # Uses "{}" because it requires string formatting to insert agency type as a parameter
+    a_file_name: appropriations_data.csv
+    d1_file_name: d1_{}agency_data.csv
+    d2_file_name: d2_{}agency_data.csv
 
     d_file_storage_path: /data-act/backend/tmp/
 

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -37,20 +37,10 @@ broker:
     # The folder within dataactvalidator/config where USPS zip4 files are stored
     zip_folder: zips
 
-    # File A, D1, and D2 generation
-    # Uses "{}" because it requires string formatting to insert agency type as a parameter
-    a_file_name: appropriations_data.csv
-    d1_file_name: d1_{}agency_data.csv
-    d2_file_name: d2_{}agency_data.csv
-
     d_file_storage_path: /data-act/backend/tmp/
 
     # File E
     awardee_attributes_file_name: awardee_data.csv
-    e_file_name: executive_compensation_data.csv
-
-    # File F
-    f_file_name: sub_award_data.csv
 
     ## AWS Configuration Settings ##
 

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -37,19 +37,11 @@ broker:
     # The folder within dataactvalidator/config where USPS zip4 files are stored
     zip_folder: zips
 
-    ## Smartronix API URLs ##
-
-    # File A Generation
-    appropriations_file_name: appropriations_data.csv
-
-    # File D1 API
+    # File A, D1, and D2 filenames
     # Uses "{}" because it requires string formatting to insert query parameters
-    # If the URL is provided, the file name provided will be used when uploading to S3
-    award_procurement_file_name: d1_data.csv
-
-    # File D2 API
-    # If the URL is provided, the file name provided will be used when uploading to S3
-    award_file_name: d2_data.csv
+    appropriations_file_name: appropriations_data.csv
+    award_procurement_file_name: d1_{}agency_data.csv
+    award_file_name: d2_{}agency_data.csv
 
     d_file_storage_path: /data-act/backend/tmp/
 

--- a/dataactvalidator/validation_handlers/file_generation_manager.py
+++ b/dataactvalidator/validation_handlers/file_generation_manager.py
@@ -16,6 +16,11 @@ from dataactvalidator.filestreaming.csv_selection import write_csv, write_query_
 
 logger = logging.getLogger(__name__)
 
+GEN_FILENAMES = {
+    'A': 'appropriations_data.csv', 'D1': 'd1_{}agency_data.csv', 'D2': 'd2_{}agency_data.csv',
+    'E': 'executive_compensation_data.csv', 'F': 'sub_award_data.csv'
+}
+
 
 class FileGenerationManager:
     """ Responsible for managing the generation of all files.
@@ -44,9 +49,8 @@ class FileGenerationManager:
 
     def generate_file(self, agency_code=None):
         """ Generates a file based on the FileGeneration object and updates any Jobs referencing it """
-        raw_filename = CONFIG_BROKER["".join([self.file_type.lower(), "_file_name"])]
-        if self.file_generation:
-            raw_filename = raw_filename.format(self.file_generation.agency_type)
+        raw_filename = (GEN_FILENAMES[self.file_type] if not self.file_generation else
+                        GEN_FILENAMES[self.file_type].format(self.file_generation.agency_type))
         file_name = S3Handler.get_timestamped_filename(raw_filename)
         if self.is_local:
             file_path = "".join([CONFIG_BROKER['broker_files'], file_name])

--- a/dataactvalidator/validation_handlers/file_generation_manager.py
+++ b/dataactvalidator/validation_handlers/file_generation_manager.py
@@ -9,7 +9,6 @@ from dataactcore.config import CONFIG_BROKER
 from dataactcore.interfaces.function_bag import mark_job_status
 from dataactcore.models.domainModels import ExecutiveCompensation
 from dataactcore.models.jobModels import Job
-from dataactcore.models.lookups import FILE_TYPE_DICT_LETTER_NAME
 from dataactcore.models.stagingModels import AwardFinancialAssistance, AwardProcurement
 from dataactcore.utils import fileA, fileD1, fileD2, fileE, fileF
 
@@ -45,7 +44,7 @@ class FileGenerationManager:
 
     def generate_file(self, agency_code=None):
         """ Generates a file based on the FileGeneration object and updates any Jobs referencing it """
-        raw_filename = CONFIG_BROKER["".join([FILE_TYPE_DICT_LETTER_NAME[self.file_type], "_file_name"])]
+        raw_filename = CONFIG_BROKER["".join([self.file_type.lower(), "_file_name"])]
         if self.file_generation:
             raw_filename = raw_filename.format(self.file_generation.agency_type)
         file_name = S3Handler.get_timestamped_filename(raw_filename)

--- a/dataactvalidator/validation_handlers/file_generation_manager.py
+++ b/dataactvalidator/validation_handlers/file_generation_manager.py
@@ -46,6 +46,8 @@ class FileGenerationManager:
     def generate_file(self, agency_code=None):
         """ Generates a file based on the FileGeneration object and updates any Jobs referencing it """
         raw_filename = CONFIG_BROKER["".join([FILE_TYPE_DICT_LETTER_NAME[self.file_type], "_file_name"])]
+        if self.file_generation:
+            raw_filename = raw_filename.format(self.file_generation.agency_type)
         file_name = S3Handler.get_timestamped_filename(raw_filename)
         if self.is_local:
             file_path = "".join([CONFIG_BROKER['broker_files'], file_name])


### PR DESCRIPTION
**High level description:**
Adding the ability to know if a D file generation is generated based on awarding or funding agency.

**Technical details:**
Update the config variable for D file generations to allow for a string to be added. Include a step in the generation to add the agency type to the filename.

**Link to JIRA Ticket:**
[DEV-2017](https://federal-spending-transparency.atlassian.net/browse/DEV-2017)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- ~Merged _after_ [Config #307](https://github.com/fedspendingtransparency/data-act-broker-config/pull/307)~
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed