### PR TITLE
DEV-2024: Do not attempt to write a file-level error when a Job does not exist

### DIFF
--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -645,10 +645,8 @@ class ValidationManager:
         # Get the job
         job = sess.query(Job).filter_by(job_id=job_id).one_or_none()
         if job is None:
-            validation_error_type = ValidationError.jobError
-            write_file_error(job_id, None, validation_error_type)
             raise ResponseException('Job ID {} not found in database'.format(job_id), StatusCode.CLIENT_ERROR, None,
-                                    validation_error_type)
+                                    ValidationError.jobError)
 
         # Make sure job's prerequisites are complete
         if not run_job_checks(job_id):

--- a/tests/unit/dataactvalidator/validation_handlers/test_validationManager.py
+++ b/tests/unit/dataactvalidator/validation_handlers/test_validationManager.py
@@ -3,8 +3,11 @@ from unittest.mock import Mock
 
 import pytest
 
+from dataactcore.config import CONFIG_BROKER
+from dataactcore.utils.responseException import ResponseException
 from dataactvalidator.validation_handlers import validationManager
 from dataactvalidator.validation_handlers.errorInterface import ErrorInterface
+
 from tests.unit.dataactcore.factories.domain import TASFactory
 from tests.unit.dataactcore.factories.job import JobFactory, SubmissionFactory
 from tests.unit.dataactcore.factories.staging import (AppropriationFactory, AwardFinancialFactory,
@@ -111,3 +114,16 @@ def test_insert_staging_model_failure():
     assert error['firstRow'] == 1234
     assert error['fieldName'] == 'Formatting Error'
     assert error['filename'] == job.filename
+
+
+@pytest.mark.usefixtures('database')
+def test_attempt_validate_deleted_job():
+    error = None
+    validation_manager = validationManager.ValidationManager(is_local=CONFIG_BROKER['local'])
+    try:
+        validation_manager.validate_job(12345678901234567890)
+    except ResponseException as e:
+        error = e
+
+    assert error is not None
+    assert str(error) == 'Job ID 12345678901234567890 not found in database'


### PR DESCRIPTION
**High level description:**
The research in [DEV-2013](https://federal-spending-transparency.atlassian.net/browse/DEV-2013) revealed a bug: putting a `job_id` in the Validator for a deleted Job will essentially "corrupt" the Validator instance because we attempt to write a file-level error. We should not attempt to write a file-level error without a valid Job.

**Technical details:**
Attempting to write a file-level error with an invalid `job_id` creates an invalid transaction in the database session, because the `job_id` field in the File table is a primary key to a Job object. Without a valid Job, we should not attempt to create the File object.

**Link to JIRA Ticket:**
[DEV-2024](https://federal-spending-transparency.atlassian.net/browse/DEV-2024)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Merged concurrently with Frontend N/A
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed