### PR TITLE
Ops/usps zipcodes

### DIFF
--- a/dataactvalidator/scripts/load_usps_files.py
+++ b/dataactvalidator/scripts/load_usps_files.py
@@ -54,7 +54,7 @@ def get_file_info(sess, download_list_response_body):
     last_load_date_obj = sess.query(ExternalDataLoadDate).\
         filter_by(external_data_type_id=EXTERNAL_DATA_TYPE_DICT['usps_download']).first()
 
-    fulfilled_date = datetime.strptime(latest_file['fulfilled'], '%Y-%m-%d').date()
+    fulfilled_date = datetime.strptime(latest_file['fulfilled'], '%Y-%m-%d')
 
     if last_load_date_obj and last_load_date_obj.last_load_date >= fulfilled_date:
         # if there is a last load date, check it against the latest file's fulfilled date
@@ -62,7 +62,7 @@ def get_file_info(sess, download_list_response_body):
         logger.info('Latest file already loaded. No further action will be taken. Exiting...')
         sys.exit(3)
 
-    return latest_file['fileid'], fulfilled_date, last_load_date_obj
+    return latest_file['fileid'], fulfilled_date.date(), last_load_date_obj
 
 
 def get_payload_string(obj_request_body):

--- a/tests/unit/dataactvalidator/test_load_usps_files.py
+++ b/tests/unit/dataactvalidator/test_load_usps_files.py
@@ -57,7 +57,7 @@ def test_get_file_info():
     """
 
     # Create test external data load date
-    last_load_date = datetime.strptime('1700-01-01', '%Y-%m-%d').date()
+    last_load_date = datetime.strptime('1700-01-01', '%Y-%m-%d')
     test_external_data_load_date = ExternalDataLoadDate(external_data_load_date_id=-1, last_load_date=last_load_date,
                                                         external_data_type_id=EXTERNAL_DATA_TYPE_DICT['usps_download'])
 
@@ -86,7 +86,7 @@ def _assert_system_exit(expected_code, f, *args):
 
 def test_exit_code_3():
     # Create test external data load date
-    last_load_date = datetime.strptime('2013-01-01', '%Y-%m-%d').date()
+    last_load_date = datetime.strptime('2013-01-01', '%Y-%m-%d')
     test_external_data_load_date = ExternalDataLoadDate(external_data_load_date_id=-1, last_load_date=last_load_date,
                                                         external_data_type_id=EXTERNAL_DATA_TYPE_DICT['usps_download'])
 


### PR DESCRIPTION
**High level description:**
The Broker-USPS-ZipCodes-Offices job is failing because of a date comparison of different formats  in data-act-broker-backend/dataactvalidator/scripts/load_usps_files.py

**Technical details:**
The existing code was comparing different dates formats YYYY-MM-DD HH:MM:SS with YYYY-MM-DD.
Changed  to have a valid comparison with same format YYYY-MM-DD HH:MM:SS

**Link to JIRA Ticket:**
[OPS-179](https://federal-spending-transparency.atlassian.net/browse/OPS-179)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed