### PR TITLE
Hotfix: Federal Hierarchy Office Type Renaming - Production

### DIFF
--- a/dataactcore/scripts/load_federal_hierarchy.py
+++ b/dataactcore/scripts/load_federal_hierarchy.py
@@ -140,6 +140,8 @@ def pull_offices(sess, filename, update_db, pull_all, updated_date_from, export_
 
                         for off_type in org.get('fhorgofficetypelist', []):
                             office_type = off_type['officetype'].lower()
+                            if office_type == 'financial assistance':
+                                office_type = 'grant'
                             if office_type in ['contracting', 'funding', 'grant']:
                                 setattr(new_office, office_type + '_office', True)
 


### PR DESCRIPTION
**High level description:**
Federal Hierarchy source renamed the office type `grant` to `financial assistance` unannounced. This is a bandaid fix and a more indepth PR to update the office model should be made soon.

**Technical details:**
(n/a)

**Link to JIRA Ticket:**
[DEV-2485](https://federal-spending-transparency.atlassian.net/browse/DEV-2485)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed