### PR TITLE
Report unit test code coverage to code climate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ after_script:
   - pwd
   - ls -lath
   - cat .coverage
-  - ./cc-test-reporter after-build --coverage-input-type coverage.py --exit-code $TRAVIS_TEST_RESULT --debug
+  - ./cc-test-reporter after-build --coverage-input-type coverage.py --prefix ./tests --exit-code $TRAVIS_TEST_RESULT
+    --debug
   - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,20 @@ script:
   - cp dataactcore/local_config_example.yml dataactcore/local_config.yml
   - cp dataactcore/local_secrets_example.yml dataactcore/local_secrets.yml
   - pwd
-  - ls -lathr
+  - ls -lath
   - |
     docker-compose run --rm dataact-broker \
       /bin/sh -c " \
       cd ./dataactcore; sleep 9s; alembic upgrade head; \
       cd ../; flake8 && \
       py.test --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml; \
-      ls -lathr"
+      ls -lath"
 
 
 after_script:
-  - ls -lathr
-  - ls /
+  - pwd
+  - ls -lath
+  - cat .coverage
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,15 @@ script:
   - cp dataactcore/local_secrets_example.yml dataactcore/local_secrets.yml
   - pwd
   - ls -lath
-  - |
-    docker-compose run --rm dataact-broker \
-      /bin/sh -c " \
-      cd ./dataactcore; sleep 9s; alembic upgrade head; \
-      cd ../; flake8 && echo 'hi' > tests/coverage.xml && echo 'hello' > .coverage && \
-      #py.test --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml; \
-      ls -lath"
+  - echo 'hi' > tests/coverage.xml
+  - echo 'hello' > .coverage
+#  - |
+#    docker-compose run --rm dataact-broker \
+#      /bin/sh -c " \
+#      cd ./dataactcore; sleep 9s; alembic upgrade head; \
+#      cd ../; flake8 && echo 'hi' > tests/coverage.xml && echo 'hello' > .coverage && \
+#      #py.test --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml; \
+#      ls -lath"
 
 
 after_script:
@@ -29,5 +31,5 @@ after_script:
   - cat .coverage
   - ./cc-test-reporter after-build --coverage-input-type coverage.py --prefix tests --exit-code $TRAVIS_TEST_RESULT
     --debug tests/coverage.xml
-  - docker-compose down
+#  - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: required
 services:
   - docker
 
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
 script:
   - cp dataactcore/config_example.yml dataactcore/config.yml
   - cp dataactcore/local_config_example.yml dataactcore/local_config.yml
@@ -14,3 +19,7 @@ script:
       cd ../; flake8 && \
       py.test --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml"
   - docker-compose down
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ after_script:
   - ls -lath
   - cat .coverage
   - ./cc-test-reporter after-build --coverage-input-type coverage.py --prefix tests --exit-code $TRAVIS_TEST_RESULT
-    --debug tests/coverage.xml
+    --debug $PWD/tests/coverage.xml
 #  - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ script:
     docker-compose run --rm dataact-broker \
       /bin/sh -c " \
       cd ./dataactcore; sleep 9s; alembic upgrade head; \
-      cd ../; flake8 && \
-      py.test --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml; \
+      cd ../; flake8 && echo 'hi' > tests/coverage.xml && echo 'hello' > .coverage && \
+      #py.test --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml; \
       ls -lath"
 
 
@@ -28,6 +28,6 @@ after_script:
   - ls -lath
   - cat .coverage
   - ./cc-test-reporter after-build --coverage-input-type coverage.py --prefix tests --exit-code $TRAVIS_TEST_RESULT
-    --debug
+    --debug tests/coverage.xml
   - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ after_script:
   - pwd
   - ls -lath
   - cat .coverage
-  - ./cc-test-reporter after-build --coverage-input-type coverage.py --prefix ./tests --exit-code $TRAVIS_TEST_RESULT
+  - ./cc-test-reporter after-build --coverage-input-type coverage.py --prefix tests --exit-code $TRAVIS_TEST_RESULT
     --debug
   - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ after_script:
   - pwd
   - ls -lath
   - cat .coverage
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - ./cc-test-reporter after-build --coverage-input-type coverage.py --exit-code $TRAVIS_TEST_RESULT --debug
   - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ after_script:
   - pwd
   - ls -lath
   - cat .coverage
+  - mv tests/coverage.xml coverage.xml
   - ./cc-test-reporter after-build --coverage-input-type coverage.py --prefix tests --exit-code $TRAVIS_TEST_RESULT
     --debug $PWD/tests/coverage.xml
 #  - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,20 @@ script:
   - cp dataactcore/config_example.yml dataactcore/config.yml
   - cp dataactcore/local_config_example.yml dataactcore/local_config.yml
   - cp dataactcore/local_secrets_example.yml dataactcore/local_secrets.yml
+  - pwd
+  - ls -lathr
   - |
     docker-compose run --rm dataact-broker \
       /bin/sh -c " \
       cd ./dataactcore; sleep 9s; alembic upgrade head; \
       cd ../; flake8 && \
-      py.test --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml"
-  - docker-compose down
+      py.test --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml; \
+      ls -lathr"
+
 
 after_script:
+  - ls -lathr
+  - ls /
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: required
 
+language: python
+
+python:
+  - '3.5'
+
 services:
   - docker
 
@@ -12,25 +17,16 @@ script:
   - cp dataactcore/config_example.yml dataactcore/config.yml
   - cp dataactcore/local_config_example.yml dataactcore/local_config.yml
   - cp dataactcore/local_secrets_example.yml dataactcore/local_secrets.yml
-  - pwd
-  - ls -lath
-  - echo 'hi' > tests/coverage.xml
-  - echo 'hello' > .coverage
-#  - |
-#    docker-compose run --rm dataact-broker \
-#      /bin/sh -c " \
-#      cd ./dataactcore; sleep 9s; alembic upgrade head; \
-#      cd ../; flake8 && echo 'hi' > tests/coverage.xml && echo 'hello' > .coverage && \
-#      #py.test --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml; \
-#      ls -lath"
+  - |
+    docker-compose run --rm dataact-broker \
+      /bin/sh -c " \
+      cd ./dataactcore; sleep 9s; alembic upgrade head; \
+      cd ../; flake8 && \
+      py.test --cov=. --cov-report term --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml"
 
 
 after_script:
-  - pwd
-  - ls -lath
-  - cat .coverage
   - mv tests/coverage.xml coverage.xml
-  - ./cc-test-reporter after-build --coverage-input-type coverage.py --prefix tests --exit-code $TRAVIS_TEST_RESULT
-    --debug
-#  - docker-compose down
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - docker-compose down
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,9 @@ script:
       cd ./dataactcore; sleep 9s; alembic upgrade head; \
       cd ../; flake8 && \
       py.test --cov=. --cov-report term --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml"
+  - docker-compose down
 
 
 after_script:
   - mv tests/coverage.xml coverage.xml
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-  - docker-compose down
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ after_script:
   - cat .coverage
   - mv tests/coverage.xml coverage.xml
   - ./cc-test-reporter after-build --coverage-input-type coverage.py --prefix tests --exit-code $TRAVIS_TEST_RESULT
-    --debug $PWD/tests/coverage.xml
+    --debug
 #  - docker-compose down
 


### PR DESCRIPTION
**High level description:**
Change the travis and code climate configuration to report code coverage stats to code climate for this repo

**Technical details:**
- Use the recommended Go executable script `cc-test-reporter`
- Configure an env var in the travis build to contain the test reporter ID from code climate
        - `cc-test-reporter` requires env var `CC_TEST_REPORTER_ID` with the value from https://codeclimate.com/repos/5723cb9f3efe1c693e002919/settings/test_reporter
- Have it pick up the generated `coverage.xml` file and report its stats to code climate
        - Needs to be moved to the root dir before reporting

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- N/A ~Frontend impact assessment completed~