### PR TITLE
DEV-2234: send email frec submission

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1285,6 +1285,46 @@ Example output:
 }
 ```
 
+#### POST "/v1/email\_users/"
+This endpoint returns metadata for the requested submission.
+
+##### Body (JSON)
+
+```
+{
+  "submission_id": 1234,
+  "email_template": "review_submission",
+  "users": [1, 2]
+}
+```
+
+##### Body Description
+- `submission_id` - **required** - an integer representing the ID of the submission to email about
+- `email_template` - **required** - a string representing the type of template to use in the email. Currently, only the following templates exist (case-sensitive):
+    - `review_submission`
+- `users` - **required** - a list of integers representing the IDs of the users to send the emails to
+
+##### Response (JSON)
+```
+{
+    "message": "Emails successfully sent"
+}
+```
+
+##### Response Attributes
+- `message`: A message indicating that the emails were sent
+
+##### Errors
+Possible HTTP Status Codes:
+
+- 400:
+    - Missing parameters
+    - Submission does not exist
+    - Submission somehow is not associated with valid CGAC/FREC
+- 401: Login required
+- 403: Permission denied, user does not have permission to view this submission
+
+
 ## Generate Files
 ### POST "/v1/generate\_file/"
 This route sends a request to the backend to utilize the relevant external APIs and generate the relevant file for the metadata that is submitted. This route is used for file generation **within** a submission.

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1314,7 +1314,7 @@ Example output:
 ```
 
 #### POST "/v1/email\_users/"
-This endpoint returns metadata for the requested submission.
+This endpoint sends an email of the specified template to the users provided.
 
 ##### Body (JSON)
 

--- a/tests/integration/userTests.py
+++ b/tests/integration/userTests.py
@@ -76,7 +76,16 @@ class UserTests(BaseTestAPI):
         response = self.app.post_json("/v1/email_users/", contents, headers={"x-session-id": self.session_id})
         self.check_response(response, StatusCode.OK, "Emails successfully sent")
 
+        # User without proper permissions
+        self.login_user(username=self.test_users['editfabs_user'])
+        contents = {"users": [self.agency_user_id], "submission_id": self.submission_id,
+                    "email_template": "review_submission"}
+        response = self.app.post_json("/v1/email_users/", contents, expect_errors=True,
+                                      headers={"x-session-id": self.session_id})
+        self.check_response(response, StatusCode.PERMISSION_DENIED)
+
         # missing request params
+        self.login_user()
         bad_input = {"users": [self.agency_user_id]}
         response = self.app.post_json("/v1/email_users/", bad_input, expect_errors=True,
                                       headers={"x-session-id": self.session_id})


### PR DESCRIPTION
**High level description:**
Errors were being thrown when trying to email from a FREC submission.

**Technical details:**
There was a problem with the way we were gathering the agency name for the email that caused an error when emails were being sent from FREC submissions. Updated the function to allow only users with access to a submission to send from that submission. Also updated the function in general to be cleaner and better.

**Link to JIRA Ticket:**
[DEV-2234](https://federal-spending-transparency.atlassian.net/browse/DEV-2234)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed