### PR TITLE
DEV-2043: Fully raise Validator exceptions

### DIFF
--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -1,5 +1,6 @@
 import logging
 import csv
+import time
 import traceback
 
 from flask import Flask, g, current_app
@@ -70,6 +71,10 @@ def run_app():
 
                 # Delete from SQS once processed
                 message.delete()
+
+            # When you receive an empty response from the queue, wait a second before trying again
+            if len(messages) == 0:
+                time.sleep(1)
 
 
 def validator_process_file_generation(file_gen_id):

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -56,31 +56,26 @@ def run_app():
         while True:
             # Set current_message to None before every loop to ensure it's never set to the previous message
             current_message = None
-            try:
-                # Grabs one (or more) messages from the queue
-                messages = queue.receive_messages(WaitTimeSeconds=10, MessageAttributeNames=['All'])
-                for message in messages:
-                    logger.info("Message received: %s", message.body)
 
-                    # Retrieve the message body and attributes
-                    current_message = message
-                    msg_attr = current_message.message_attributes
+            # Grabs one (or more) messages from the queue
+            messages = queue.receive_messages(WaitTimeSeconds=10, MessageAttributeNames=['All'])
+            for message in messages:
+                logger.info("Message received: %s", message.body)
 
-                    # Generating a file
-                    if msg_attr and msg_attr.get('validation_type', {}).get('StringValue') == 'generation':
-                        handled_error = validator_process_file_generation(message.body)
-                    # Running validations
-                    else:
-                        a_agency_code = msg_attr.get('agency_code', {}).get('StringValue') if msg_attr else None
-                        handled_error = validator_process_job(message.body, current_message, a_agency_code)
+                # Retrieve the message body and attributes
+                current_message = message
+                msg_attr = current_message.message_attributes
 
-                    # Delete from SQS once processed
-                    if not handled_error:
-                        message.delete()
+                # Generating a file
+                if msg_attr and msg_attr.get('validation_type', {}).get('StringValue') == 'generation':
+                    validator_process_file_generation(message.body)
+                # Running validations
+                else:
+                    a_agency_code = msg_attr.get('agency_code', {}).get('StringValue') if msg_attr else None
+                    validator_process_job(message.body, current_message, a_agency_code)
 
-            except Exception as e:
-                # Log exceptions
-                logger.error(traceback.format_exc())
+                # Delete from SQS once processed
+                message.delete()
 
 
 def validator_process_file_generation(file_gen_id):
@@ -95,7 +90,6 @@ def validator_process_file_generation(file_gen_id):
     """
     sess = GlobalDB.db().session
     file_generation = None
-    has_errors = False
 
     try:
         file_generation = sess.query(FileGeneration).filter_by(file_generation_id=file_gen_id).one_or_none()
@@ -106,42 +100,58 @@ def validator_process_file_generation(file_gen_id):
         file_generation_manager = FileGenerationManager(sess, g.is_local, file_generation=file_generation)
         file_generation_manager.generate_file()
 
-    except Exception as e:
-        logger.error(traceback.format_exc())
-        has_errors = True
-
+    except ResponseException as e:
+        # Log uncaught exceptions and fail all Jobs referencing this FileGeneration
+        error_data = {
+            'message': 'An unhandled exception occurred in the Validator during file generation',
+            'message_type': 'ValidatorInfo',
+            'file_generation_id': file_gen_id,
+            'traceback': traceback.format_exc()
+        }
         if file_generation:
-            # Uncache the FileGeneration
-            sess.refresh(file_generation)
-            file_generation.is_cached_file = False
+            error_data.update({
+                'agency_code': file_generation.agency_code, 'agency_type': file_generation.agency_type,
+                'start_date': file_generation.start_date, 'end_date': file_generation.end_date,
+                'file_type': file_generation.file_type, 'file_path': file_generation.file_path,
+            })
+        logger.error(error_data)
 
-            # Mark all Jobs waiting on this FileGeneration as failed
-            generation_jobs = sess.query(Job).filter_by(file_generation_id=file_gen_id).all()
-            for job in generation_jobs:
-                if job.job_status in [JOB_STATUS_DICT['waiting'], JOB_STATUS_DICT['ready'], JOB_STATUS_DICT['running']]:
-                    mark_job_status(job.job_id, 'failed')
-                    sess.refresh(job)
-                    job.update({'file_generation_id': None}, synchronize_session=False)
+        # Try to mark the Jobs as failed, but continue raising the original Exception if not possible
+        try:
+            if file_generation:
+                # Uncache the FileGeneration
+                sess.refresh(file_generation)
+                file_generation.is_cached_file = False
 
-            sess.commit()
+                # Mark all Jobs waiting on this FileGeneration as failed
+                generation_jobs = sess.query(Job).filter_by(file_generation_id=file_gen_id).all()
+                for job in generation_jobs:
+                    if job.job_status in [JOB_STATUS_DICT['waiting'], JOB_STATUS_DICT['ready'],
+                                          JOB_STATUS_DICT['running']]:
+                        mark_job_status(job.job_id, 'failed')
+                        sess.refresh(job)
+                        job.update({'file_generation_id': None, }, synchronize_session=False)
+                sess.commit()
+        except:
+            pass
 
-    return has_errors
+        raise e
 
 
-def validator_process_job(job_id, current_message, agency_code):
+def validator_process_job(job_id, agency_code):
     """ Retrieves a Job based on its ID, and kicks off a validation. Handles errors by ensuring the Job (if exists) is
         no longer running.
 
     Args:
         job_id: ID of a Job
-        current_message: The currently in-transit SQS message
+        agency_code: CGAC or FREC code for agency, only required for file generations by Job
 
     Raises:
-        Any Exceptions raised by the ValidationManager
+        Any Exceptions raised by the GenerationManager or ValidationManager, excluding those explicitly handled
     """
     sess = GlobalDB.db().session
     job = None
-    has_errors = False
+
     try:
         mark_job_status(job_id, 'ready')
 
@@ -163,52 +173,53 @@ def validator_process_job(job_id, current_message, agency_code):
             validation_manager = ValidationManager(g.is_local, CONFIG_SERVICES['error_report_path'])
             validation_manager.validate_job(job.job_id)
 
-    except ResponseException as e:
-        # Handle exceptions explicitly raised during validation.
-        logger.error(traceback.format_exc())
-        has_errors = True
+    except (ResponseException, csv.Error, UnicodeDecodeError, ValueError) as e:
+        # Handle exceptions explicitly raised during validation
+        error_data = {
+            'message': 'An exception occurred in the Validator',
+            'message_type': 'ValidatorInfo',
+            'job_id': job_id,
+            'traceback': traceback.format_exc()
+        }
 
         if job:
+            error_data.update({'submission_id': job.submission_id, 'file_type': job.file_type.name})
+            logger.error(error_data)
+
             sess.refresh(job)
-            if job.filename is not None:
-                # Insert file-level error info to the database
-                write_file_error(job.job_id, job.filename, e.errorType, e.extraInfo)
-
-            if e.errorType != ValidationError.jobError:
-                # Job passed prerequisites for validation but an error happened somewhere: mark job as 'invalid'
-                mark_job_status(job.job_id, 'invalid')
-                if current_message:
-                    if e.errorType in [ValidationError.rowCountError, ValidationError.headerError,
-                                       ValidationError.fileTypeError]:
-                        current_message.delete()
-
-    except Exception as e:
-        # Handle uncaught exceptions in validation process.
-        logger.error(traceback.format_exc())
-        has_errors = True
-
-        if job:
-            # csv-specific errors get a different job status and response code
-            sess.refresh(job)
-            if isinstance(e, ValueError) or isinstance(e, csv.Error) or isinstance(e, UnicodeDecodeError):
-                job_status = 'invalid'
-            else:
-                job_status = 'failed'
-
             if job.filename is not None:
                 error_type = ValidationError.unknownError
-
-                # Delete UnicodeDecodeErrors because they're the only legitimate errors caught as exceptions
                 if isinstance(e, UnicodeDecodeError):
                     error_type = ValidationError.encodingError
-                    if current_message:
-                        current_message.delete()
+                elif isinstance(e, ResponseException):
+                    error_type = e.errorType
 
                 write_file_error(job.job_id, job.filename, error_type)
 
-            mark_job_status(job.job_id, job_status)
+            mark_job_status(job.job_id, 'invalid')
+        else:
+            logger.error(error_data)
+            raise e
 
-    return has_errors
+    except Exception as e:
+        # Log uncaught exceptions and fail the Job
+        error_data = {
+            'message': 'An unhandled exception occurred in the Validator',
+            'message_type': 'ValidatorInfo',
+            'job_id': job_id,
+            'traceback': traceback.format_exc()
+        }
+        if job:
+            error_data.update({'submission_id': job.submission_id, 'file_type': job.file_type.name})
+        logger.error(error_data)
+
+        # Try to mark the Job as failed, but continue raising the original Exception if not possible
+        try:
+            mark_job_status(job_id, 'failed')
+        except:
+            pass
+
+        raise e
 
 
 if __name__ == "__main__":

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -124,7 +124,7 @@ def validator_process_file_generation(file_gen_id):
                                           JOB_STATUS_DICT['running']]:
                         mark_job_status(job.job_id, 'failed')
                         sess.refresh(job)
-                        job.update({'file_generation_id': None, }, synchronize_session=False)
+                        job.update({'file_generation_id': None, 'error_message': str(e)}, synchronize_session=False)
                 sess.commit()
         except:
             pass
@@ -181,6 +181,7 @@ def validator_process_job(job_id, agency_code):
             logger.error(error_data)
 
             sess.refresh(job)
+            job.update({'error_message': str(e)}, synchronize_session=False)
             if job.filename is not None:
                 error_type = ValidationError.unknownError
                 if isinstance(e, UnicodeDecodeError):
@@ -210,6 +211,10 @@ def validator_process_job(job_id, agency_code):
         # Try to mark the Job as failed, but continue raising the original Exception if not possible
         try:
             mark_job_status(job_id, 'failed')
+
+            sess.refresh(job)
+            job.update({'error_message': str(e)}, synchronize_session=False)
+            sess.commit()
         except:
             pass
 

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -99,7 +99,7 @@ def validator_process_file_generation(file_gen_id):
         file_generation_manager = FileGenerationManager(sess, g.is_local, file_generation=file_generation)
         file_generation_manager.generate_file()
 
-    except ResponseException as e:
+    except Exception as e:
         # Log uncaught exceptions and fail all Jobs referencing this FileGeneration
         error_data = {
             'message': 'An unhandled exception occurred in the Validator during file generation',
@@ -134,7 +134,10 @@ def validator_process_file_generation(file_gen_id):
         except:
             pass
 
-        raise e
+        # ResponseExceptions only occur at very specific times, and should not affect the Validator's future attempts
+        # at handling messages from SQS
+        if not isinstance(e, ResponseException):
+            raise e
 
 
 def validator_process_job(job_id, agency_code):

--- a/dataactvalidator/validation_handlers/file_generation_manager.py
+++ b/dataactvalidator/validation_handlers/file_generation_manager.py
@@ -12,6 +12,7 @@ from dataactcore.models.jobModels import Job
 from dataactcore.models.lookups import FILE_TYPE_DICT_LETTER_NAME
 from dataactcore.models.stagingModels import AwardFinancialAssistance, AwardProcurement
 from dataactcore.utils import fileA, fileD1, fileD2, fileE, fileF
+from dataactcore.utils.responseException import ResponseException
 
 from dataactvalidator.filestreaming.csv_selection import write_csv, write_query_to_file
 
@@ -69,7 +70,7 @@ class FileGenerationManager:
 
             if self.job.file_type.letter_name == 'A':
                 if not agency_code:
-                    raise Exception('Agency code not provided for an A file generation')
+                    raise ResponseException('Agency code not provided for an A file generation')
 
                 self.generate_a_file(agency_code, file_path)
             else:
@@ -81,7 +82,7 @@ class FileGenerationManager:
         else:
             e = 'No FileGeneration object for D file generation.' if self.file_type in ['D1', 'D2'] else \
                 'Cannot generate file for {} file type.'.format(self.file_type if self.file_type else 'empty')
-            raise Exception(e)
+            raise ResponseException(e)
 
         logger.info(log_data)
 
@@ -105,7 +106,8 @@ class FileGenerationManager:
         elif self.file_type == 'D2':
             file_utils = fileD2
         else:
-            raise Exception('Failed to generate_d_file with file_type:{} (must be D1 or D2).'.format(self.file_type))
+            raise ResponseException('Failed to generate_d_file with file_type:{} (must be D1 or D2).'.format(
+                self.file_type))
         headers = [key for key in file_utils.mapping]
         query_utils = {
             "sess": self.sess, "file_utils": file_utils, "agency_code": self.file_generation.agency_code,


### PR DESCRIPTION
**High level description:**
Currently, when a process on the Validator runs into an Exception that we have not accounted for explicitly, the Validator instance swallows the error without failing (but still sends the message to the Dead Letter Queue). We want the Validator process itself to fail.

**Technical details:**
Remove the `try`/`except` code for Exceptions that we do not plan for. This will ensure that when an unhandled Exception is raised, it continues until the Validator process is killed. Supervisord should already be configured to spin up a new Validator instance to replace the old one.

**Link to JIRA Ticket:**
[DEV-2043](https://federal-spending-transparency.atlassian.net/browse/DEV-2043)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Merged concurrently with Frontend N/A
- Unit & integration tests updated with relevant test cases N/A
- [x] Frontend impact assessment completed
```
We need to make sure we update the frontend to start handling different combinations of errors.
If any part of the Job is in an errored state, it should be shown to the user.
```