### PR TITLE
DEV-2308: Office backfill updates

### DIFF
--- a/dataactcore/scripts/raw_sql/backfill_funding_agency_data_q12019.sql
+++ b/dataactcore/scripts/raw_sql/backfill_funding_agency_data_q12019.sql
@@ -1,0 +1,35 @@
+WITH agency_list AS
+	(SELECT (CASE WHEN sta.is_frec
+                THEN frec.frec_code
+                ELSE cgac.cgac_code
+                END) AS agency_code,
+        (CASE WHEN sta.is_frec
+            THEN frec.agency_name
+            ELSE cgac.agency_name
+            END) AS agency_name,
+        sta.sub_tier_agency_code AS sub_tier_code,
+        sta.sub_tier_agency_name AS sub_tier_name
+    FROM sub_tier_agency AS sta
+        INNER JOIN cgac
+            ON cgac.cgac_id = sta.cgac_id
+        INNER JOIN frec
+            ON frec.frec_id = sta.frec_id),
+office_list AS
+	(SELECT office.office_code,
+		agency_list.agency_code,
+		agency_list.agency_name,
+		agency_list.sub_tier_code,
+        agency_list.sub_tier_name
+    FROM office
+    	INNER JOIN agency_list
+    		ON agency_list.sub_tier_code = office.sub_tier_code)
+UPDATE published_award_financial_assistance AS pafa
+SET funding_sub_tier_agency_co = office_list.sub_tier_code,
+	funding_sub_tier_agency_na = office_list.sub_tier_name,
+	funding_agency_code = office_list.agency_code,
+	funding_agency_name = office_list.agency_name
+FROM office_list
+WHERE pafa.funding_office_code = office_list.office_code
+    AND cast_as_date(pafa.action_date) >= '2018/10/01'
+    AND pafa.funding_sub_tier_agency_co IS NULL
+    AND pafa.funding_office_code IS NOT NULL;

--- a/dataactcore/scripts/raw_sql/backfill_funding_agency_data_q12019.sql
+++ b/dataactcore/scripts/raw_sql/backfill_funding_agency_data_q12019.sql
@@ -1,5 +1,5 @@
 WITH agency_list AS
-	(SELECT (CASE WHEN sta.is_frec
+    (SELECT (CASE WHEN sta.is_frec
                 THEN frec.frec_code
                 ELSE cgac.cgac_code
                 END) AS agency_code,
@@ -15,19 +15,19 @@ WITH agency_list AS
         INNER JOIN frec
             ON frec.frec_id = sta.frec_id),
 office_list AS
-	(SELECT office.office_code,
-		agency_list.agency_code,
-		agency_list.agency_name,
-		agency_list.sub_tier_code,
+    (SELECT office.office_code,
+        agency_list.agency_code,
+        agency_list.agency_name,
+        agency_list.sub_tier_code,
         agency_list.sub_tier_name
     FROM office
-    	INNER JOIN agency_list
-    		ON agency_list.sub_tier_code = office.sub_tier_code)
+        INNER JOIN agency_list
+            ON agency_list.sub_tier_code = office.sub_tier_code)
 UPDATE published_award_financial_assistance AS pafa
 SET funding_sub_tier_agency_co = office_list.sub_tier_code,
-	funding_sub_tier_agency_na = office_list.sub_tier_name,
-	funding_agency_code = office_list.agency_code,
-	funding_agency_name = office_list.agency_name
+    funding_sub_tier_agency_na = office_list.sub_tier_name,
+    funding_agency_code = office_list.agency_code,
+    funding_agency_name = office_list.agency_name
 FROM office_list
 WHERE pafa.funding_office_code = office_list.office_code
     AND cast_as_date(pafa.action_date) >= '2018/10/01'


### PR DESCRIPTION
**High level description:**
Creating SQL for backfilling funding agency data based on office code

**Technical details:**
Adding new SQL to update funding sub tier name/code and funding top tier name/code based on office codes starting 10/1/18. The choice was made to make a new script rather than update the original because the original is still needed but some of the offices were filled in already in the first run of the scripts so we would be missing some of the filling that needs to happen if we just used the existing ones.

**Link to JIRA Ticket:**
[DEV-2308](https://federal-spending-transparency.atlassian.net/browse/DEV-2308)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed