### PR TITLE
DEV-2180: B9 program activity code is case-insensitive

### DIFF
--- a/dataactvalidator/config/sqlrules/b9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/b9_award_financial.sql
@@ -28,7 +28,7 @@ WHERE (af.program_activity_code <> '0000'
         WHERE af.agency_identifier = pa.agency_id
             AND af.main_account_code = pa.account_number
             AND UPPER(COALESCE(af.program_activity_name, '')) = UPPER(pa.program_activity_name)
-            AND COALESCE(af.program_activity_code, '') = pa.program_activity_code
+            AND UPPER(COALESCE(af.program_activity_code, '')) = UPPER(pa.program_activity_code)
             AND pa.fiscal_year_quarter = 'FY' || RIGHT(CAST(sub.reporting_fiscal_year AS CHAR(4)), 2) || 'Q' || sub.reporting_fiscal_period / 3
 
     );

--- a/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b9_object_class_program_activity.sql
@@ -35,7 +35,7 @@ WHERE (sub.reporting_fiscal_year, sub.reporting_fiscal_period) NOT IN (('2017', 
             WHERE op.agency_identifier = pa.agency_id
             AND op.main_account_code = pa.account_number
             AND UPPER(COALESCE(op.program_activity_name, '')) = UPPER(pa.program_activity_name)
-            AND COALESCE(op.program_activity_code, '') = pa.program_activity_code
+            AND UPPER(COALESCE(op.program_activity_code, '')) = UPPER(pa.program_activity_code)
             AND pa.fiscal_year_quarter = 'FY' || RIGHT(CAST(sub.reporting_fiscal_year AS CHAR(4)), 2) || 'Q' || sub.reporting_fiscal_period / 3
     )
     AND (op.program_activity_code <> '0000'

--- a/tests/unit/dataactvalidator/test_b9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_b9_award_financial.py
@@ -119,7 +119,7 @@ def test_success_ignore_case(database):
     populate_publish_status(database)
 
     af = AwardFinancialFactory(row_number=1, submission_id=1, agency_identifier='test', main_account_code='test',
-                               program_activity_name='TEST', program_activity_code='test')
+                               program_activity_name='TEST', program_activity_code='TEST')
 
     pa = ProgramActivityFactory(fiscal_year_quarter='FY16Q4', agency_id='test', allocation_transfer_id='test',
                                 account_number='test', program_activity_name='test', program_activity_code='test')


### PR DESCRIPTION
**High level description:**
Program Activity Code in Rule B9 should be case-insensitive.

**Technical details:**
(see high level)

**Link to JIRA Ticket:**
[DEV-2180](https://federal-spending-transparency.atlassian.net/browse/DEV-2180)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases