### PR TITLE
Excluding the tests/ directory from test coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,8 @@ python_files=test_*.py *_test.py *_tests.py *Tests.py
 [flake8]
 exclude=dataactcore/migrations/versions
 max-line-length=120
+
+[coverage:run]
+omit =
+    # tests themselves don't need coverage measurements
+    tests/*


### PR DESCRIPTION
**High level description:**
Current coverage is factoring in unit test code too. We should only measure coverage of code to be used in or supporting production.

**Technical details:**
* Leverage the [pytest coverage plugins pickup of `setup.cfg`](https://pytest-cov.readthedocs.io/en/latest/config.html)
* And put the [`omit` config section under `[coverage:run]`](https://coverage.readthedocs.io/en/latest/config.html#configuration-reference) in there to indicate [to exclude](https://coverage.readthedocs.io/en/latest/source.html#source) `tests/*` from coverage

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- `N/A` ~Merged concurrently with Frontend~
- `N/A` ~Unit & integration tests updated with relevant test cases~
- `N/A` ~Frontend impact assessment completed~