### PR TITLE
Update container name in Install guide

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -139,7 +139,7 @@ _:bulb: TIP: Many of the commands below use the format `docker exec -it dataact-
 
 **Create a User**
 ```bash
-$ docker exec -it dataact-broker-backend python dataactcore/scripts/initialize.py -a
+$ docker exec -it dataact-broker python dataactcore/scripts/initialize.py -a
 ```
 This creates a local admin user that you can use to log in. The Broker utilizes MAX.gov for login when using a remote server, but we cannot recieve their response locally so we use a username and password for local development login. The credentials for the user created are the values you have configured in the `db.admin_email` and `db.admin_password` config params in `config.yml` or overridden in `local_config.yml`.
 
@@ -147,7 +147,7 @@ Now try to browse to http://localhost:3000, and login with the configured creden
 
 **Initialize Database**
 ```bash
-$ docker exec -it dataact-broker-backend python dataactcore/scripts/initialize.py -i
+$ docker exec -it dataact-broker python dataactcore/scripts/initialize.py -i
 ```
 This loads the information needed to validate data submissions: schemas, rules, and reference data such as object classes and account codes. You can view what each function does [here](https://github.com/fedspendingtransparency/data-act-broker-backend/blob/master/dataactcore/scripts/initialize.py), but the functions called by `initialize.py -i` are as follows:
 
@@ -175,13 +175,13 @@ If instead, you want to match the production environment (and are a developer on
 
 Once you've placed those files, run:
 ```bash
-$ docker exec -it dataact-broker-backend python dataactvalidator/scripts/load_sf133.py
+$ docker exec -it dataact-broker python dataactvalidator/scripts/load_sf133.py
 ```
 
 This will only load the new SF133 entries. To force load from your files, you can add the `-f` or `--force` flag:
 
 ```bash
-$ docker exec -it dataact-broker-backend python dataactvalidator/scripts/load_sf133.py -f
+$ docker exec -it dataact-broker python dataactvalidator/scripts/load_sf133.py -f
 ```
 
 This will take several minutes to process.
@@ -196,7 +196,7 @@ Program Activity file location: `dataactvalidator/config/program_activity.csv`
 
 To load these files:
 ```bash
-$ docker exec -it dataact-broker-backend python dataactcore/scripts/initialize.py -d
+$ docker exec -it dataact-broker python dataactcore/scripts/initialize.py -d
 ```
 
 ### TAS data:
@@ -205,5 +205,5 @@ TAS file location: `dataactvalidator/config/cars_tas.csv`
 
 To load TAS data:
 ```bash
-$ docker exec -it dataact-broker-backend python dataactcore/scripts/initialize.py -t
+$ docker exec -it dataact-broker python dataactcore/scripts/initialize.py -t
 ```


### PR DESCRIPTION
In my experimentation, the backend container is just called dataact-broker, not dataact-broker-backed