### PR TITLE
DEV-2339: sql account for nulls

### DIFF
--- a/dataactvalidator/config/sqlrules/a10_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a10_appropriations.sql
@@ -20,4 +20,4 @@ FROM appropriation_a10_{0} AS approp
 WHERE sf.line IN (1340, 1440)
 GROUP BY approp.row_number,
     approp.borrowing_authority_amount_cpe
-HAVING approp.borrowing_authority_amount_cpe <> SUM(sf.amount);
+HAVING COALESCE(approp.borrowing_authority_amount_cpe, 0) <> SUM(sf.amount);

--- a/dataactvalidator/config/sqlrules/a11_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a11_appropriations.sql
@@ -20,4 +20,4 @@ FROM appropriation_a11_{0} AS approp
 WHERE sf.line IN (1750, 1850)
 GROUP BY approp.row_number,
     approp.spending_authority_from_of_cpe
-HAVING approp.spending_authority_from_of_cpe <> SUM(sf.amount);
+HAVING COALESCE(approp.spending_authority_from_of_cpe, 0) <> SUM(sf.amount);

--- a/dataactvalidator/config/sqlrules/a7_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a7_appropriations.sql
@@ -18,4 +18,4 @@ FROM appropriation_a7_{0} AS approp
         AND sf.period = sub.reporting_fiscal_period
         AND sf.fiscal_year = sub.reporting_fiscal_year
 WHERE sf.line = 1000
-    AND approp.budget_authority_unobligat_fyb <> sf.amount;
+    AND COALESCE(approp.budget_authority_unobligat_fyb, 0) <> sf.amount;

--- a/dataactvalidator/config/sqlrules/a9_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a9_appropriations.sql
@@ -20,4 +20,4 @@ FROM appropriation_a9_{0} AS approp
 WHERE sf.line IN (1540, 1640)
 GROUP BY approp.row_number,
     approp.contract_authority_amount_cpe
-HAVING approp.contract_authority_amount_cpe <> SUM(sf.amount);
+HAVING COALESCE(approp.contract_authority_amount_cpe, 0) <> SUM(sf.amount);

--- a/tests/unit/dataactvalidator/test_a10_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a10_appropriations.py
@@ -6,37 +6,33 @@ from tests.unit.dataactvalidator.utils import number_of_errors
 _FILE = 'a10_appropriations'
 _TAS = 'a10_appropriations_tas'
 
-# @todo: that a10 sql joins to a submission on particular values which aren't
-# being set up here?
-
 
 def test_success(database):
-    """ Tests that SF 133 amount sum for lines 1340, 1440 matches Appropriation borrowing_authority_amount_cpe
-        for the specified fiscal year and period """
-    tas = "".join([_TAS, "_success"])
+    """ Tests that SF 133 amount sum for lines 1340, 1440 matches Appropriation borrowing_authority_amount_cpe for the
+        specified fiscal year and period
+    """
+    tas_1 = "".join([_TAS, "_success"])
+    tas_2 = "".join([_TAS, "_success_2"])
 
-    sf_1 = SF133Factory(line=1340, tas=tas, period=1, fiscal_year=2016,
-                        amount=1)
-    sf_2 = SF133Factory(line=1440, tas=tas, period=1, fiscal_year=2016,
-                        amount=1)
-    ap = AppropriationFactory(tas=tas, borrowing_authority_amount_cpe=2)
+    sf_1 = SF133Factory(line=1340, tas=tas_1, period=1, fiscal_year=2016, amount=1)
+    sf_2 = SF133Factory(line=1440, tas=tas_1, period=1, fiscal_year=2016, amount=1)
+    sf_3 = SF133Factory(line=1340, tas=tas_2, period=1, fiscal_year=2016, amount=0)
+    sf_4 = SF133Factory(line=1440, tas=tas_2, period=1, fiscal_year=2016, amount=0)
+    ap_1 = AppropriationFactory(tas=tas_1, borrowing_authority_amount_cpe=2)
+    ap_2 = AppropriationFactory(tas=tas_2, borrowing_authority_amount_cpe=None)
 
