### PR TITLE
add supervisor to server reqs, remove legacy file

### DIFF
--- a/legacy_requirements.txt
+++ b/legacy_requirements.txt
@@ -1,1 +1,0 @@
-supervisor==3.2.2

--- a/server_requirements.txt
+++ b/server_requirements.txt
@@ -1,1 +1,2 @@
+supervisor==4.0.2
 uwsgi==2.0.17


### PR DESCRIPTION
During the deploy process (see https://github.com/fedspendingtransparency/data-act-build-tools/pull/198) we use Python 2 to support an old version of supervisor. This upgrades that by moving it into the reqs file used w/Python 3, `server_requirements.txt`.

The conditional check will happen with the next deployment. Supervisord 4.0.2 is currently running in sandbox.