### PR TITLE
DEV-2837: Hotfix FSRS loader Performance

### DIFF
--- a/dataactbroker/scripts/load_fsrs.py
+++ b/dataactbroker/scripts/load_fsrs.py
@@ -124,7 +124,7 @@ if __name__ == '__main__':
                     logger.error('Missing --procurement or --grants argument when loading specific award ids')
                 sys.exit(1)
 
-            # Populate subaward table off new ids
+            logger.info('Populating subaward table based off new data')
             new_procurements = (SERVICE_MODEL[PROCUREMENT].next_id(sess) > original_min_procurement_id)
             new_grants = (SERVICE_MODEL[GRANT].next_id(sess) > original_min_grant_id)
             proc_ids = list(set(updated_proc_internal_ids))

--- a/dataactbroker/scripts/load_fsrs.py
+++ b/dataactbroker/scripts/load_fsrs.py
@@ -72,10 +72,11 @@ if __name__ == '__main__':
             sys.exit(1)
         else:
             # Regular FSRS data load, starts where last load left off
-            updated_internal_ids = []
+            updated_proc_internal_ids = []
+            updated_grant_internal_ids = []
             original_min_procurement_id = SERVICE_MODEL[PROCUREMENT].next_id(sess)
             original_min_grant_id = SERVICE_MODEL[GRANT].next_id(sess)
-            last_updated_at = sess.query(func.max(Subaward.updated_at)).one_or_none()
+            last_updated_at = sess.query(func.max(Subaward.updated_at)).one_or_none()[0]
             if len(sys.argv) <= 1:
                 # there may be more transaction data since we've last run, let's fix any links before importing new data
                 if last_updated_at:
@@ -83,12 +84,14 @@ if __name__ == '__main__':
                     fix_broken_links(sess, GRANT, min_date=last_updated_at)
 
                 awards = ['Starting']
+                logger.info('Loading latest FSRS reports')
                 while len(awards) > 0:
                     procs = fetch_and_replace_batch(sess, PROCUREMENT, SERVICE_MODEL[PROCUREMENT].next_id(sess),
                                                     min_id=True)
                     grants = fetch_and_replace_batch(sess, GRANT, SERVICE_MODEL[GRANT].next_id(sess), min_id=True)
+                    updated_proc_internal_ids.extend([proc.internal_id for proc in procs])
+                    updated_grant_internal_ids.extend([grant.internal_id for grant in grants])
                     awards = procs + grants
-                    updated_internal_ids.extend([award.internal_id for award in awards])
                     log_fsrs_counts(awards)
                     metric_counts(procs, 'procurement', metrics_json)
                     metric_counts(grants, 'grant', metrics_json)
@@ -98,9 +101,9 @@ if __name__ == '__main__':
                     fix_broken_links(sess, PROCUREMENT, min_date=last_updated_at)
 
                 for procurement_id in args.ids:
-                    logger.info('Begin loading FSRS reports for procurement id {}'.format(procurement_id))
+                    logger.info('Loading FSRS reports for procurement id {}'.format(procurement_id))
                     procs = fetch_and_replace_batch(sess, PROCUREMENT, procurement_id)
-                    updated_internal_ids.extend([award.internal_id for award in procs])
+                    updated_proc_internal_ids.extend([proc.internal_id for proc in procs])
                     log_fsrs_counts(procs)
                     metric_counts(procs, 'procurement', metrics_json)
 
@@ -109,9 +112,9 @@ if __name__ == '__main__':
                     fix_broken_links(sess, GRANT, min_date=last_updated_at)
 
                 for grant_id in args.ids:
-                    logger.info('Begin loading FSRS reports for grant id {}'.format(grant_id))
+                    logger.info('Loading FSRS reports for grant id {}'.format(grant_id))
                     grants = fetch_and_replace_batch(sess, GRANT, grant_id)
-                    updated_internal_ids.extend([award.internal_id for award in grants])
+                    updated_grant_internal_ids.extend([grant.internal_id for grant in grants])
                     log_fsrs_counts(grants)
                     metric_counts(grants, 'grant', metrics_json)
             else:
@@ -121,17 +124,25 @@ if __name__ == '__main__':
                     logger.error('Missing --procurement or --grants argument when loading specific award ids')
                 sys.exit(1)
 
-            # Delete internal ids from subaward table
-            sess.query(Subaward.internal_id.in_(list(set(updated_internal_ids)))).delete()
-
             # Populate subaward table off new ids
+            new_procurements = (SERVICE_MODEL[PROCUREMENT].next_id(sess) > original_min_procurement_id)
+            new_grants = (SERVICE_MODEL[GRANT].next_id(sess) > original_min_grant_id)
+            proc_ids = list(set(updated_proc_internal_ids))
+            grant_ids = list(set(updated_grant_internal_ids))
+
             if len(sys.argv) <= 1:
-                populate_subaward_table(sess, 'procurements', min_id=original_min_procurement_id)
-                populate_subaward_table(sess, 'grants', min_id=original_min_grant_id)
-            elif args.procurement and args.ids:
-                populate_subaward_table(sess, 'procurements', ids=args.ids)
-            elif args.grants and args.ids:
-                populate_subaward_table(sess, 'grants', ids=args.ids)
+                if new_procurements:
+                    sess.query(Subaward).filter(Subaward.internal_id.in_(proc_ids)).delete(synchronize_session=False)
+                    populate_subaward_table(sess, PROCUREMENT, min_id=original_min_procurement_id)
+                if new_grants:
+                    sess.query(Subaward).filter(Subaward.internal_id.in_(grant_ids)).delete(synchronize_session=False)
+                    populate_subaward_table(sess, GRANT, min_id=original_min_grant_id)
+            elif args.procurement and new_procurements and args.ids:
+                sess.query(Subaward).filter(Subaward.internal_id.in_(proc_ids)).delete(synchronize_session=False)
+                populate_subaward_table(sess, PROCUREMENT, ids=args.ids)
+            elif args.grants and new_grants and args.ids:
+                sess.query(Subaward).filter(Subaward.internal_id.in_(grant_ids)).delete(synchronize_session=False)
+                populate_subaward_table(sess, GRANT, ids=args.ids)
 
         # Deletes state mapping variable
         config_state_mappings()

--- a/dataactcore/scripts/populate_subaward_table.py
+++ b/dataactcore/scripts/populate_subaward_table.py
@@ -76,7 +76,7 @@ def populate_subaward_table(sess, service_type, ids=None, min_id=None):
     return inserted_count
 
 
-def fix_broken_links(sess, service_type):
+def fix_broken_links(sess, service_type, min_date=None):
     """ Attempts to resolve any unlinked subawards given the current data
 
         Args:
@@ -92,6 +92,8 @@ def fix_broken_links(sess, service_type):
         raise Exception('Invalid service type provided: {}'.format(service_type))
 
     sql = extract_subaward_sql(service_type, 'link')
+    min_date_sql = '' if min_date is None else 'AND updated_at >= \'{}\''.format(min_date)
+    sql = sql.format(min_date_sql)
 
     # run the SQL
     updated = sess.execute(sql)

--- a/dataactcore/scripts/populate_subaward_table.py
+++ b/dataactcore/scripts/populate_subaward_table.py
@@ -62,7 +62,7 @@ def populate_subaward_table(sess, service_type, ids=None, min_id=None):
     sql = extract_subaward_sql(service_type, 'populate')
     if min_id is not None:
         operator = '>'
-        values = min_id
+        values = min_id - 1
     else:
         operator = 'IN'
         values = '({})'.format(','.join([str(id) for id in ids]))
@@ -72,7 +72,8 @@ def populate_subaward_table(sess, service_type, ids=None, min_id=None):
     inserted = sess.execute(sql)
     sess.commit()
     inserted_count = inserted.rowcount
-    logger.info('Inserted {} sub-{} to the subaward table'.format(inserted_count, service_type))
+    award_type = service_type[:service_type.index('_')]
+    logger.info('Inserted {} sub-{}s to the subaward table'.format(inserted_count, award_type))
     return inserted_count
 
 
@@ -86,7 +87,8 @@ def fix_broken_links(sess, service_type, min_date=None):
         Raises:
             Exception: service type is invalid
     """
-    # get the broken links to delete later
+    award_type = service_type[:service_type.index('_')]
+    logger.info('Attempting to fix broken sub-{} links in the subaward table'.format(award_type))
     subaward_type_map = {PROCUREMENT: 'sub-contract', GRANT: 'sub-grant'}
     if service_type not in subaward_type_map:
         raise Exception('Invalid service type provided: {}'.format(service_type))
@@ -100,7 +102,7 @@ def fix_broken_links(sess, service_type, min_date=None):
     sess.commit()
 
     updated_count = updated.rowcount
-    logger.info('Updated {} sub-{} in the subaward table'.format(updated_count, service_type))
+    logger.info('Updated {} sub-{}s in the subaward table'.format(updated_count, award_type))
     return updated_count
 
 

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
@@ -1,4 +1,16 @@
-WITH aw_dap AS
+WITH unlinked_subs AS
+    (
+        SELECT id,
+            prime_id,
+            sub_id,
+            award_id,
+            parent_award_id,
+            awarding_sub_tier_agency_c
+        FROM subaward
+        WHERE subaward.unique_award_key IS NULL
+            AND subaward.subaward_type = 'sub-contract'
+    )
+aw_dap AS
     (SELECT DISTINCT ON (
             dap.piid,
             dap.parent_award_id,
@@ -18,177 +30,26 @@ WITH aw_dap AS
     FROM detached_award_procurement AS dap
     WHERE EXISTS (
         SELECT 1
-        FROM fsrs_procurement
-        WHERE fsrs_procurement.contract_number = dap.piid
-            AND fsrs_procurement.idv_reference_number IS NOT DISTINCT FROM dap.parent_award_id
-            AND fsrs_procurement.contracting_office_aid = dap.awarding_sub_tier_agency_c
-    )
+        FROM unlinked_subs
+        WHERE unlinked_subs.award_id = dap.piid
+            AND unlinked_subs.parent_award_id IS NOT DISTINCT FROM dap.parent_award_id
+            AND unlinked_subs.awarding_sub_tier_agency_c = dap.awarding_sub_tier_agency_c
+        )
+        {0}
     ORDER BY dap.piid, dap.parent_award_id, dap.awarding_sub_tier_agency_c, dap.action_date
-    )
+    ),
 UPDATE subaward
 SET
     unique_award_key = aw_dap.unique_award_key,
-    award_id = fsrs_procurement.contract_number,
-    parent_award_id = fsrs_procurement.idv_reference_number,
-    award_amount = fsrs_procurement.dollar_obligated,
-    action_date = fsrs_procurement.date_signed,
-    fy = 'FY' || fy(fsrs_procurement.date_signed),
     awarding_agency_code = aw_dap.awarding_agency_code,
     awarding_agency_name = aw_dap.awarding_agency_name,
-    awarding_sub_tier_agency_c = fsrs_procurement.contracting_office_aid,
-    awarding_sub_tier_agency_n = fsrs_procurement.contracting_office_aname,
-    awarding_office_code = fsrs_procurement.contracting_office_id,
-    awarding_office_name = fsrs_procurement.contracting_office_name,
     funding_agency_code = aw_dap.funding_agency_code,
     funding_agency_name = aw_dap.funding_agency_name,
-    funding_sub_tier_agency_co = fsrs_procurement.funding_agency_id,
-    funding_sub_tier_agency_na = fsrs_procurement.funding_agency_name,
-    funding_office_code = fsrs_procurement.funding_office_id,
-    funding_office_name = fsrs_procurement.funding_office_name,
-    awardee_or_recipient_uniqu = fsrs_procurement.duns,
-    awardee_or_recipient_legal = fsrs_procurement.company_name,
-    dba_name = fsrs_procurement.dba_name,
-    ultimate_parent_unique_ide = fsrs_procurement.parent_duns,
-    ultimate_parent_legal_enti = fsrs_procurement.parent_company_name,
-    legal_entity_country_code = fsrs_procurement.company_address_country,
-    legal_entity_country_name = le_country.country_name,
-    legal_entity_address_line1 = fsrs_procurement.company_address_street,
-    legal_entity_city_name = fsrs_procurement.company_address_city,
-    legal_entity_state_code = fsrs_procurement.company_address_state,
-    legal_entity_state_name = fsrs_procurement.company_address_state_name,
-    legal_entity_zip = CASE WHEN fsrs_procurement.company_address_country = 'USA'
-                            THEN fsrs_procurement.company_address_zip
-                            ELSE NULL
-                       END,
-    legal_entity_congressional = fsrs_procurement.company_address_district,
-    legal_entity_foreign_posta = CASE WHEN fsrs_procurement.company_address_country <> 'USA'
-                                      THEN fsrs_procurement.company_address_zip
-                                      ELSE NULL
-                                 END,
-    business_types = fsrs_procurement.bus_types,
-    place_of_perform_city_name = fsrs_procurement.principle_place_city,
-    place_of_perform_state_code = fsrs_procurement.principle_place_state,
-    place_of_perform_state_name = fsrs_procurement.principle_place_state_name,
-    place_of_performance_zip = fsrs_procurement.principle_place_zip,
-    place_of_perform_congressio = fsrs_procurement.principle_place_district,
-    place_of_perform_country_co = fsrs_procurement.principle_place_country,
-    place_of_perform_country_na = ppop_country.country_name,
     award_description = aw_dap.award_description,
-    naics = fsrs_procurement.naics,
-    naics_description = aw_dap.naics_description,
-    cfda_numbers = NULL,
-    cfda_titles = NULL,
-
-    -- File F Subawards
-    subaward_type = 'sub-contract',
-    subaward_report_year = fsrs_procurement.report_period_year,
-    subaward_report_month = fsrs_procurement.report_period_mon,
-    subaward_number = fsrs_subcontract.subcontract_num,
-    subaward_amount = fsrs_subcontract.subcontract_amount,
-    sub_action_date = fsrs_subcontract.subcontract_date,
-    sub_awardee_or_recipient_uniqu = fsrs_subcontract.duns,
-    sub_awardee_or_recipient_legal = fsrs_subcontract.company_name,
-    sub_dba_name = fsrs_subcontract.dba_name,
-    sub_ultimate_parent_unique_ide = fsrs_subcontract.parent_duns,
-    sub_ultimate_parent_legal_enti = fsrs_subcontract.parent_company_name,
-    sub_legal_entity_country_code = fsrs_subcontract.company_address_country,
-    sub_legal_entity_country_name = sub_le_country.country_name,
-    sub_legal_entity_address_line1 = fsrs_subcontract.company_address_street,
-    sub_legal_entity_city_name = fsrs_subcontract.company_address_city,
-    sub_legal_entity_state_code = fsrs_subcontract.company_address_state,
-    sub_legal_entity_state_name = fsrs_subcontract.company_address_state_name,
-    sub_legal_entity_zip = CASE WHEN fsrs_subcontract.company_address_country = 'USA'
-                                THEN fsrs_subcontract.company_address_zip
-                                ELSE NULL
-                           END,
-    sub_legal_entity_congressional = fsrs_subcontract.company_address_district,
-    sub_legal_entity_foreign_posta = CASE WHEN fsrs_subcontract.company_address_country <> 'USA'
-                                          THEN fsrs_subcontract.company_address_zip
-                                          ELSE NULL
-                                     END,
-    sub_business_types = fsrs_subcontract.bus_types,
-    sub_place_of_perform_city_name = fsrs_subcontract.principle_place_city,
-    sub_place_of_perform_state_code = fsrs_subcontract.principle_place_state,
-    sub_place_of_perform_state_name = fsrs_subcontract.principle_place_state_name,
-    sub_place_of_performance_zip = fsrs_subcontract.principle_place_zip,
-    sub_place_of_perform_congressio = fsrs_subcontract.principle_place_district,
-    sub_place_of_perform_country_co = fsrs_subcontract.principle_place_country,
-    sub_place_of_perform_country_na = sub_ppop_country.country_name,
-    subaward_description = fsrs_subcontract.overall_description,
-    sub_high_comp_officer1_full_na = fsrs_subcontract.top_paid_fullname_1,
-    sub_high_comp_officer1_amount = fsrs_subcontract.top_paid_amount_1,
-    sub_high_comp_officer2_full_na = fsrs_subcontract.top_paid_fullname_2,
-    sub_high_comp_officer2_amount = fsrs_subcontract.top_paid_amount_2,
-    sub_high_comp_officer3_full_na = fsrs_subcontract.top_paid_fullname_3,
-    sub_high_comp_officer3_amount = fsrs_subcontract.top_paid_amount_3,
-    sub_high_comp_officer4_full_na = fsrs_subcontract.top_paid_fullname_4,
-    sub_high_comp_officer4_amount = fsrs_subcontract.top_paid_amount_4,
-    sub_high_comp_officer5_full_na = fsrs_subcontract.top_paid_fullname_5,
-    sub_high_comp_officer5_amount = fsrs_subcontract.top_paid_amount_5,
-
-    -- File F Prime Awards
-    prime_id = fsrs_procurement.id,
-    internal_id = fsrs_procurement.internal_id,
-    date_submitted = fsrs_procurement.date_submitted,
-    report_type = fsrs_procurement.report_type,
-    transaction_type = fsrs_procurement.transaction_type,
-    program_title = fsrs_procurement.program_title,
-    contract_agency_code = fsrs_procurement.contract_agency_code,
-    contract_idv_agency_code = fsrs_procurement.contract_idv_agency_code,
-    grant_funding_agency_id = NULL,
-    grant_funding_agency_name = NULL,
-    federal_agency_name = NULL,
-    treasury_symbol = fsrs_procurement.treasury_symbol,
-    dunsplus4 = NULL,
-    recovery_model_q1 = fsrs_procurement.recovery_model_q1,
-    recovery_model_q2 = fsrs_procurement.recovery_model_q2,
-    compensation_q1 = NULL,
-    compensation_q2 = NULL,
-    high_comp_officer1_full_na = fsrs_procurement.top_paid_fullname_1,
-    high_comp_officer1_amount = fsrs_procurement.top_paid_amount_1,
-    high_comp_officer2_full_na = fsrs_procurement.top_paid_fullname_2,
-    high_comp_officer2_amount = fsrs_procurement.top_paid_amount_2,
-    high_comp_officer3_full_na = fsrs_procurement.top_paid_fullname_3,
-    high_comp_officer3_amount = fsrs_procurement.top_paid_amount_3,
-    high_comp_officer4_full_na = fsrs_procurement.top_paid_fullname_4,
-    high_comp_officer4_amount = fsrs_procurement.top_paid_amount_4,
-    high_comp_officer5_full_na = fsrs_procurement.top_paid_fullname_5,
-    high_comp_officer5_amount = fsrs_procurement.top_paid_amount_5,
-
-    -- File F Subawards
-    sub_id = fsrs_subcontract.id,
-    sub_parent_id = fsrs_subcontract.parent_id,
-    sub_federal_agency_id = NULL,
-    sub_federal_agency_name = NULL,
-    sub_funding_agency_id = fsrs_subcontract.funding_agency_id,
-    sub_funding_agency_name = fsrs_subcontract.funding_agency_name,
-    sub_funding_office_id = fsrs_subcontract.funding_office_id,
-    sub_funding_office_name = fsrs_subcontract.funding_office_name,
-    sub_naics = fsrs_subcontract.naics,
-    sub_cfda_numbers = NULL,
-    sub_dunsplus4 = NULL,
-    sub_recovery_subcontract_amt = fsrs_subcontract.recovery_subcontract_amt,
-    sub_recovery_model_q1 = fsrs_subcontract.recovery_model_q1,
-    sub_recovery_model_q2 = fsrs_subcontract.recovery_model_q2,
-    sub_compensation_q1 = NULL,
-    sub_compensation_q2 = NULL,
-    "updated_at" = NOW()
-
-FROM fsrs_procurement
-    JOIN fsrs_subcontract
-        ON fsrs_subcontract.parent_id = fsrs_procurement.id
-    LEFT OUTER JOIN aw_dap
-        ON (fsrs_procurement.contract_number = aw_dap.piid
-        AND fsrs_procurement.idv_reference_number IS NOT DISTINCT FROM aw_dap.parent_award_id
-        AND fsrs_procurement.contracting_office_aid = aw_dap.awarding_sub_tier_agency_c)
-    LEFT OUTER JOIN country_code AS le_country
-        ON fsrs_procurement.company_address_country = le_country.country_code
-    LEFT OUTER JOIN country_code AS ppop_country
-        ON fsrs_procurement.principle_place_country = ppop_country.country_code
-    LEFT OUTER JOIN country_code AS sub_le_country
-        ON fsrs_subcontract.company_address_country = sub_le_country.country_code
-    LEFT OUTER JOIN country_code AS sub_ppop_country
-        ON fsrs_subcontract.principle_place_country = sub_ppop_country.country_code
-WHERE subaward.unique_award_key IS NULL
-    AND subaward.subaward_type = 'sub-contract'
-    AND subaward.prime_id = fsrs_procurement.id
+    naics_description = aw_dap.naics_description
+FROM unlinked_subs
+    JOIN aw_dap
+        ON (unlinked_subs.award_id = aw_dap.piid
+        AND unlinked_subs.parent_award_id IS NOT DISTINCT FROM aw_dap.parent_award_id
+        AND unlinked_subs.awarding_sub_tier_agency_c = aw_dap.awarding_sub_tier_agency_c)
+WHERE subaward.id = unlinked_subs.id;

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
@@ -9,7 +9,7 @@ WITH unlinked_subs AS
         FROM subaward
         WHERE subaward.unique_award_key IS NULL
             AND subaward.subaward_type = 'sub-contract'
-    )
+    ),
 aw_dap AS
     (SELECT DISTINCT ON (
             dap.piid,
@@ -37,7 +37,7 @@ aw_dap AS
         )
         {0}
     ORDER BY dap.piid, dap.parent_award_id, dap.awarding_sub_tier_agency_c, dap.action_date
-    ),
+    )
 UPDATE subaward
 SET
     unique_award_key = aw_dap.unique_award_key,

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
@@ -32,7 +32,7 @@ aw_dap AS
         SELECT 1
         FROM unlinked_subs
         WHERE unlinked_subs.award_id = dap.piid
-            AND unlinked_subs.parent_award_id IS NOT DISTINCT FROM dap.parent_award_id
+            AND COALESCE(unlinked_subs.parent_award_id, '') = COALESCE(dap.parent_award_id, '')
             AND unlinked_subs.awarding_sub_tier_agency_c = dap.awarding_sub_tier_agency_c
         )
         {0}
@@ -50,6 +50,6 @@ SET
 FROM unlinked_subs
     JOIN aw_dap
         ON (unlinked_subs.award_id = aw_dap.piid
-        AND unlinked_subs.parent_award_id IS NOT DISTINCT FROM aw_dap.parent_award_id
+        AND COALESCE(unlinked_subs.parent_award_id, '') = COALESCE(aw_dap.parent_award_id, '')
         AND unlinked_subs.awarding_sub_tier_agency_c = aw_dap.awarding_sub_tier_agency_c)
 WHERE subaward.id = unlinked_subs.id;

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
@@ -8,8 +8,7 @@ WITH unlinked_subs AS
             awarding_sub_tier_agency_c
         FROM subaward
         WHERE subaward.unique_award_key IS NULL
-            AND subaward.subaward_type = 'sub-contract'
-    ),
+            AND subaward.subaward_type = 'sub-contract'),
 aw_dap AS
     (SELECT DISTINCT ON (
             dap.piid,
@@ -36,8 +35,7 @@ aw_dap AS
             AND unlinked_subs.awarding_sub_tier_agency_c = dap.awarding_sub_tier_agency_c
         )
         {0}
-    ORDER BY dap.piid, dap.parent_award_id, dap.awarding_sub_tier_agency_c, dap.action_date
-    )
+    ORDER BY dap.piid, dap.parent_award_id, dap.awarding_sub_tier_agency_c, dap.action_date)
 UPDATE subaward
 SET
     unique_award_key = aw_dap.unique_award_key,
@@ -51,5 +49,6 @@ FROM unlinked_subs
     JOIN aw_dap
         ON (unlinked_subs.award_id = aw_dap.piid
         AND COALESCE(unlinked_subs.parent_award_id, '') = COALESCE(aw_dap.parent_award_id, '')
-        AND unlinked_subs.awarding_sub_tier_agency_c = aw_dap.awarding_sub_tier_agency_c)
+        AND unlinked_subs.awarding_sub_tier_agency_c = aw_dap.awarding_sub_tier_agency_c
+        )
 WHERE subaward.id = unlinked_subs.id;

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_grants.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_grants.sql
@@ -6,8 +6,7 @@ WITH unlinked_subs AS
             award_id
         FROM subaward
         WHERE subaward.unique_award_key IS NULL
-            AND subaward.subaward_type = 'sub-grant'
-    ),
+            AND subaward.subaward_type = 'sub-grant'),
 aw_pafa AS
     (SELECT DISTINCT ON (
             pafa.fain

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_grants.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_grants.sql
@@ -1,4 +1,14 @@
-WITH aw_pafa AS
+WITH unlinked_subs AS
+    (
+        SELECT id,
+            prime_id,
+            sub_id,
+            award_id
+        FROM subaward
+        WHERE subaward.unique_award_key IS NULL
+            AND subaward.subaward_type = 'sub-grant'
+    ),
+aw_pafa AS
     (SELECT DISTINCT ON (
             pafa.fain
         )
@@ -24,68 +34,17 @@ WITH aw_pafa AS
     WHERE is_active IS TRUE
         AND EXISTS (
             SELECT 1
-            FROM fsrs_grant
-            WHERE fsrs_grant.fain = pafa.fain
+            FROM unlinked_subs
+            WHERE unlinked_subs.award_id = pafa.fain
         )
-    ORDER BY pafa.fain, pafa.action_date),
-grant_pduns AS
-    (SELECT grand_pduns_from.awardee_or_recipient_uniqu AS awardee_or_recipient_uniqu,
-        grand_pduns_from.legal_business_name AS legal_business_name
-    FROM (
-        SELECT duns.awardee_or_recipient_uniqu AS awardee_or_recipient_uniqu,
-            duns.legal_business_name AS legal_business_name,
-            row_number() OVER (PARTITION BY
-                duns.awardee_or_recipient_uniqu
-            ) AS row
-        FROM fsrs_grant
-            LEFT OUTER JOIN duns
-                ON fsrs_grant.parent_duns = duns.awardee_or_recipient_uniqu
-        ORDER BY duns.activation_date DESC
-     ) AS grand_pduns_from
-    WHERE grand_pduns_from.row = 1),
-subgrant_pduns AS (
-    SELECT sub_pduns_from.awardee_or_recipient_uniqu AS awardee_or_recipient_uniqu,
-        sub_pduns_from.legal_business_name AS legal_business_name
-    FROM (
-        SELECT duns.awardee_or_recipient_uniqu AS awardee_or_recipient_uniqu,
-            duns.legal_business_name AS legal_business_name,
-            row_number() OVER (PARTITION BY
-                duns.awardee_or_recipient_uniqu
-            ) AS row
-        FROM fsrs_subgrant
-            LEFT OUTER JOIN duns
-                ON fsrs_subgrant.parent_duns = duns.awardee_or_recipient_uniqu
-        ORDER BY duns.activation_date DESC
-    ) AS sub_pduns_from
-    WHERE sub_pduns_from.row = 1),
-subgrant_duns AS (
-    SELECT sub_duns_from.awardee_or_recipient_uniqu AS awardee_or_recipient_uniqu,
-        sub_duns_from.business_types_codes AS business_types_codes
-    FROM (
-        SELECT
-            duns.awardee_or_recipient_uniqu AS awardee_or_recipient_uniqu,
-            duns.business_types_codes AS business_types_codes,
-            row_number() OVER (PARTITION BY
-                duns.awardee_or_recipient_uniqu
-            ) AS row
-        FROM fsrs_subgrant
-            LEFT OUTER JOIN duns
-                ON fsrs_subgrant.duns = duns.awardee_or_recipient_uniqu
-        ORDER BY duns.activation_date DESC
-    ) AS sub_duns_from
-    WHERE sub_duns_from.row = 1)
+        {0}
+    ORDER BY pafa.fain, pafa.action_date)
 UPDATE subaward
 SET
     -- File F Prime Awards
     unique_award_key = aw_pafa.unique_award_key,
-    award_id = fsrs_grant.fain,
-    parent_award_id = NULL,
-    award_amount = fsrs_grant.total_fed_funding_amount,
-    action_date = fsrs_grant.obligation_date,
-    fy = 'FY' || fy(obligation_date),
     awarding_agency_code = aw_pafa.awarding_agency_code,
     awarding_agency_name = aw_pafa.awarding_agency_name,
-    awarding_sub_tier_agency_c = fsrs_grant.federal_agency_id,
     awarding_sub_tier_agency_n = aw_pafa.awarding_sub_tier_agency_n,
     awarding_office_code = aw_pafa.awarding_office_code,
     awarding_office_name = aw_pafa.awarding_office_name,
@@ -95,160 +54,8 @@ SET
     funding_sub_tier_agency_na = aw_pafa.funding_sub_tier_agency_na,
     funding_office_code = aw_pafa.funding_office_code,
     funding_office_name = aw_pafa.funding_office_name,
-    awardee_or_recipient_uniqu = fsrs_grant.duns,
-    awardee_or_recipient_legal = fsrs_grant.awardee_name,
-    dba_name = fsrs_grant.dba_name,
-    ultimate_parent_unique_ide = fsrs_grant.parent_duns,
-    ultimate_parent_legal_enti = grant_pduns.legal_business_name,
-    legal_entity_country_code = fsrs_grant.awardee_address_country,
-    legal_entity_country_name = le_country.country_name,
-    legal_entity_address_line1 = fsrs_grant.awardee_address_street,
-    legal_entity_city_name = fsrs_grant.awardee_address_city,
-    legal_entity_state_code = fsrs_grant.awardee_address_state,
-    legal_entity_state_name = fsrs_grant.awardee_address_state_name,
-    legal_entity_zip = CASE WHEN fsrs_grant.awardee_address_country = 'USA'
-                            THEN fsrs_grant.awardee_address_zip
-                            ELSE NULL
-                       END,
-    legal_entity_congressional = fsrs_grant.awardee_address_district,
-    legal_entity_foreign_posta = CASE WHEN fsrs_grant.awardee_address_country <> 'USA'
-                                      THEN fsrs_grant.awardee_address_zip
-                                      ELSE NULL
-                                 END,
-    business_types = aw_pafa.business_types_desc,
-    place_of_perform_city_name = fsrs_grant.principle_place_city,
-    place_of_perform_state_code = fsrs_grant.principle_place_state,
-    place_of_perform_state_name = fsrs_grant.principle_place_state_name,
-    place_of_performance_zip = fsrs_grant.principle_place_zip,
-    place_of_perform_congressio = fsrs_grant.principle_place_district,
-    place_of_perform_country_co = fsrs_grant.principle_place_country,
-    place_of_perform_country_na = ppop_country.country_name,
-    award_description = fsrs_grant.project_description,
-    naics = NULL,
-    naics_description = NULL,
-    cfda_numbers = CASE WHEN fsrs_grant.cfda_numbers ~ ';'
-                        THEN cfda_num_loop(fsrs_grant.cfda_numbers)
-                        ELSE cfda_num(fsrs_grant.cfda_numbers)
-                   END,
-    cfda_titles = CASE WHEN fsrs_grant.cfda_numbers ~ ';'
-                       THEN cfda_word_loop(fsrs_grant.cfda_numbers)
-                       ELSE cfda_word(fsrs_grant.cfda_numbers)
-                  END,
-
-    -- File F Subawards
-    subaward_type = 'sub-grant',
-    subaward_report_year = fsrs_grant.report_period_year,
-    subaward_report_month = fsrs_grant.report_period_mon,
-    subaward_number = fsrs_subgrant.subaward_num,
-    subaward_amount = fsrs_subgrant.subaward_amount,
-    sub_action_date = fsrs_subgrant.subaward_date,
-    sub_awardee_or_recipient_uniqu = fsrs_subgrant.duns,
-    sub_awardee_or_recipient_legal = fsrs_subgrant.awardee_name,
-    sub_dba_name = fsrs_subgrant.dba_name,
-    sub_ultimate_parent_unique_ide = fsrs_subgrant.parent_duns,
-    sub_ultimate_parent_legal_enti = subgrant_pduns.legal_business_name,
-    sub_legal_entity_country_code = fsrs_subgrant.awardee_address_country,
-    sub_legal_entity_country_name = sub_le_country.country_name,
-    sub_legal_entity_address_line1 = fsrs_subgrant.awardee_address_street,
-    sub_legal_entity_city_name = fsrs_subgrant.awardee_address_city,
-    sub_legal_entity_state_code = fsrs_subgrant.awardee_address_state,
-    sub_legal_entity_state_name = fsrs_subgrant.awardee_address_state_name,
-    sub_legal_entity_zip = CASE WHEN fsrs_subgrant.awardee_address_country = 'USA'
-                                THEN fsrs_subgrant.awardee_address_zip
-                                ELSE NULL
-                           END,
-    sub_legal_entity_congressional = fsrs_subgrant.awardee_address_district,
-    sub_legal_entity_foreign_posta = CASE WHEN fsrs_subgrant.awardee_address_country <> 'USA'
-                                          THEN fsrs_subgrant.awardee_address_zip
-                                          ELSE NULL
-                                     END,
-    sub_business_types = array_to_string(subgrant_duns.business_types_codes, ', '),
-    sub_place_of_perform_city_name = fsrs_subgrant.principle_place_city,
-    sub_place_of_perform_state_code = fsrs_subgrant.principle_place_state,
-    sub_place_of_perform_state_name = fsrs_subgrant.principle_place_state_name,
-    sub_place_of_performance_zip = fsrs_subgrant.principle_place_zip,
-    sub_place_of_perform_congressio = fsrs_subgrant.principle_place_district,
-    sub_place_of_perform_country_co = fsrs_subgrant.principle_place_country,
-    sub_place_of_perform_country_na = sub_ppop_country.country_name,
-    subaward_description = fsrs_subgrant.project_description,
-    sub_high_comp_officer1_full_na = fsrs_subgrant.top_paid_fullname_1,
-    sub_high_comp_officer1_amount = fsrs_subgrant.top_paid_amount_1,
-    sub_high_comp_officer2_full_na = fsrs_subgrant.top_paid_fullname_2,
-    sub_high_comp_officer2_amount = fsrs_subgrant.top_paid_amount_2,
-    sub_high_comp_officer3_full_na = fsrs_subgrant.top_paid_fullname_3,
-    sub_high_comp_officer3_amount = fsrs_subgrant.top_paid_amount_3,
-    sub_high_comp_officer4_full_na = fsrs_subgrant.top_paid_fullname_4,
-    sub_high_comp_officer4_amount = fsrs_subgrant.top_paid_amount_4,
-    sub_high_comp_officer5_full_na = fsrs_subgrant.top_paid_fullname_5,
-    sub_high_comp_officer5_amount = fsrs_subgrant.top_paid_amount_5,
-
-    -- File F Prime Awards
-    prime_id = fsrs_grant.id,
-    internal_id = fsrs_grant.internal_id,
-    date_submitted = fsrs_grant.date_submitted,
-    report_type = NULL,
-    transaction_type = NULL,
-    program_title = NULL,
-    contract_agency_code = NULL,
-    contract_idv_agency_code = NULL,
-    grant_funding_agency_id = fsrs_grant.funding_agency_id,
-    grant_funding_agency_name = fsrs_grant.funding_agency_name,
-    federal_agency_name = fsrs_grant.federal_agency_name,
-    treasury_symbol = NULL,
-    dunsplus4 = fsrs_grant.dunsplus4,
-    recovery_model_q1 = NULL,
-    recovery_model_q2 = NULL,
-    compensation_q1 = fsrs_grant.compensation_q1,
-    compensation_q2 = fsrs_grant.compensation_q2,
-    high_comp_officer1_full_na = fsrs_grant.top_paid_fullname_1,
-    high_comp_officer1_amount = fsrs_grant.top_paid_amount_1,
-    high_comp_officer2_full_na = fsrs_grant.top_paid_fullname_2,
-    high_comp_officer2_amount = fsrs_grant.top_paid_amount_2,
-    high_comp_officer3_full_na = fsrs_grant.top_paid_fullname_3,
-    high_comp_officer3_amount = fsrs_grant.top_paid_amount_3,
-    high_comp_officer4_full_na = fsrs_grant.top_paid_fullname_4,
-    high_comp_officer4_amount = fsrs_grant.top_paid_amount_4,
-    high_comp_officer5_full_na = fsrs_grant.top_paid_fullname_5,
-    high_comp_officer5_amount = fsrs_grant.top_paid_amount_5,
-
-    -- File F Subawards
-    sub_id = fsrs_subgrant.id,
-    sub_parent_id = fsrs_subgrant.parent_id,
-    sub_federal_agency_id = fsrs_subgrant.federal_agency_id,
-    sub_federal_agency_name = fsrs_subgrant.federal_agency_name,
-    sub_funding_agency_id = fsrs_subgrant.funding_agency_id,
-    sub_funding_agency_name = fsrs_subgrant.funding_agency_name,
-    sub_funding_office_id = NULL,
-    sub_funding_office_name = NULL,
-    sub_naics = NULL,
-    sub_cfda_numbers = fsrs_subgrant.cfda_numbers,
-    sub_dunsplus4 = fsrs_subgrant.dunsplus4,
-    sub_recovery_subcontract_amt = NULL,
-    sub_recovery_model_q1 = NULL,
-    sub_recovery_model_q2 = NULL,
-    sub_compensation_q1 = fsrs_subgrant.compensation_q1,
-    sub_compensation_q2 = fsrs_subgrant.compensation_q2,
-    "updated_at" = NOW()
-
-FROM fsrs_grant
-    JOIN fsrs_subgrant
-        ON fsrs_subgrant.parent_id = fsrs_grant.id
-    LEFT OUTER JOIN aw_pafa
-        ON fsrs_grant.fain = aw_pafa.fain
-    LEFT OUTER JOIN country_code AS le_country
-        ON fsrs_grant.awardee_address_country = le_country.country_code
-    LEFT OUTER JOIN country_code AS ppop_country
-        ON fsrs_grant.principle_place_country = ppop_country.country_code
-    LEFT OUTER JOIN country_code AS sub_le_country
-        ON fsrs_subgrant.awardee_address_country = sub_le_country.country_code
-    LEFT OUTER JOIN country_code AS sub_ppop_country
-        ON fsrs_subgrant.principle_place_country = sub_ppop_country.country_code
-    LEFT OUTER JOIN grant_pduns
-        ON fsrs_grant.parent_duns = grant_pduns.awardee_or_recipient_uniqu
-    LEFT OUTER JOIN subgrant_pduns
-        ON fsrs_subgrant.parent_duns = subgrant_pduns.awardee_or_recipient_uniqu
-    LEFT OUTER JOIN subgrant_duns
-        ON fsrs_subgrant.duns = subgrant_duns.awardee_or_recipient_uniqu
-WHERE subaward.unique_award_key IS NULL
-    AND subaward.subaward_type = 'sub-grant'
-    AND subaward.prime_id = fsrs_grant.id
+    business_types = aw_pafa.business_types_desc
+FROM unlinked_subs
+     JOIN aw_pafa
+        ON unlinked_subs.award_id = aw_pafa.fain
+WHERE subaward.id = unlinked_subs.id;

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -20,7 +20,7 @@ WITH aw_dap AS
         SELECT 1
         FROM fsrs_procurement
         WHERE fsrs_procurement.contract_number = dap.piid
-            AND COALESCE(fsrs_procurement.idv_reference_number, '') = COALESCE(dap.parent_award_id, '')
+            AND fsrs_procurement.idv_reference_number IS NOT DISTINCT FROM dap.parent_award_id
             AND fsrs_procurement.contracting_office_aid = dap.awarding_sub_tier_agency_c
             AND fsrs_procurement.id {0} {1}
     )
@@ -310,7 +310,7 @@ FROM fsrs_procurement
         ON fsrs_subcontract.parent_id = fsrs_procurement.id
     LEFT OUTER JOIN aw_dap
         ON (fsrs_procurement.contract_number = aw_dap.piid
-        AND COALESCE(fsrs_procurement.idv_reference_number, '') = COALESCE(aw_dap.parent_award_id, '')
+        AND fsrs_procurement.idv_reference_number IS NOT DISTINCT FROM dap.parent_award_id
         AND fsrs_procurement.contracting_office_aid = aw_dap.awarding_sub_tier_agency_c)
     LEFT OUTER JOIN country_code AS le_country
         ON fsrs_procurement.company_address_country = le_country.country_code

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -158,61 +158,61 @@ INSERT INTO subaward (
 )
 SELECT
     aw_dap.unique_award_key AS "unique_award_key",
-    procurement_filtered.contract_number AS "award_id",
-    procurement_filtered.idv_reference_number AS "parent_award_id",
-    procurement_filtered.dollar_obligated AS "award_amount",
-    procurement_filtered.date_signed AS "action_date",
-    'FY' || fy(procurement_filtered.date_signed) AS "fy",
+    fsrs_procurement.contract_number AS "award_id",
+    fsrs_procurement.idv_reference_number AS "parent_award_id",
+    fsrs_procurement.dollar_obligated AS "award_amount",
+    fsrs_procurement.date_signed AS "action_date",
+    'FY' || fy(fsrs_procurement.date_signed) AS "fy",
     aw_dap.awarding_agency_code AS "awarding_agency_code",
     aw_dap.awarding_agency_name AS "awarding_agency_name",
-    procurement_filtered.contracting_office_aid AS "awarding_sub_tier_agency_c",
-    procurement_filtered.contracting_office_aname AS "awarding_sub_tier_agency_n",
-    procurement_filtered.contracting_office_id AS "awarding_office_code",
-    procurement_filtered.contracting_office_name AS "awarding_office_name",
+    fsrs_procurement.contracting_office_aid AS "awarding_sub_tier_agency_c",
+    fsrs_procurement.contracting_office_aname AS "awarding_sub_tier_agency_n",
+    fsrs_procurement.contracting_office_id AS "awarding_office_code",
+    fsrs_procurement.contracting_office_name AS "awarding_office_name",
     aw_dap.funding_agency_code AS "funding_agency_code",
     aw_dap.funding_agency_name AS "funding_agency_name",
-    procurement_filtered.funding_agency_id AS "funding_sub_tier_agency_co",
-    procurement_filtered.funding_agency_name AS "funding_sub_tier_agency_na",
-    procurement_filtered.funding_office_id AS "funding_office_code",
-    procurement_filtered.funding_office_name AS "funding_office_name",
-    procurement_filtered.duns AS "awardee_or_recipient_uniqu",
-    procurement_filtered.company_name AS "awardee_or_recipient_legal",
-    procurement_filtered.dba_name AS "dba_name",
-    procurement_filtered.parent_duns AS "ultimate_parent_unique_ide",
-    procurement_filtered.parent_company_name AS "ultimate_parent_legal_enti",
-    procurement_filtered.company_address_country AS "legal_entity_country_code",
+    fsrs_procurement.funding_agency_id AS "funding_sub_tier_agency_co",
+    fsrs_procurement.funding_agency_name AS "funding_sub_tier_agency_na",
+    fsrs_procurement.funding_office_id AS "funding_office_code",
+    fsrs_procurement.funding_office_name AS "funding_office_name",
+    fsrs_procurement.duns AS "awardee_or_recipient_uniqu",
+    fsrs_procurement.company_name AS "awardee_or_recipient_legal",
+    fsrs_procurement.dba_name AS "dba_name",
+    fsrs_procurement.parent_duns AS "ultimate_parent_unique_ide",
+    fsrs_procurement.parent_company_name AS "ultimate_parent_legal_enti",
+    fsrs_procurement.company_address_country AS "legal_entity_country_code",
     le_country.country_name AS "legal_entity_country_name",
-    procurement_filtered.company_address_street AS "legal_entity_address_line1",
-    procurement_filtered.company_address_city AS "legal_entity_city_name",
-    procurement_filtered.company_address_state AS "legal_entity_state_code",
-    procurement_filtered.company_address_state_name AS "legal_entity_state_name",
-    CASE WHEN procurement_filtered.company_address_country = 'USA'
-         THEN procurement_filtered.company_address_zip
+    fsrs_procurement.company_address_street AS "legal_entity_address_line1",
+    fsrs_procurement.company_address_city AS "legal_entity_city_name",
+    fsrs_procurement.company_address_state AS "legal_entity_state_code",
+    fsrs_procurement.company_address_state_name AS "legal_entity_state_name",
+    CASE WHEN fsrs_procurement.company_address_country = 'USA'
+         THEN fsrs_procurement.company_address_zip
          ELSE NULL
     END AS "legal_entity_zip",
-    procurement_filtered.company_address_district AS "legal_entity_congressional",
-    CASE WHEN procurement_filtered.company_address_country <> 'USA'
-         THEN procurement_filtered.company_address_zip
+    fsrs_procurement.company_address_district AS "legal_entity_congressional",
+    CASE WHEN fsrs_procurement.company_address_country <> 'USA'
+         THEN fsrs_procurement.company_address_zip
          ELSE NULL
     END AS "legal_entity_foreign_posta",
-    procurement_filtered.bus_types AS "business_types",
-    procurement_filtered.principle_place_city AS "place_of_perform_city_name",
-    procurement_filtered.principle_place_state AS "place_of_perform_state_code",
-    procurement_filtered.principle_place_state_name AS "place_of_perform_state_name",
-    procurement_filtered.principle_place_zip AS "place_of_performance_zip",
-    procurement_filtered.principle_place_district AS "place_of_perform_congressio",
-    procurement_filtered.principle_place_country AS "place_of_perform_country_co",
+    fsrs_procurement.bus_types AS "business_types",
+    fsrs_procurement.principle_place_city AS "place_of_perform_city_name",
+    fsrs_procurement.principle_place_state AS "place_of_perform_state_code",
+    fsrs_procurement.principle_place_state_name AS "place_of_perform_state_name",
+    fsrs_procurement.principle_place_zip AS "place_of_performance_zip",
+    fsrs_procurement.principle_place_district AS "place_of_perform_congressio",
+    fsrs_procurement.principle_place_country AS "place_of_perform_country_co",
     ppop_country.country_name AS "place_of_perform_country_na",
     aw_dap.award_description AS "award_description",
-    procurement_filtered.naics AS "naics",
+    fsrs_procurement.naics AS "naics",
     aw_dap.naics_description AS "naics_description",
     NULL AS "cfda_numbers",
     NULL AS "cfda_titles",
 
     -- File F Subawards
     'sub-contract' AS "subaward_type",
-    procurement_filtered.report_period_year AS "subaward_report_year",
-    procurement_filtered.report_period_mon AS "subaward_report_month",
+    fsrs_procurement.report_period_year AS "subaward_report_year",
+    fsrs_procurement.report_period_mon AS "subaward_report_month",
     fsrs_subcontract.subcontract_num AS "subaward_number",
     fsrs_subcontract.subcontract_amount AS "subaward_amount",
     fsrs_subcontract.subcontract_date AS "sub_action_date",
@@ -257,33 +257,33 @@ SELECT
     fsrs_subcontract.top_paid_amount_5 AS "sub_high_comp_officer5_amount",
 
     -- File F Prime Awards
-    procurement_filtered.id AS "prime_id",
-    procurement_filtered.internal_id AS "internal_id",
-    procurement_filtered.date_submitted AS "date_submitted",
-    procurement_filtered.report_type AS "report_type",
-    procurement_filtered.transaction_type AS "transaction_type",
-    procurement_filtered.program_title AS "program_title",
-    procurement_filtered.contract_agency_code AS "contract_agency_code",
-    procurement_filtered.contract_idv_agency_code AS "contract_idv_agency_code",
+    fsrs_procurement.id AS "prime_id",
+    fsrs_procurement.internal_id AS "internal_id",
+    fsrs_procurement.date_submitted AS "date_submitted",
+    fsrs_procurement.report_type AS "report_type",
+    fsrs_procurement.transaction_type AS "transaction_type",
+    fsrs_procurement.program_title AS "program_title",
+    fsrs_procurement.contract_agency_code AS "contract_agency_code",
+    fsrs_procurement.contract_idv_agency_code AS "contract_idv_agency_code",
     NULL AS "grant_funding_agency_id",
     NULL AS "grant_funding_agency_name",
     NULL AS "federal_agency_name",
-    procurement_filtered.treasury_symbol AS "treasury_symbol",
+    fsrs_procurement.treasury_symbol AS "treasury_symbol",
     NULL AS "dunsplus4",
-    procurement_filtered.recovery_model_q1 AS "recovery_model_q1",
-    procurement_filtered.recovery_model_q2 AS "recovery_model_q2",
+    fsrs_procurement.recovery_model_q1 AS "recovery_model_q1",
+    fsrs_procurement.recovery_model_q2 AS "recovery_model_q2",
     NULL AS "compensation_q1",
     NULL AS "compensation_q2",
-    procurement_filtered.top_paid_fullname_1 AS "high_comp_officer1_full_na",
-    procurement_filtered.top_paid_amount_1 AS "high_comp_officer1_amount",
-    procurement_filtered.top_paid_fullname_2 AS "high_comp_officer2_full_na",
-    procurement_filtered.top_paid_amount_2 AS "high_comp_officer2_amount",
-    procurement_filtered.top_paid_fullname_3 AS "high_comp_officer3_full_na",
-    procurement_filtered.top_paid_amount_3 AS "high_comp_officer3_amount",
-    procurement_filtered.top_paid_fullname_4 AS "high_comp_officer4_full_na",
-    procurement_filtered.top_paid_amount_4 AS "high_comp_officer4_amount",
-    procurement_filtered.top_paid_fullname_5 AS "high_comp_officer5_full_na",
-    procurement_filtered.top_paid_amount_5 AS "high_comp_officer5_amount",
+    fsrs_procurement.top_paid_fullname_1 AS "high_comp_officer1_full_na",
+    fsrs_procurement.top_paid_amount_1 AS "high_comp_officer1_amount",
+    fsrs_procurement.top_paid_fullname_2 AS "high_comp_officer2_full_na",
+    fsrs_procurement.top_paid_amount_2 AS "high_comp_officer2_amount",
+    fsrs_procurement.top_paid_fullname_3 AS "high_comp_officer3_full_na",
+    fsrs_procurement.top_paid_amount_3 AS "high_comp_officer3_amount",
+    fsrs_procurement.top_paid_fullname_4 AS "high_comp_officer4_full_na",
+    fsrs_procurement.top_paid_amount_4 AS "high_comp_officer4_amount",
+    fsrs_procurement.top_paid_fullname_5 AS "high_comp_officer5_full_na",
+    fsrs_procurement.top_paid_amount_5 AS "high_comp_officer5_amount",
 
     -- File F Subawards
     fsrs_subcontract.id AS "sub_id",
@@ -305,19 +305,19 @@ SELECT
     NOW() AS "created_at",
     NOW() AS "updated_at"
 
-FROM procurement_filtered
+FROM fsrs_procurement
     JOIN fsrs_subcontract
-        ON fsrs_subcontract.parent_id = procurement_filtered.id
+        ON fsrs_subcontract.parent_id = fsrs_procurement.id
     LEFT OUTER JOIN aw_dap
-        ON (procurement_filtered.contract_number = aw_dap.piid
-        AND COALESCE(procurement_filtered.idv_reference_number, '') = COALESCE(aw_dap.parent_award_id, '')
-        AND procurement_filtered.contracting_office_aid = aw_dap.awarding_sub_tier_agency_c
-        )
+        ON (fsrs_procurement.contract_number = aw_dap.piid
+        AND COALESCE(fsrs_procurement.idv_reference_number, '') = COALESCE(aw_dap.parent_award_id, '')
+        AND fsrs_procurement.contracting_office_aid = aw_dap.awarding_sub_tier_agency_c)
     LEFT OUTER JOIN country_code AS le_country
-        ON procurement_filtered.company_address_country = le_country.country_code
+        ON fsrs_procurement.company_address_country = le_country.country_code
     LEFT OUTER JOIN country_code AS ppop_country
-        ON procurement_filtered.principle_place_country = ppop_country.country_code
+        ON fsrs_procurement.principle_place_country = ppop_country.country_code
     LEFT OUTER JOIN country_code AS sub_le_country
         ON fsrs_subcontract.company_address_country = sub_le_country.country_code
     LEFT OUTER JOIN country_code AS sub_ppop_country
         ON fsrs_subcontract.principle_place_country = sub_ppop_country.country_code
+WHERE fsrs_procurement.id {0} {1}

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -24,7 +24,7 @@ aw_dap AS
         SELECT 1
         FROM procurement_filtered
         WHERE procurement_filtered.contract_number = dap.piid
-            AND procurement_filtered.idv_reference_number IS NOT DISTINCT FROM dap.parent_award_id
+            AND COALESCE(procurement_filtered.idv_reference_number, '') = COALESCE(dap.parent_award_id, '')
             AND procurement_filtered.contracting_office_aid = dap.awarding_sub_tier_agency_c
     )
     ORDER BY dap.piid, dap.parent_award_id, dap.awarding_sub_tier_agency_c, dap.action_date

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -1,4 +1,8 @@
-WITH aw_dap AS
+WITH procurement_filtered AS
+    (SELECT *
+    FROM fsrs_procurement
+    WHERE fsrs_procurement.id {0} {1}),
+aw_dap AS
     (SELECT DISTINCT ON (
             dap.piid,
             dap.parent_award_id,
@@ -18,11 +22,10 @@ WITH aw_dap AS
     FROM detached_award_procurement AS dap
     WHERE EXISTS (
         SELECT 1
-        FROM fsrs_procurement
-        WHERE fsrs_procurement.contract_number = dap.piid
-            AND fsrs_procurement.idv_reference_number IS NOT DISTINCT FROM dap.parent_award_id
-            AND fsrs_procurement.contracting_office_aid = dap.awarding_sub_tier_agency_c
-            AND fsrs_procurement.id {0} {1}
+        FROM procurement_filtered
+        WHERE procurement_filtered.contract_number = dap.piid
+            AND procurement_filtered.idv_reference_number IS NOT DISTINCT FROM dap.parent_award_id
+            AND procurement_filtered.contracting_office_aid = dap.awarding_sub_tier_agency_c
     )
     ORDER BY dap.piid, dap.parent_award_id, dap.awarding_sub_tier_agency_c, dap.action_date
     )

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -310,7 +310,7 @@ FROM fsrs_procurement
         ON fsrs_subcontract.parent_id = fsrs_procurement.id
     LEFT OUTER JOIN aw_dap
         ON (fsrs_procurement.contract_number = aw_dap.piid
-        AND fsrs_procurement.idv_reference_number IS NOT DISTINCT FROM dap.parent_award_id
+        AND fsrs_procurement.idv_reference_number IS NOT DISTINCT FROM aw_dap.parent_award_id
         AND fsrs_procurement.contracting_office_aid = aw_dap.awarding_sub_tier_agency_c)
     LEFT OUTER JOIN country_code AS le_country
         ON fsrs_procurement.company_address_country = le_country.country_code

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -1,8 +1,4 @@
-WITH procurement_filtered AS
-    (SELECT *
-    FROM fsrs_procurement
-    WHERE fsrs_procurement.id {0} {1}),
-aw_dap AS
+WITH aw_dap AS
     (SELECT DISTINCT ON (
             dap.piid,
             dap.parent_award_id,
@@ -22,10 +18,11 @@ aw_dap AS
     FROM detached_award_procurement AS dap
     WHERE EXISTS (
         SELECT 1
-        FROM procurement_filtered
-        WHERE procurement_filtered.contract_number = dap.piid
-            AND COALESCE(procurement_filtered.idv_reference_number, '') = COALESCE(dap.parent_award_id, '')
-            AND procurement_filtered.contracting_office_aid = dap.awarding_sub_tier_agency_c
+        FROM fsrs_procurement
+        WHERE fsrs_procurement.contract_number = dap.piid
+            AND COALESCE(fsrs_procurement.idv_reference_number, '') = COALESCE(dap.parent_award_id, '')
+            AND fsrs_procurement.contracting_office_aid = dap.awarding_sub_tier_agency_c
+            AND fsrs_procurement.id {0} {1}
     )
     ORDER BY dap.piid, dap.parent_award_id, dap.awarding_sub_tier_agency_c, dap.action_date)
 INSERT INTO subaward (

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -27,8 +27,7 @@ aw_dap AS
             AND COALESCE(procurement_filtered.idv_reference_number, '') = COALESCE(dap.parent_award_id, '')
             AND procurement_filtered.contracting_office_aid = dap.awarding_sub_tier_agency_c
     )
-    ORDER BY dap.piid, dap.parent_award_id, dap.awarding_sub_tier_agency_c, dap.action_date
-    )
+    ORDER BY dap.piid, dap.parent_award_id, dap.awarding_sub_tier_agency_c, dap.action_date)
 INSERT INTO subaward (
     "unique_award_key",
     "award_id",
@@ -315,7 +314,8 @@ FROM procurement_filtered
     LEFT OUTER JOIN aw_dap
         ON (procurement_filtered.contract_number = aw_dap.piid
         AND COALESCE(procurement_filtered.idv_reference_number, '') = COALESCE(aw_dap.parent_award_id, '')
-        AND procurement_filtered.contracting_office_aid = aw_dap.awarding_sub_tier_agency_c)
+        AND procurement_filtered.contracting_office_aid = aw_dap.awarding_sub_tier_agency_c
+        )
     LEFT OUTER JOIN country_code AS le_country
         ON procurement_filtered.company_address_country = le_country.country_code
     LEFT OUTER JOIN country_code AS ppop_country

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -314,7 +314,7 @@ FROM procurement_filtered
         ON fsrs_subcontract.parent_id = procurement_filtered.id
     LEFT OUTER JOIN aw_dap
         ON (procurement_filtered.contract_number = aw_dap.piid
-        AND procurement_filtered.idv_reference_number IS NOT DISTINCT FROM aw_dap.parent_award_id
+        AND COALESCE(procurement_filtered.idv_reference_number, '') = COALESCE(aw_dap.parent_award_id, '')
         AND procurement_filtered.contracting_office_aid = aw_dap.awarding_sub_tier_agency_c)
     LEFT OUTER JOIN country_code AS le_country
         ON procurement_filtered.company_address_country = le_country.country_code

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -162,61 +162,61 @@ INSERT INTO subaward (
 )
 SELECT
     aw_dap.unique_award_key AS "unique_award_key",
-    fsrs_procurement.contract_number AS "award_id",
-    fsrs_procurement.idv_reference_number AS "parent_award_id",
-    fsrs_procurement.dollar_obligated AS "award_amount",
-    fsrs_procurement.date_signed AS "action_date",
-    'FY' || fy(fsrs_procurement.date_signed) AS "fy",
+    procurement_filtered.contract_number AS "award_id",
+    procurement_filtered.idv_reference_number AS "parent_award_id",
+    procurement_filtered.dollar_obligated AS "award_amount",
+    procurement_filtered.date_signed AS "action_date",
+    'FY' || fy(procurement_filtered.date_signed) AS "fy",
     aw_dap.awarding_agency_code AS "awarding_agency_code",
     aw_dap.awarding_agency_name AS "awarding_agency_name",
-    fsrs_procurement.contracting_office_aid AS "awarding_sub_tier_agency_c",
-    fsrs_procurement.contracting_office_aname AS "awarding_sub_tier_agency_n",
-    fsrs_procurement.contracting_office_id AS "awarding_office_code",
-    fsrs_procurement.contracting_office_name AS "awarding_office_name",
+    procurement_filtered.contracting_office_aid AS "awarding_sub_tier_agency_c",
+    procurement_filtered.contracting_office_aname AS "awarding_sub_tier_agency_n",
+    procurement_filtered.contracting_office_id AS "awarding_office_code",
+    procurement_filtered.contracting_office_name AS "awarding_office_name",
     aw_dap.funding_agency_code AS "funding_agency_code",
     aw_dap.funding_agency_name AS "funding_agency_name",
-    fsrs_procurement.funding_agency_id AS "funding_sub_tier_agency_co",
-    fsrs_procurement.funding_agency_name AS "funding_sub_tier_agency_na",
-    fsrs_procurement.funding_office_id AS "funding_office_code",
-    fsrs_procurement.funding_office_name AS "funding_office_name",
-    fsrs_procurement.duns AS "awardee_or_recipient_uniqu",
-    fsrs_procurement.company_name AS "awardee_or_recipient_legal",
-    fsrs_procurement.dba_name AS "dba_name",
-    fsrs_procurement.parent_duns AS "ultimate_parent_unique_ide",
-    fsrs_procurement.parent_company_name AS "ultimate_parent_legal_enti",
-    fsrs_procurement.company_address_country AS "legal_entity_country_code",
+    procurement_filtered.funding_agency_id AS "funding_sub_tier_agency_co",
+    procurement_filtered.funding_agency_name AS "funding_sub_tier_agency_na",
+    procurement_filtered.funding_office_id AS "funding_office_code",
+    procurement_filtered.funding_office_name AS "funding_office_name",
+    procurement_filtered.duns AS "awardee_or_recipient_uniqu",
+    procurement_filtered.company_name AS "awardee_or_recipient_legal",
+    procurement_filtered.dba_name AS "dba_name",
+    procurement_filtered.parent_duns AS "ultimate_parent_unique_ide",
+    procurement_filtered.parent_company_name AS "ultimate_parent_legal_enti",
+    procurement_filtered.company_address_country AS "legal_entity_country_code",
     le_country.country_name AS "legal_entity_country_name",
-    fsrs_procurement.company_address_street AS "legal_entity_address_line1",
-    fsrs_procurement.company_address_city AS "legal_entity_city_name",
-    fsrs_procurement.company_address_state AS "legal_entity_state_code",
-    fsrs_procurement.company_address_state_name AS "legal_entity_state_name",
-    CASE WHEN fsrs_procurement.company_address_country = 'USA'
-         THEN fsrs_procurement.company_address_zip
+    procurement_filtered.company_address_street AS "legal_entity_address_line1",
+    procurement_filtered.company_address_city AS "legal_entity_city_name",
+    procurement_filtered.company_address_state AS "legal_entity_state_code",
+    procurement_filtered.company_address_state_name AS "legal_entity_state_name",
+    CASE WHEN procurement_filtered.company_address_country = 'USA'
+         THEN procurement_filtered.company_address_zip
          ELSE NULL
     END AS "legal_entity_zip",
-    fsrs_procurement.company_address_district AS "legal_entity_congressional",
-    CASE WHEN fsrs_procurement.company_address_country <> 'USA'
-         THEN fsrs_procurement.company_address_zip
+    procurement_filtered.company_address_district AS "legal_entity_congressional",
+    CASE WHEN procurement_filtered.company_address_country <> 'USA'
+         THEN procurement_filtered.company_address_zip
          ELSE NULL
     END AS "legal_entity_foreign_posta",
-    fsrs_procurement.bus_types AS "business_types",
-    fsrs_procurement.principle_place_city AS "place_of_perform_city_name",
-    fsrs_procurement.principle_place_state AS "place_of_perform_state_code",
-    fsrs_procurement.principle_place_state_name AS "place_of_perform_state_name",
-    fsrs_procurement.principle_place_zip AS "place_of_performance_zip",
-    fsrs_procurement.principle_place_district AS "place_of_perform_congressio",
-    fsrs_procurement.principle_place_country AS "place_of_perform_country_co",
+    procurement_filtered.bus_types AS "business_types",
+    procurement_filtered.principle_place_city AS "place_of_perform_city_name",
+    procurement_filtered.principle_place_state AS "place_of_perform_state_code",
+    procurement_filtered.principle_place_state_name AS "place_of_perform_state_name",
+    procurement_filtered.principle_place_zip AS "place_of_performance_zip",
+    procurement_filtered.principle_place_district AS "place_of_perform_congressio",
+    procurement_filtered.principle_place_country AS "place_of_perform_country_co",
     ppop_country.country_name AS "place_of_perform_country_na",
     aw_dap.award_description AS "award_description",
-    fsrs_procurement.naics AS "naics",
+    procurement_filtered.naics AS "naics",
     aw_dap.naics_description AS "naics_description",
     NULL AS "cfda_numbers",
     NULL AS "cfda_titles",
 
     -- File F Subawards
     'sub-contract' AS "subaward_type",
-    fsrs_procurement.report_period_year AS "subaward_report_year",
-    fsrs_procurement.report_period_mon AS "subaward_report_month",
+    procurement_filtered.report_period_year AS "subaward_report_year",
+    procurement_filtered.report_period_mon AS "subaward_report_month",
     fsrs_subcontract.subcontract_num AS "subaward_number",
     fsrs_subcontract.subcontract_amount AS "subaward_amount",
     fsrs_subcontract.subcontract_date AS "sub_action_date",
@@ -261,33 +261,33 @@ SELECT
     fsrs_subcontract.top_paid_amount_5 AS "sub_high_comp_officer5_amount",
 
     -- File F Prime Awards
-    fsrs_procurement.id AS "prime_id",
-    fsrs_procurement.internal_id AS "internal_id",
-    fsrs_procurement.date_submitted AS "date_submitted",
-    fsrs_procurement.report_type AS "report_type",
-    fsrs_procurement.transaction_type AS "transaction_type",
-    fsrs_procurement.program_title AS "program_title",
-    fsrs_procurement.contract_agency_code AS "contract_agency_code",
-    fsrs_procurement.contract_idv_agency_code AS "contract_idv_agency_code",
+    procurement_filtered.id AS "prime_id",
+    procurement_filtered.internal_id AS "internal_id",
+    procurement_filtered.date_submitted AS "date_submitted",
+    procurement_filtered.report_type AS "report_type",
+    procurement_filtered.transaction_type AS "transaction_type",
+    procurement_filtered.program_title AS "program_title",
+    procurement_filtered.contract_agency_code AS "contract_agency_code",
+    procurement_filtered.contract_idv_agency_code AS "contract_idv_agency_code",
     NULL AS "grant_funding_agency_id",
     NULL AS "grant_funding_agency_name",
     NULL AS "federal_agency_name",
-    fsrs_procurement.treasury_symbol AS "treasury_symbol",
+    procurement_filtered.treasury_symbol AS "treasury_symbol",
     NULL AS "dunsplus4",
-    fsrs_procurement.recovery_model_q1 AS "recovery_model_q1",
-    fsrs_procurement.recovery_model_q2 AS "recovery_model_q2",
+    procurement_filtered.recovery_model_q1 AS "recovery_model_q1",
+    procurement_filtered.recovery_model_q2 AS "recovery_model_q2",
     NULL AS "compensation_q1",
     NULL AS "compensation_q2",
-    fsrs_procurement.top_paid_fullname_1 AS "high_comp_officer1_full_na",
-    fsrs_procurement.top_paid_amount_1 AS "high_comp_officer1_amount",
-    fsrs_procurement.top_paid_fullname_2 AS "high_comp_officer2_full_na",
-    fsrs_procurement.top_paid_amount_2 AS "high_comp_officer2_amount",
-    fsrs_procurement.top_paid_fullname_3 AS "high_comp_officer3_full_na",
-    fsrs_procurement.top_paid_amount_3 AS "high_comp_officer3_amount",
-    fsrs_procurement.top_paid_fullname_4 AS "high_comp_officer4_full_na",
-    fsrs_procurement.top_paid_amount_4 AS "high_comp_officer4_amount",
-    fsrs_procurement.top_paid_fullname_5 AS "high_comp_officer5_full_na",
-    fsrs_procurement.top_paid_amount_5 AS "high_comp_officer5_amount",
+    procurement_filtered.top_paid_fullname_1 AS "high_comp_officer1_full_na",
+    procurement_filtered.top_paid_amount_1 AS "high_comp_officer1_amount",
+    procurement_filtered.top_paid_fullname_2 AS "high_comp_officer2_full_na",
+    procurement_filtered.top_paid_amount_2 AS "high_comp_officer2_amount",
+    procurement_filtered.top_paid_fullname_3 AS "high_comp_officer3_full_na",
+    procurement_filtered.top_paid_amount_3 AS "high_comp_officer3_amount",
+    procurement_filtered.top_paid_fullname_4 AS "high_comp_officer4_full_na",
+    procurement_filtered.top_paid_amount_4 AS "high_comp_officer4_amount",
+    procurement_filtered.top_paid_fullname_5 AS "high_comp_officer5_full_na",
+    procurement_filtered.top_paid_amount_5 AS "high_comp_officer5_amount",
 
     -- File F Subawards
     fsrs_subcontract.id AS "sub_id",
@@ -309,19 +309,18 @@ SELECT
     NOW() AS "created_at",
     NOW() AS "updated_at"
 
-FROM fsrs_procurement
+FROM procurement_filtered
     JOIN fsrs_subcontract
-        ON fsrs_subcontract.parent_id = fsrs_procurement.id
+        ON fsrs_subcontract.parent_id = procurement_filtered.id
     LEFT OUTER JOIN aw_dap
-        ON (fsrs_procurement.contract_number = aw_dap.piid
-        AND fsrs_procurement.idv_reference_number IS NOT DISTINCT FROM aw_dap.parent_award_id
-        AND fsrs_procurement.contracting_office_aid = aw_dap.awarding_sub_tier_agency_c)
+        ON (procurement_filtered.contract_number = aw_dap.piid
+        AND procurement_filtered.idv_reference_number IS NOT DISTINCT FROM aw_dap.parent_award_id
+        AND procurement_filtered.contracting_office_aid = aw_dap.awarding_sub_tier_agency_c)
     LEFT OUTER JOIN country_code AS le_country
-        ON fsrs_procurement.company_address_country = le_country.country_code
+        ON procurement_filtered.company_address_country = le_country.country_code
     LEFT OUTER JOIN country_code AS ppop_country
-        ON fsrs_procurement.principle_place_country = ppop_country.country_code
+        ON procurement_filtered.principle_place_country = ppop_country.country_code
     LEFT OUTER JOIN country_code AS sub_le_country
         ON fsrs_subcontract.company_address_country = sub_le_country.country_code
     LEFT OUTER JOIN country_code AS sub_ppop_country
         ON fsrs_subcontract.principle_place_country = sub_ppop_country.country_code
-WHERE fsrs_procurement.id {0} {1}

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
@@ -1,4 +1,12 @@
-WITH aw_pafa AS
+WITH grant_filtered AS
+    (SELECT *
+        FROM fsrs_grant
+        WHERE fsrs_grant.id {0} {1}),
+subgrant_filtered AS
+    (SELECT *
+    FROM fsrs_subgrant
+    WHERE fsrs_subgrant.parent_id {0} {1}),
+aw_pafa AS
     (SELECT DISTINCT ON (
             pafa.fain
         )
@@ -24,9 +32,8 @@ WITH aw_pafa AS
     WHERE is_active IS TRUE
         AND EXISTS (
             SELECT 1
-            FROM fsrs_grant
-            WHERE fsrs_grant.fain = pafa.fain
-                AND fsrs_grant.id {0} {1}
+            FROM grant_filtered
+            WHERE grant_filtered.fain = pafa.fain
         )
     ORDER BY pafa.fain, pafa.action_date),
 grant_pduns AS
@@ -38,10 +45,9 @@ grant_pduns AS
             row_number() OVER (PARTITION BY
                 duns.awardee_or_recipient_uniqu
             ) AS row
-        FROM fsrs_grant
+        FROM grant_filtered
             LEFT OUTER JOIN duns
-                ON fsrs_grant.parent_duns = duns.awardee_or_recipient_uniqu
-                AND fsrs_grant.id {0} {1}
+                ON grant_filtered.parent_duns = duns.awardee_or_recipient_uniqu
         ORDER BY duns.activation_date DESC
      ) AS grand_pduns_from
     WHERE grand_pduns_from.row = 1),
@@ -54,10 +60,9 @@ subgrant_pduns AS (
             row_number() OVER (PARTITION BY
                 duns.awardee_or_recipient_uniqu
             ) AS row
-        FROM fsrs_subgrant
+        FROM subgrant_filtered
             LEFT OUTER JOIN duns
-                ON fsrs_subgrant.parent_duns = duns.awardee_or_recipient_uniqu
-                AND fsrs_subgrant.parent_id {0} {1}
+                ON subgrant_filtered.parent_duns = duns.awardee_or_recipient_uniqu
         ORDER BY duns.activation_date DESC
     ) AS sub_pduns_from
     WHERE sub_pduns_from.row = 1),
@@ -71,10 +76,9 @@ subgrant_duns AS (
             row_number() OVER (PARTITION BY
                 duns.awardee_or_recipient_uniqu
             ) AS row
-        FROM fsrs_subgrant
+        FROM subgrant_filtered
             LEFT OUTER JOIN duns
-                ON fsrs_subgrant.duns = duns.awardee_or_recipient_uniqu
-                AND fsrs_subgrant.parent_id {0} {1}
+                ON subgrant_filtered.duns = duns.awardee_or_recipient_uniqu
         ORDER BY duns.activation_date DESC
     ) AS sub_duns_from
     WHERE sub_duns_from.row = 1)

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
@@ -216,14 +216,14 @@ INSERT INTO subaward (
 SELECT
     -- File F Prime Awards
     aw_pafa.unique_award_key AS "unique_award_key",
-    fsrs_grant.fain AS "award_id",
+    grant_filtered.fain AS "award_id",
     NULL AS "parent_award_id",
-    fsrs_grant.total_fed_funding_amount AS "award_amount",
-    fsrs_grant.obligation_date AS "action_date",
+    grant_filtered.total_fed_funding_amount AS "award_amount",
+    grant_filtered.obligation_date AS "action_date",
     'FY' || fy(obligation_date) AS "fy",
     aw_pafa.awarding_agency_code AS "awarding_agency_code",
     aw_pafa.awarding_agency_name AS "awarding_agency_name",
-    fsrs_grant.federal_agency_id AS "awarding_sub_tier_agency_c",
+    grant_filtered.federal_agency_id AS "awarding_sub_tier_agency_c",
     aw_pafa.awarding_sub_tier_agency_n AS "awarding_sub_tier_agency_n",
     aw_pafa.awarding_office_code AS "awarding_office_code",
     aw_pafa.awarding_office_name AS "awarding_office_name",
@@ -233,50 +233,50 @@ SELECT
     aw_pafa.funding_sub_tier_agency_na AS "funding_sub_tier_agency_na",
     aw_pafa.funding_office_code AS "funding_office_code",
     aw_pafa.funding_office_name AS "funding_office_name",
-    fsrs_grant.duns AS "awardee_or_recipient_uniqu",
-    fsrs_grant.awardee_name AS "awardee_or_recipient_legal",
-    fsrs_grant.dba_name AS "dba_name",
-    fsrs_grant.parent_duns AS "ultimate_parent_unique_ide",
+    grant_filtered.duns AS "awardee_or_recipient_uniqu",
+    grant_filtered.awardee_name AS "awardee_or_recipient_legal",
+    grant_filtered.dba_name AS "dba_name",
+    grant_filtered.parent_duns AS "ultimate_parent_unique_ide",
     grant_pduns.legal_business_name AS "ultimate_parent_legal_enti",
-    fsrs_grant.awardee_address_country AS "legal_entity_country_code",
+    grant_filtered.awardee_address_country AS "legal_entity_country_code",
     le_country.country_name AS "legal_entity_country_name",
-    fsrs_grant.awardee_address_street AS "legal_entity_address_line1",
-    fsrs_grant.awardee_address_city AS "legal_entity_city_name",
-    fsrs_grant.awardee_address_state AS "legal_entity_state_code",
-    fsrs_grant.awardee_address_state_name AS "legal_entity_state_name",
-    CASE WHEN fsrs_grant.awardee_address_country = 'USA'
-         THEN fsrs_grant.awardee_address_zip
+    grant_filtered.awardee_address_street AS "legal_entity_address_line1",
+    grant_filtered.awardee_address_city AS "legal_entity_city_name",
+    grant_filtered.awardee_address_state AS "legal_entity_state_code",
+    grant_filtered.awardee_address_state_name AS "legal_entity_state_name",
+    CASE WHEN grant_filtered.awardee_address_country = 'USA'
+         THEN grant_filtered.awardee_address_zip
          ELSE NULL
     END AS "legal_entity_zip",
-    fsrs_grant.awardee_address_district AS "legal_entity_congressional",
-    CASE WHEN fsrs_grant.awardee_address_country <> 'USA'
-        THEN fsrs_grant.awardee_address_zip
+    grant_filtered.awardee_address_district AS "legal_entity_congressional",
+    CASE WHEN grant_filtered.awardee_address_country <> 'USA'
+        THEN grant_filtered.awardee_address_zip
         ELSE NULL
     END AS "legal_entity_foreign_posta",
     aw_pafa.business_types_desc AS "business_types",
-    fsrs_grant.principle_place_city AS "place_of_perform_city_name",
-    fsrs_grant.principle_place_state AS "place_of_perform_state_code",
-    fsrs_grant.principle_place_state_name AS "place_of_perform_state_name",
-    fsrs_grant.principle_place_zip AS "place_of_performance_zip",
-    fsrs_grant.principle_place_district AS "place_of_perform_congressio",
-    fsrs_grant.principle_place_country AS "place_of_perform_country_co",
+    grant_filtered.principle_place_city AS "place_of_perform_city_name",
+    grant_filtered.principle_place_state AS "place_of_perform_state_code",
+    grant_filtered.principle_place_state_name AS "place_of_perform_state_name",
+    grant_filtered.principle_place_zip AS "place_of_performance_zip",
+    grant_filtered.principle_place_district AS "place_of_perform_congressio",
+    grant_filtered.principle_place_country AS "place_of_perform_country_co",
     ppop_country.country_name AS "place_of_perform_country_na",
-    fsrs_grant.project_description AS "award_description",
+    grant_filtered.project_description AS "award_description",
     NULL AS "naics",
     NULL AS "naics_description",
-    CASE WHEN fsrs_grant.cfda_numbers ~ ';'
-         THEN cfda_num_loop(fsrs_grant.cfda_numbers)
-         ELSE cfda_num(fsrs_grant.cfda_numbers)
+    CASE WHEN grant_filtered.cfda_numbers ~ ';'
+         THEN cfda_num_loop(grant_filtered.cfda_numbers)
+         ELSE cfda_num(grant_filtered.cfda_numbers)
     END AS "cfda_numbers",
-    CASE WHEN fsrs_grant.cfda_numbers ~ ';'
-         THEN cfda_word_loop(fsrs_grant.cfda_numbers)
-         ELSE cfda_word(fsrs_grant.cfda_numbers)
+    CASE WHEN grant_filtered.cfda_numbers ~ ';'
+         THEN cfda_word_loop(grant_filtered.cfda_numbers)
+         ELSE cfda_word(grant_filtered.cfda_numbers)
     END AS "cfda_titles",
 
     -- File F Subawards
     'sub-grant' AS "subaward_type",
-    fsrs_grant.report_period_year AS "subaward_report_year",
-    fsrs_grant.report_period_mon AS "subaward_report_month",
+    grant_filtered.report_period_year AS "subaward_report_year",
+    grant_filtered.report_period_mon AS "subaward_report_month",
     fsrs_subgrant.subaward_num AS "subaward_number",
     fsrs_subgrant.subaward_amount AS "subaward_amount",
     fsrs_subgrant.subaward_date AS "sub_action_date",
@@ -321,33 +321,33 @@ SELECT
     fsrs_subgrant.top_paid_amount_5 AS "sub_high_comp_officer5_amount",
 
     -- File F Prime Awards
-    fsrs_grant.id AS "prime_id",
-    fsrs_grant.internal_id AS "internal_id",
-    fsrs_grant.date_submitted AS "date_submitted",
+    grant_filtered.id AS "prime_id",
+    grant_filtered.internal_id AS "internal_id",
+    grant_filtered.date_submitted AS "date_submitted",
     NULL AS "report_type",
     NULL AS "transaction_type",
     NULL AS "program_title",
     NULL AS "contract_agency_code",
     NULL AS "contract_idv_agency_code",
-    fsrs_grant.funding_agency_id AS "grant_funding_agency_id",
-    fsrs_grant.funding_agency_name AS "grant_funding_agency_name",
-    fsrs_grant.federal_agency_name AS "federal_agency_name",
+    grant_filtered.funding_agency_id AS "grant_funding_agency_id",
+    grant_filtered.funding_agency_name AS "grant_funding_agency_name",
+    grant_filtered.federal_agency_name AS "federal_agency_name",
     NULL AS "treasury_symbol",
-    fsrs_grant.dunsplus4 AS "dunsplus4",
+    grant_filtered.dunsplus4 AS "dunsplus4",
     NULL AS "recovery_model_q1",
     NULL AS "recovery_model_q2",
-    fsrs_grant.compensation_q1 AS "compensation_q1",
-    fsrs_grant.compensation_q2 AS "compensation_q2",
-    fsrs_grant.top_paid_fullname_1 AS "high_comp_officer1_full_na",
-    fsrs_grant.top_paid_amount_1 AS "high_comp_officer1_amount",
-    fsrs_grant.top_paid_fullname_2 AS "high_comp_officer2_full_na",
-    fsrs_grant.top_paid_amount_2 AS "high_comp_officer2_amount",
-    fsrs_grant.top_paid_fullname_3 AS "high_comp_officer3_full_na",
-    fsrs_grant.top_paid_amount_3 AS "high_comp_officer3_amount",
-    fsrs_grant.top_paid_fullname_4 AS "high_comp_officer4_full_na",
-    fsrs_grant.top_paid_amount_4 AS "high_comp_officer4_amount",
-    fsrs_grant.top_paid_fullname_5 AS "high_comp_officer5_full_na",
-    fsrs_grant.top_paid_amount_5 AS "high_comp_officer5_amount",
+    grant_filtered.compensation_q1 AS "compensation_q1",
+    grant_filtered.compensation_q2 AS "compensation_q2",
+    grant_filtered.top_paid_fullname_1 AS "high_comp_officer1_full_na",
+    grant_filtered.top_paid_amount_1 AS "high_comp_officer1_amount",
+    grant_filtered.top_paid_fullname_2 AS "high_comp_officer2_full_na",
+    grant_filtered.top_paid_amount_2 AS "high_comp_officer2_amount",
+    grant_filtered.top_paid_fullname_3 AS "high_comp_officer3_full_na",
+    grant_filtered.top_paid_amount_3 AS "high_comp_officer3_amount",
+    grant_filtered.top_paid_fullname_4 AS "high_comp_officer4_full_na",
+    grant_filtered.top_paid_amount_4 AS "high_comp_officer4_amount",
+    grant_filtered.top_paid_fullname_5 AS "high_comp_officer5_full_na",
+    grant_filtered.top_paid_amount_5 AS "high_comp_officer5_amount",
 
     -- File F Subawards
     fsrs_subgrant.id AS "sub_id",
@@ -369,23 +369,22 @@ SELECT
     NOW() AS "created_at",
     NOW() AS "updated_at"
 
-FROM fsrs_grant
+FROM grant_filtered
     JOIN fsrs_subgrant
-        ON fsrs_subgrant.parent_id = fsrs_grant.id
+        ON fsrs_subgrant.parent_id = grant_filtered.id
     LEFT OUTER JOIN aw_pafa
-        ON fsrs_grant.fain = aw_pafa.fain
+        ON grant_filtered.fain = aw_pafa.fain
     LEFT OUTER JOIN country_code AS le_country
-        ON fsrs_grant.awardee_address_country = le_country.country_code
+        ON grant_filtered.awardee_address_country = le_country.country_code
     LEFT OUTER JOIN country_code AS ppop_country
-        ON fsrs_grant.principle_place_country = ppop_country.country_code
+        ON grant_filtered.principle_place_country = ppop_country.country_code
     LEFT OUTER JOIN country_code AS sub_le_country
         ON fsrs_subgrant.awardee_address_country = sub_le_country.country_code
     LEFT OUTER JOIN country_code AS sub_ppop_country
         ON fsrs_subgrant.principle_place_country = sub_ppop_country.country_code
     LEFT OUTER JOIN grant_pduns
-        ON fsrs_grant.parent_duns = grant_pduns.awardee_or_recipient_uniqu
+        ON grant_filtered.parent_duns = grant_pduns.awardee_or_recipient_uniqu
     LEFT OUTER JOIN subgrant_pduns
         ON fsrs_subgrant.parent_duns = subgrant_pduns.awardee_or_recipient_uniqu
     LEFT OUTER JOIN subgrant_duns
         ON fsrs_subgrant.duns = subgrant_duns.awardee_or_recipient_uniqu
-WHERE fsrs_grant.id {0} {1}

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
@@ -212,14 +212,14 @@ INSERT INTO subaward (
 SELECT
     -- File F Prime Awards
     aw_pafa.unique_award_key AS "unique_award_key",
-    grant_filtered.fain AS "award_id",
+    fsrs_grant.fain AS "award_id",
     NULL AS "parent_award_id",
-    grant_filtered.total_fed_funding_amount AS "award_amount",
-    grant_filtered.obligation_date AS "action_date",
+    fsrs_grant.total_fed_funding_amount AS "award_amount",
+    fsrs_grant.obligation_date AS "action_date",
     'FY' || fy(obligation_date) AS "fy",
     aw_pafa.awarding_agency_code AS "awarding_agency_code",
     aw_pafa.awarding_agency_name AS "awarding_agency_name",
-    grant_filtered.federal_agency_id AS "awarding_sub_tier_agency_c",
+    fsrs_grant.federal_agency_id AS "awarding_sub_tier_agency_c",
     aw_pafa.awarding_sub_tier_agency_n AS "awarding_sub_tier_agency_n",
     aw_pafa.awarding_office_code AS "awarding_office_code",
     aw_pafa.awarding_office_name AS "awarding_office_name",
@@ -229,50 +229,50 @@ SELECT
     aw_pafa.funding_sub_tier_agency_na AS "funding_sub_tier_agency_na",
     aw_pafa.funding_office_code AS "funding_office_code",
     aw_pafa.funding_office_name AS "funding_office_name",
-    grant_filtered.duns AS "awardee_or_recipient_uniqu",
-    grant_filtered.awardee_name AS "awardee_or_recipient_legal",
-    grant_filtered.dba_name AS "dba_name",
-    grant_filtered.parent_duns AS "ultimate_parent_unique_ide",
+    fsrs_grant.duns AS "awardee_or_recipient_uniqu",
+    fsrs_grant.awardee_name AS "awardee_or_recipient_legal",
+    fsrs_grant.dba_name AS "dba_name",
+    fsrs_grant.parent_duns AS "ultimate_parent_unique_ide",
     grant_pduns.legal_business_name AS "ultimate_parent_legal_enti",
-    grant_filtered.awardee_address_country AS "legal_entity_country_code",
+    fsrs_grant.awardee_address_country AS "legal_entity_country_code",
     le_country.country_name AS "legal_entity_country_name",
-    grant_filtered.awardee_address_street AS "legal_entity_address_line1",
-    grant_filtered.awardee_address_city AS "legal_entity_city_name",
-    grant_filtered.awardee_address_state AS "legal_entity_state_code",
-    grant_filtered.awardee_address_state_name AS "legal_entity_state_name",
-    CASE WHEN grant_filtered.awardee_address_country = 'USA'
-         THEN grant_filtered.awardee_address_zip
+    fsrs_grant.awardee_address_street AS "legal_entity_address_line1",
+    fsrs_grant.awardee_address_city AS "legal_entity_city_name",
+    fsrs_grant.awardee_address_state AS "legal_entity_state_code",
+    fsrs_grant.awardee_address_state_name AS "legal_entity_state_name",
+    CASE WHEN fsrs_grant.awardee_address_country = 'USA'
+         THEN fsrs_grant.awardee_address_zip
          ELSE NULL
     END AS "legal_entity_zip",
-    grant_filtered.awardee_address_district AS "legal_entity_congressional",
-    CASE WHEN grant_filtered.awardee_address_country <> 'USA'
-        THEN grant_filtered.awardee_address_zip
+    fsrs_grant.awardee_address_district AS "legal_entity_congressional",
+    CASE WHEN fsrs_grant.awardee_address_country <> 'USA'
+        THEN fsrs_grant.awardee_address_zip
         ELSE NULL
     END AS "legal_entity_foreign_posta",
     aw_pafa.business_types_desc AS "business_types",
-    grant_filtered.principle_place_city AS "place_of_perform_city_name",
-    grant_filtered.principle_place_state AS "place_of_perform_state_code",
-    grant_filtered.principle_place_state_name AS "place_of_perform_state_name",
-    grant_filtered.principle_place_zip AS "place_of_performance_zip",
-    grant_filtered.principle_place_district AS "place_of_perform_congressio",
-    grant_filtered.principle_place_country AS "place_of_perform_country_co",
+    fsrs_grant.principle_place_city AS "place_of_perform_city_name",
+    fsrs_grant.principle_place_state AS "place_of_perform_state_code",
+    fsrs_grant.principle_place_state_name AS "place_of_perform_state_name",
+    fsrs_grant.principle_place_zip AS "place_of_performance_zip",
+    fsrs_grant.principle_place_district AS "place_of_perform_congressio",
+    fsrs_grant.principle_place_country AS "place_of_perform_country_co",
     ppop_country.country_name AS "place_of_perform_country_na",
-    grant_filtered.project_description AS "award_description",
+    fsrs_grant.project_description AS "award_description",
     NULL AS "naics",
     NULL AS "naics_description",
-    CASE WHEN grant_filtered.cfda_numbers ~ ';'
-         THEN cfda_num_loop(grant_filtered.cfda_numbers)
-         ELSE cfda_num(grant_filtered.cfda_numbers)
+    CASE WHEN fsrs_grant.cfda_numbers ~ ';'
+         THEN cfda_num_loop(fsrs_grant.cfda_numbers)
+         ELSE cfda_num(fsrs_grant.cfda_numbers)
     END AS "cfda_numbers",
-    CASE WHEN grant_filtered.cfda_numbers ~ ';'
-         THEN cfda_word_loop(grant_filtered.cfda_numbers)
-         ELSE cfda_word(grant_filtered.cfda_numbers)
+    CASE WHEN fsrs_grant.cfda_numbers ~ ';'
+         THEN cfda_word_loop(fsrs_grant.cfda_numbers)
+         ELSE cfda_word(fsrs_grant.cfda_numbers)
     END AS "cfda_titles",
 
     -- File F Subawards
     'sub-grant' AS "subaward_type",
-    grant_filtered.report_period_year AS "subaward_report_year",
-    grant_filtered.report_period_mon AS "subaward_report_month",
+    fsrs_grant.report_period_year AS "subaward_report_year",
+    fsrs_grant.report_period_mon AS "subaward_report_month",
     fsrs_subgrant.subaward_num AS "subaward_number",
     fsrs_subgrant.subaward_amount AS "subaward_amount",
     fsrs_subgrant.subaward_date AS "sub_action_date",
@@ -317,33 +317,33 @@ SELECT
     fsrs_subgrant.top_paid_amount_5 AS "sub_high_comp_officer5_amount",
 
     -- File F Prime Awards
-    grant_filtered.id AS "prime_id",
-    grant_filtered.internal_id AS "internal_id",
-    grant_filtered.date_submitted AS "date_submitted",
+    fsrs_grant.id AS "prime_id",
+    fsrs_grant.internal_id AS "internal_id",
+    fsrs_grant.date_submitted AS "date_submitted",
     NULL AS "report_type",
     NULL AS "transaction_type",
     NULL AS "program_title",
     NULL AS "contract_agency_code",
     NULL AS "contract_idv_agency_code",
-    grant_filtered.funding_agency_id AS "grant_funding_agency_id",
-    grant_filtered.funding_agency_name AS "grant_funding_agency_name",
-    grant_filtered.federal_agency_name AS "federal_agency_name",
+    fsrs_grant.funding_agency_id AS "grant_funding_agency_id",
+    fsrs_grant.funding_agency_name AS "grant_funding_agency_name",
+    fsrs_grant.federal_agency_name AS "federal_agency_name",
     NULL AS "treasury_symbol",
-    grant_filtered.dunsplus4 AS "dunsplus4",
+    fsrs_grant.dunsplus4 AS "dunsplus4",
     NULL AS "recovery_model_q1",
     NULL AS "recovery_model_q2",
-    grant_filtered.compensation_q1 AS "compensation_q1",
-    grant_filtered.compensation_q2 AS "compensation_q2",
-    grant_filtered.top_paid_fullname_1 AS "high_comp_officer1_full_na",
-    grant_filtered.top_paid_amount_1 AS "high_comp_officer1_amount",
-    grant_filtered.top_paid_fullname_2 AS "high_comp_officer2_full_na",
-    grant_filtered.top_paid_amount_2 AS "high_comp_officer2_amount",
-    grant_filtered.top_paid_fullname_3 AS "high_comp_officer3_full_na",
-    grant_filtered.top_paid_amount_3 AS "high_comp_officer3_amount",
-    grant_filtered.top_paid_fullname_4 AS "high_comp_officer4_full_na",
-    grant_filtered.top_paid_amount_4 AS "high_comp_officer4_amount",
-    grant_filtered.top_paid_fullname_5 AS "high_comp_officer5_full_na",
-    grant_filtered.top_paid_amount_5 AS "high_comp_officer5_amount",
+    fsrs_grant.compensation_q1 AS "compensation_q1",
+    fsrs_grant.compensation_q2 AS "compensation_q2",
+    fsrs_grant.top_paid_fullname_1 AS "high_comp_officer1_full_na",
+    fsrs_grant.top_paid_amount_1 AS "high_comp_officer1_amount",
+    fsrs_grant.top_paid_fullname_2 AS "high_comp_officer2_full_na",
+    fsrs_grant.top_paid_amount_2 AS "high_comp_officer2_amount",
+    fsrs_grant.top_paid_fullname_3 AS "high_comp_officer3_full_na",
+    fsrs_grant.top_paid_amount_3 AS "high_comp_officer3_amount",
+    fsrs_grant.top_paid_fullname_4 AS "high_comp_officer4_full_na",
+    fsrs_grant.top_paid_amount_4 AS "high_comp_officer4_amount",
+    fsrs_grant.top_paid_fullname_5 AS "high_comp_officer5_full_na",
+    fsrs_grant.top_paid_amount_5 AS "high_comp_officer5_amount",
 
     -- File F Subawards
     fsrs_subgrant.id AS "sub_id",
@@ -365,22 +365,23 @@ SELECT
     NOW() AS "created_at",
     NOW() AS "updated_at"
 
-FROM grant_filtered
+FROM fsrs_grant
     JOIN fsrs_subgrant
-        ON fsrs_subgrant.parent_id = grant_filtered.id
+        ON fsrs_subgrant.parent_id = fsrs_grant.id
     LEFT OUTER JOIN aw_pafa
-        ON grant_filtered.fain = aw_pafa.fain
+        ON fsrs_grant.fain = aw_pafa.fain
     LEFT OUTER JOIN country_code AS le_country
-        ON grant_filtered.awardee_address_country = le_country.country_code
+        ON fsrs_grant.awardee_address_country = le_country.country_code
     LEFT OUTER JOIN country_code AS ppop_country
-        ON grant_filtered.principle_place_country = ppop_country.country_code
+        ON fsrs_grant.principle_place_country = ppop_country.country_code
     LEFT OUTER JOIN country_code AS sub_le_country
         ON fsrs_subgrant.awardee_address_country = sub_le_country.country_code
     LEFT OUTER JOIN country_code AS sub_ppop_country
         ON fsrs_subgrant.principle_place_country = sub_ppop_country.country_code
     LEFT OUTER JOIN grant_pduns
-        ON grant_filtered.parent_duns = grant_pduns.awardee_or_recipient_uniqu
+        ON fsrs_grant.parent_duns = grant_pduns.awardee_or_recipient_uniqu
     LEFT OUTER JOIN subgrant_pduns
         ON fsrs_subgrant.parent_duns = subgrant_pduns.awardee_or_recipient_uniqu
     LEFT OUTER JOIN subgrant_duns
         ON fsrs_subgrant.duns = subgrant_duns.awardee_or_recipient_uniqu
+WHERE fsrs_grant.id {0} {1}

--- a/tests/unit/dataactcore/test_populate_subaward_table.py
+++ b/tests/unit/dataactcore/test_populate_subaward_table.py
@@ -480,6 +480,8 @@ def test_fix_broken_links(database, monkeypatch):
     sess.commit()
 
     parent_duns, duns, dom_country, int_country = reference_data(sess)
+    min_date = '2019-06-06'
+    award_updated_at = '2019-06-07'
 
     # Setup - Grants
     sub = SubmissionFactory(submission_id=1)
@@ -487,7 +489,8 @@ def test_fix_broken_links(database, monkeypatch):
         submission_id=sub.submission_id,
         record_type='2',
         unique_award_key='NON',
-        is_active=True
+        is_active=True,
+        updated_at=award_updated_at
     )
     grant_non = FSRSGrantFactory(
         fain=d2_non.fain,
@@ -510,7 +513,8 @@ def test_fix_broken_links(database, monkeypatch):
         submission_id=sub.submission_id,
         record_type='1',
         unique_award_key='AGG',
-        is_active=True
+        is_active=True,
+        updated_at=award_updated_at
     )
     grant_agg = FSRSGrantFactory(
         fain=d2_agg.fain,
@@ -534,7 +538,8 @@ def test_fix_broken_links(database, monkeypatch):
     d1_awd = DetachedAwardProcurementFactory(
         submission_id=sub.submission_id,
         idv_type=None,
-        unique_award_key='AWD'
+        unique_award_key='AWD',
+        updated_at=award_updated_at
     )
     contract_awd = FSRSProcurementFactory(
         contract_number=d1_awd.piid,
@@ -555,7 +560,8 @@ def test_fix_broken_links(database, monkeypatch):
     d1_idv = DetachedAwardProcurementFactory(
         submission_id=sub.submission_id,
         idv_type='C',
-        unique_award_key='IDV'
+        unique_award_key='IDV',
+        updated_at=award_updated_at
     )
     contract_idv = FSRSProcurementFactory(
         contract_number=d1_idv.piid,
@@ -605,8 +611,8 @@ def test_fix_broken_links(database, monkeypatch):
     sess.add_all([d1_awd, d2_non, d1_idv, d2_agg])
     sess.commit()
 
-    updated_proc_count = fix_broken_links(sess, 'procurement_service')
-    updated_grant_count = fix_broken_links(sess, 'grant_service')
+    updated_proc_count = fix_broken_links(sess, 'procurement_service', min_date=min_date)
+    updated_grant_count = fix_broken_links(sess, 'grant_service', min_date=min_date)
 
     assert updated_proc_count == updated_grant_count == 2
 


### PR DESCRIPTION
**High level description:**
With the Subaward table included in the FSRS, it was discovered that performance lacked for the main environments. This should resolve it.

**Technical details:**
* Updated fix_broken_links functionality to only update based on new awards from the last subaward load.
* Updated SQL performance of populate_subaward_table functionality.
* Updated FSRS loader subaward logic to populate only with new FSRS data and cleaned up logs. 

**Link to JIRA Ticket:**
[DEV-2837](https://federal-spending-transparency.atlassian.net/browse/DEV-2837)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Testing modified FSRS loader on dev (ask for jenkins links)