-    models = [sf_1, sf_2, ap]
-
-    assert number_of_errors(_FILE, database, models=models) == 0
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, sf_3, sf_4, ap_1, ap_2]) == 0
 
 
 def test_failure(database):
     """ Tests that SF 133 amount sum for lines 1340, 1440 does not match Appropriation borrowing_authority_amount_cpe
-        for the specified fiscal year and period """
+        for the specified fiscal year and period
+    """
     tas = "".join([_TAS, "_failure"])
 
-    sf_1 = SF133Factory(line=1340, tas=tas, period=1, fiscal_year=2016,
-                        amount=1)
-    sf_2 = SF133Factory(line=1440, tas=tas, period=1, fiscal_year=2016,
-                        amount=1)
-    ap = AppropriationFactory(tas=tas, borrowing_authority_amount_cpe=1)
+    sf_1 = SF133Factory(line=1340, tas=tas, period=1, fiscal_year=2016, amount=1)
+    sf_2 = SF133Factory(line=1440, tas=tas, period=1, fiscal_year=2016, amount=1)
+    ap_1 = AppropriationFactory(tas=tas, borrowing_authority_amount_cpe=1)
+    ap_2 = AppropriationFactory(tas=tas, borrowing_authority_amount_cpe=None)
 
-    models = [sf_1, sf_2, ap]
-
-    assert number_of_errors(_FILE, database, models=models) == 1
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap_1, ap_2]) == 2

--- a/tests/unit/dataactvalidator/test_a11_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a11_appropriations.py
@@ -8,32 +8,37 @@ _TAS = 'a11_appropriations_tas'
 
 
 def test_success(database):
-    """ Tests that SF 133 amount sum for lines 1750, 1850 matches Appropriation spending_authority_from_of_cpe
-        for the specified fiscal year and period """
-    tas = "".join([_TAS, "_success"])
+    """ Tests that SF 133 amount sum for lines 1750, 1850 matches Appropriation spending_authority_from_of_cpe for the
+        specified fiscal year and period
+    """
+    tas_1 = "".join([_TAS, "_success"])
+    tas_2 = "".join([_TAS, "_success_2"])
 
-    sf_1 = SF133(line=1750, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
+    sf_1 = SF133(line=1750, tas=tas_1, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                  main_account_code="000", sub_account_code="000")
-    sf_2 = SF133(line=1850, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
+    sf_2 = SF133(line=1850, tas=tas_1, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                  main_account_code="000", sub_account_code="000")
-    ap = Appropriation(job_id=1, row_number=1, tas=tas, spending_authority_from_of_cpe=2)
+    sf_3 = SF133(line=1750, tas=tas_2, period=1, fiscal_year=2016, amount=0, agency_identifier="sys",
+                 main_account_code="000", sub_account_code="000")
+    sf_4 = SF133(line=1850, tas=tas_2, period=1, fiscal_year=2016, amount=0, agency_identifier="sys",
+                 main_account_code="000", sub_account_code="000")
+    ap_1 = Appropriation(job_id=1, row_number=1, tas=tas_1, spending_authority_from_of_cpe=2)
+    ap_2 = Appropriation(job_id=2, row_number=1, tas=tas_2, spending_authority_from_of_cpe=None)
 
-    models = [sf_1, sf_2, ap]
-
-    assert number_of_errors(_FILE, database, models=models) == 0
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, sf_3, sf_4, ap_1, ap_2]) == 0
 
 
 def test_failure(database):
     """ Tests that SF 133 amount sum for lines 1750, 1850 does not match Appropriation spending_authority_from_of_cpe
-        for the specified fiscal year and period """
+        for the specified fiscal year and period
+    """
     tas = "".join([_TAS, "_failure"])
 
     sf_1 = SF133(line=1750, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                  main_account_code="000", sub_account_code="000")
     sf_2 = SF133(line=1850, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                  main_account_code="000", sub_account_code="000")
-    ap = Appropriation(job_id=1, row_number=1, tas=tas, spending_authority_from_of_cpe=1)
+    ap_1 = Appropriation(job_id=1, row_number=1, tas=tas, spending_authority_from_of_cpe=1)
+    ap_2 = Appropriation(job_id=1, row_number=1, tas=tas, spending_authority_from_of_cpe=None)
 
-    models = [sf_1, sf_2, ap]
-
-    assert number_of_errors(_FILE, database, models=models) == 1
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap_1, ap_2]) == 2

--- a/tests/unit/dataactvalidator/test_a7_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a7_appropriations.py
@@ -18,7 +18,7 @@ def test_success(database):
     sf_2 = SF133(line=1000, tas=tas_2, period=1, fiscal_year=2016, amount=0, agency_identifier="sys",
                  main_account_code="000", sub_account_code="000")
     ap_1 = Appropriation(job_id=1, row_number=1, tas=tas_1, budget_authority_unobligat_fyb=1)
-    ap_2 = Appropriation(job_id=1, row_number=1, tas=tas_2, budget_authority_unobligat_fyb=None)
+    ap_2 = Appropriation(job_id=2, row_number=1, tas=tas_2, budget_authority_unobligat_fyb=None)
 
     assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap_1, ap_2]) == 0
 
@@ -31,6 +31,6 @@ def test_failure(database):
     sf = SF133(line=1000, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                main_account_code="000", sub_account_code="000")
     ap_1 = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_unobligat_fyb=0)
-    ap_2 = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_unobligat_fyb=None)
+    ap_2 = Appropriation(job_id=2, row_number=1, tas=tas, budget_authority_unobligat_fyb=None)
 
     assert number_of_errors(_FILE, database, models=[sf, ap_1, ap_2]) == 2

--- a/tests/unit/dataactvalidator/test_a7_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a7_appropriations.py
@@ -10,13 +10,17 @@ _TAS = 'a7_appropriations_tas'
 def test_success(database):
     """ Tests that SF 133 amount for line 1000 matches Appropriation budget_authority_unobligat_fyb
         for the specified fiscal year and period """
-    tas = "".join([_TAS, "_success"])
+    tas_1 = "".join([_TAS, "_success"])
+    tas_2 = "".join([_TAS, "_success_2"])
 
-    sf = SF133(line=1000, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
-    ap = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_unobligat_fyb=1)
+    sf_1 = SF133(line=1000, tas=tas_1, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
+                 main_account_code="000", sub_account_code="000")
+    sf_2 = SF133(line=1000, tas=tas_2, period=1, fiscal_year=2016, amount=0, agency_identifier="sys",
+                 main_account_code="000", sub_account_code="000")
+    ap_1 = Appropriation(job_id=1, row_number=1, tas=tas_1, budget_authority_unobligat_fyb=1)
+    ap_2 = Appropriation(job_id=1, row_number=1, tas=tas_2, budget_authority_unobligat_fyb=None)
 
-    assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap_1, ap_2]) == 0
 
 
 def test_failure(database):
@@ -26,6 +30,7 @@ def test_failure(database):
 
     sf = SF133(line=1000, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                main_account_code="000", sub_account_code="000")
-    ap = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_unobligat_fyb=0)
+    ap_1 = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_unobligat_fyb=0)
+    ap_2 = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_unobligat_fyb=None)
 
-    assert number_of_errors(_FILE, database, models=[sf, ap]) == 1
+    assert number_of_errors(_FILE, database, models=[sf, ap_1, ap_2]) == 2

--- a/tests/unit/dataactvalidator/test_a7_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a7_appropriations.py
@@ -8,8 +8,9 @@ _TAS = 'a7_appropriations_tas'
 
 
 def test_success(database):
-    """ Tests that SF 133 amount for line 1000 matches Appropriation budget_authority_unobligat_fyb
-        for the specified fiscal year and period """
+    """ Tests that SF 133 amount for line 1000 matches Appropriation budget_authority_unobligat_fyb for the specified
+        fiscal year and period
+    """
     tas_1 = "".join([_TAS, "_success"])
     tas_2 = "".join([_TAS, "_success_2"])
 
@@ -24,8 +25,9 @@ def test_success(database):
 
 
 def test_failure(database):
-    """ Tests that SF 133 amount for line 1000 does not match Appropriation budget_authority_unobligat_fyb
-        for the specified fiscal year and period """
+    """ Tests that SF 133 amount for line 1000 does not match Appropriation budget_authority_unobligat_fyb for the
+        specified fiscal year and period
+    """
     tas = "".join([_TAS, "_failure"])
 
     sf = SF133(line=1000, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",

--- a/tests/unit/dataactvalidator/test_a9_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a9_appropriations.py
@@ -8,8 +8,9 @@ _TAS = 'a9_appropriations_tas'
 
 
 def test_success(database):
-    """ Tests that SF 133 amount sum for lines 1540, 1640 matches Appropriation contract_authority_amount_cpe
-        for the specified fiscal year and period """
+    """ Tests that SF 133 amount sum for lines 1540, 1640 matches Appropriation contract_authority_amount_cpe for the
+        specified fiscal year and period
+    """
     tas_1 = "".join([_TAS, "_success"])
     tas_2 = "".join([_TAS, "_success_2"])
 
@@ -28,8 +29,9 @@ def test_success(database):
 
 
 def test_failure(database):
-    """ Tests that SF 133 amount sum for lines 1540, 1640 does not match Appropriation contract_authority_amount_cpe
-        for the specified fiscal year and period """
+    """ Tests that SF 133 amount sum for lines 1540, 1640 does not match Appropriation contract_authority_amount_cpe for
+        the specified fiscal year and period
+    """
     tas = "".join([_TAS, "_failure"])
 
     sf_1 = SF133(line=1540, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",

--- a/tests/unit/dataactvalidator/test_a9_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a9_appropriations.py
@@ -10,17 +10,21 @@ _TAS = 'a9_appropriations_tas'
 def test_success(database):
     """ Tests that SF 133 amount sum for lines 1540, 1640 matches Appropriation contract_authority_amount_cpe
         for the specified fiscal year and period """
-    tas = "".join([_TAS, "_success"])
+    tas_1 = "".join([_TAS, "_success"])
+    tas_2 = "".join([_TAS, "_success_2"])
 
-    sf_1 = SF133(line=1540, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
+    sf_1 = SF133(line=1540, tas=tas_1, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                  main_account_code="000", sub_account_code="000")
-    sf_2 = SF133(line=1640, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
+    sf_2 = SF133(line=1640, tas=tas_1, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                  main_account_code="000", sub_account_code="000")
-    ap = Appropriation(job_id=1, row_number=1, tas=tas, contract_authority_amount_cpe=2)
+    sf_3 = SF133(line=1540, tas=tas_2, period=1, fiscal_year=2016, amount=0, agency_identifier="sys",
+                 main_account_code="000", sub_account_code="000")
+    sf_4 = SF133(line=1640, tas=tas_2, period=1, fiscal_year=2016, amount=0, agency_identifier="sys",
+                 main_account_code="000", sub_account_code="000")
+    ap_1 = Appropriation(job_id=1, row_number=1, tas=tas_1, contract_authority_amount_cpe=2)
+    ap_2 = Appropriation(job_id=2, row_number=1, tas=tas_2, contract_authority_amount_cpe=None)
 
-    models = [sf_1, sf_2, ap]
-
-    assert number_of_errors(_FILE, database, models=models) == 0
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, sf_3, sf_4, ap_1, ap_2]) == 0
 
 
 def test_failure(database):
@@ -32,8 +36,7 @@ def test_failure(database):
                  main_account_code="000", sub_account_code="000")
     sf_2 = SF133(line=1640, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                  main_account_code="000", sub_account_code="000")
-    ap = Appropriation(job_id=1, row_number=1, tas=tas, contract_authority_amount_cpe=1)
+    ap_1 = Appropriation(job_id=1, row_number=1, tas=tas, contract_authority_amount_cpe=1)
+    ap_2 = Appropriation(job_id=2, row_number=1, tas=tas, contract_authority_amount_cpe=None)
 
-    models = [sf_1, sf_2, ap]
-
-    assert number_of_errors(_FILE, database, models=models) == 1
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap_1, ap_2]) == 2


### PR DESCRIPTION
**High level description:**
Account for NULLs in A rules

**Technical details:**
Several other rules don't fire off when a NULL is in one of the monetary value columns despite that being considered a 0. Counting NULL as a 0 where relevant now.

**Link to JIRA Ticket:**
[DEV-2339](https://federal-spending-transparency.atlassian.net/browse/DEV-2339)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed