### PR TITLE
Speeding up c11 SQL

### DIFF
--- a/dataactvalidator/config/sqlrules/c11_cross_file.sql
+++ b/dataactvalidator/config/sqlrules/c11_cross_file.sql
@@ -14,7 +14,29 @@ award_procurement_c11_{0} AS
     (SELECT piid,
         parent_award_id
     FROM award_procurement
-    WHERE submission_id = {0})
+    WHERE submission_id = {0}),
+-- perform a union so we can have both of these conditions checked without using an OR
+unioned_financial_procurement_c11_{0} AS
+    (SELECT piid,
+        parent_award_id
+    FROM award_financial_c11_{0} AS af1
+    WHERE af1.parent_award_id IS NULL
+        AND NOT EXISTS (
+            SELECT 1
+            FROM award_procurement_c11_{0} AS ap
+            WHERE ap.piid = af1.piid
+        )
+    UNION
+    SELECT piid,
+        parent_award_id
+    FROM award_financial_c11_{0} AS af2
+    WHERE af2.parent_award_id IS NOT NULL
+        AND NOT EXISTS (
+            SELECT 1
+            FROM award_procurement_c11_{0} AS ap
+            WHERE ap.piid = af2.piid
+                AND COALESCE(ap.parent_award_id, '') = COALESCE(af2.parent_award_id, '')
+        ))
 SELECT
     af.row_number,
     af.piid,
@@ -27,19 +49,11 @@ WHERE af.transaction_obligated_amou IS NOT NULL
             AND af.allocation_transfer_agency = af.agency_identifier
         )
     )
-    AND ((af.parent_award_id IS NULL
-            AND NOT EXISTS (
-              SELECT 1
-              FROM award_procurement_c11_{0} AS ap
-              WHERE ap.piid = af.piid
-            )
-        )
-         OR (af.parent_award_id IS NOT NULL
-             AND NOT EXISTS (
-                 SELECT 1
-                 FROM award_procurement_c11_{0} AS ap
-                 WHERE ap.piid = af.piid
-                     AND COALESCE(ap.parent_award_id, '') = COALESCE(af.parent_award_id, '')
-             )
-         )
+    -- check the results of the union. We can do this coalesce because the piid and parent_award_id returned are both
+    -- from award_financial to begin with so it's won't break anything to join on them
+    AND EXISTS (
+        SELECT 1
+        FROM unioned_financial_procurement_c11_{0} AS ufc
+        WHERE af.piid = ufc.piid
+            AND COALESCE(af.parent_award_id, '') = COALESCE(ufc.parent_award_id, '')
     );


### PR DESCRIPTION
**High level description:**
Speeding up C11 SQL

**Technical details:**
Using a UNION instead of an OR on 2 EXISTS statements

**Link to JIRA Ticket:**
[DEV-2513](https://federal-spending-transparency.atlassian.net/browse/DEV-2513)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed