### PR TITLE
DEV-2083: Check status cross-file

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1245,7 +1245,7 @@ def process_job_status(jobs, response_content):
         else:
             validation = job
             validation_status = JOB_STATUS_DICT_ID[job['job_status']]
-            validation_em = upload['error_message']
+            validation_em = validation['error_message']
 
     # checking for failures
     if upload_status == 'invalid' or upload_status == 'failed' or validation_status == 'failed':

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1235,25 +1235,29 @@ def process_job_status(jobs, response_content):
     validation = None
     upload_status = ''
     validation_status = ''
+    upload_em = ''
+    validation_em = ''
     for job in jobs:
         if job['job_type'] == JOB_TYPE_DICT['file_upload']:
             upload = job
             upload_status = JOB_STATUS_DICT_ID[job['job_status']]
+            upload_em = upload['error_message']
         else:
             validation = job
             validation_status = JOB_STATUS_DICT_ID[job['job_status']]
+            validation_em = upload['error_message']
 
     # checking for failures
     if upload_status == 'invalid' or upload_status == 'failed' or validation_status == 'failed':
         response_content['status'] = 'failed'
         response_content['has_errors'] = True
-        response_content['message'] = upload['error_message'] or validation['error_message'] or ''
+        response_content['message'] = upload_em or validation_em or ''
         return response_content
 
     if validation_status == 'invalid':
         response_content['status'] = 'finished'
         response_content['has_errors'] = True
-        response_content['message'] = upload['error_message'] or validation['error_message'] or ''
+        response_content['message'] = upload_em or validation_em or ''
         return response_content
 
     # If upload job exists and hasn't started or if it doesn't exist and validation job hasn't started,


### PR DESCRIPTION
**High level description:**
When a cross-file job fails, it shouldn't break the submission.

**Technical details:**
check_status was throwing an error if cross-file was in the "failed" status. Removed that error and made sure the same issue couldn't happen again with an upload file somehow either.

**Link to JIRA Ticket:**
[DEV-2083](https://federal-spending-transparency.atlassian.net/browse/DEV-2083)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed

- Note: There is another ticket for a frontend fix to actually display the error on the frontend, this is just to stop the endpoint from throwing errors.