### PR TITLE
DEV-2685: case insensitive subtier fabs

### DIFF
--- a/dataactvalidator/config/sqlrules/fabs21_detached_award_financial_assistance_1.sql
+++ b/dataactvalidator/config/sqlrules/fabs21_detached_award_financial_assistance_1.sql
@@ -8,5 +8,5 @@ WHERE dafa.submission_id = {0}
     AND NOT EXISTS (
         SELECT 1
         FROM sub_tier_agency AS sta
-        WHERE sta.sub_tier_agency_code = dafa.funding_sub_tier_agency_co
+        WHERE UPPER(sta.sub_tier_agency_code) = UPPER(dafa.funding_sub_tier_agency_co)
     );

--- a/dataactvalidator/config/sqlrules/fabs21_detached_award_financial_assistance_2.sql
+++ b/dataactvalidator/config/sqlrules/fabs21_detached_award_financial_assistance_2.sql
@@ -29,7 +29,7 @@ sub_tier_offices_{0} AS
 	WHERE EXISTS (
 	        SELECT 1
 		    FROM detached_award_financial_assistance_23_2_{0} AS dafa
-		    WHERE dafa.funding_sub_tier_agency_co = stac.sub_tier_code
+		    WHERE UPPER(dafa.funding_sub_tier_agency_co) = UPPER(stac.sub_tier_code)
 			    AND UPPER(dafa.funding_office_code) = UPPER(office.office_code)
 	))
 SELECT
@@ -41,6 +41,6 @@ WHERE NOT EXISTS (
         -- Find all funding sub tier agency and office codes that are not part of the valid pairings list
         SELECT 1
 	    FROM sub_tier_offices_{0} AS sto
-	    WHERE sto.sub_tier_code = dafa.funding_sub_tier_agency_co
+	    WHERE UPPER(sto.sub_tier_code) = UPPER(dafa.funding_sub_tier_agency_co)
 		    AND UPPER(sto.office_code) = UPPER(dafa.funding_office_code)
 	);

--- a/dataactvalidator/config/sqlrules/fabs23_detached_award_financial_assistance_1.sql
+++ b/dataactvalidator/config/sqlrules/fabs23_detached_award_financial_assistance_1.sql
@@ -8,5 +8,5 @@ WHERE submission_id = {0}
     AND NOT EXISTS (
         SELECT 1
         FROM sub_tier_agency AS sta
-        WHERE sta.sub_tier_agency_code = dafa.awarding_sub_tier_agency_c
+        WHERE UPPER(sta.sub_tier_agency_code) = UPPER(dafa.awarding_sub_tier_agency_c)
     );

--- a/dataactvalidator/config/sqlrules/fabs23_detached_award_financial_assistance_2.sql
+++ b/dataactvalidator/config/sqlrules/fabs23_detached_award_financial_assistance_2.sql
@@ -29,7 +29,7 @@ sub_tier_offices_{0} AS
 	WHERE EXISTS (
 	        SELECT 1
 		    FROM detached_award_financial_assistance_23_2_{0} AS dafa
-		    WHERE dafa.awarding_sub_tier_agency_c = stac.sub_tier_code
+		    WHERE UPPER(dafa.awarding_sub_tier_agency_c) = UPPER(stac.sub_tier_code)
 			    AND UPPER(dafa.awarding_office_code) = UPPER(office.office_code)
 	))
 SELECT
@@ -41,6 +41,6 @@ WHERE NOT EXISTS (
         -- Find all awarding sub tier agency and office codes that are not part of the valid pairings list
         SELECT 1
 	    FROM sub_tier_offices_{0} AS sto
-	    WHERE sto.sub_tier_code = dafa.awarding_sub_tier_agency_c
+	    WHERE UPPER(sto.sub_tier_code) = UPPER(dafa.awarding_sub_tier_agency_c)
 		    AND UPPER(sto.office_code) = UPPER(dafa.awarding_office_code)
 	);

--- a/tests/unit/dataactvalidator/test_fabs21_detached_award_financial_assistance_1.py
+++ b/tests/unit/dataactvalidator/test_fabs21_detached_award_financial_assistance_1.py
@@ -15,13 +15,14 @@ def test_success(database):
     """ FundingSubTierAgencyCode is an optional field, but when provided
     must be a valid 4-digit sub-tier agency code.  """
 
-    subcode = SubTierAgency(sub_tier_agency_code='0000', cgac_id='1')
+    subcode = SubTierAgency(sub_tier_agency_code='A000', cgac_id='1')
     cgac = CGAC(cgac_id='1', cgac_code='001', agency_name='test')
-    det_award = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co='0000')
-    det_award_2 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co=None)
-    det_award_3 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co='')
+    det_award = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co='A000')
+    det_award_2 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co='a000')
+    det_award_3 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co=None)
+    det_award_4 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co='')
 
-    errors = number_of_errors(_FILE, database, models=[det_award, det_award_2, det_award_3, subcode, cgac])
+    errors = number_of_errors(_FILE, database, models=[det_award, det_award_2, det_award_3, det_award_4, subcode, cgac])
     assert errors == 0
 
 

--- a/tests/unit/dataactvalidator/test_fabs21_detached_award_financial_assistance_2.py
+++ b/tests/unit/dataactvalidator/test_fabs21_detached_award_financial_assistance_2.py
@@ -21,27 +21,28 @@ def test_success(database):
     # as long as the top tier codes match
     office_1 = OfficeFactory(office_code='12345a', sub_tier_code='abcd', agency_code=cgac.cgac_code)
     office_2 = OfficeFactory(office_code='123457', sub_tier_code='efgh', agency_code=frec.frec_code)
-    agency_1 = SubTierAgency(sub_tier_agency_code='0000', cgac_id=1, frec_id=1, is_frec=False)
+    agency_1 = SubTierAgency(sub_tier_agency_code='a000', cgac_id=1, frec_id=1, is_frec=False)
     agency_2 = SubTierAgency(sub_tier_agency_code='0001', cgac_id=1, frec_id=1, is_frec=True)
 
     # Same agency for cgac
     det_award_1 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co=agency_1.sub_tier_agency_code,
                                                           funding_office_code=office_1.office_code)
     # Same agency for cgac (uppercase)
-    det_award_1 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co=agency_1.sub_tier_agency_code,
+    det_award_2 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co=agency_1.sub_tier_agency_code.
+                                                          upper(),
                                                           funding_office_code=office_1.office_code.upper())
     # Same agency for frec
-    det_award_2 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co=agency_2.sub_tier_agency_code,
+    det_award_3 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co=agency_2.sub_tier_agency_code,
                                                           funding_office_code=office_2.office_code)
     # Missing sub tier code
-    det_award_3 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co='',
+    det_award_4 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co='',
                                                           funding_office_code=office_2.office_code)
     # Missing office code
-    det_award_4 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co=agency_1.sub_tier_agency_code,
+    det_award_5 = DetachedAwardFinancialAssistanceFactory(funding_sub_tier_agency_co=agency_1.sub_tier_agency_code,
                                                           funding_office_code=None)
 
     errors = number_of_errors(_FILE, database, models=[cgac, frec, office_1, office_2, agency_1, agency_2, det_award_1,
-                                                       det_award_2, det_award_3, det_award_4])
+                                                       det_award_2, det_award_3, det_award_4, det_award_5])
     assert errors == 0
 
 

--- a/tests/unit/dataactvalidator/test_fabs23_detached_award_financial_assistance_1.py
+++ b/tests/unit/dataactvalidator/test_fabs23_detached_award_financial_assistance_1.py
@@ -14,9 +14,9 @@ def test_column_headers(database):
 def test_success(database):
     """ AwardingSubTierAgencyCode must be a valid 4-digit sub-tier agency code. Doesn't fail when code not provided. """
 
-    agency = SubTierAgency(sub_tier_agency_code='0000', cgac_id='1')
+    agency = SubTierAgency(sub_tier_agency_code='a000', cgac_id='1')
     cgac = CGAC(cgac_id='1', cgac_code='001', agency_name='test')
-    det_award = DetachedAwardFinancialAssistanceFactory(awarding_sub_tier_agency_c=agency.sub_tier_agency_code)
+    det_award = DetachedAwardFinancialAssistanceFactory(awarding_sub_tier_agency_c=agency.sub_tier_agency_code.upper())
     det_award_2 = DetachedAwardFinancialAssistanceFactory(awarding_sub_tier_agency_c=None)
     det_award_3 = DetachedAwardFinancialAssistanceFactory(awarding_sub_tier_agency_c='')
 

--- a/tests/unit/dataactvalidator/test_fabs23_detached_award_financial_assistance_2.py
+++ b/tests/unit/dataactvalidator/test_fabs23_detached_award_financial_assistance_2.py
@@ -22,14 +22,15 @@ def test_success(database):
     # as long as the top tier codes match
     office_1 = OfficeFactory(office_code='12345a', sub_tier_code='abcd', agency_code=cgac.cgac_code)
     office_2 = OfficeFactory(office_code='123457', sub_tier_code='efgh', agency_code=frec.frec_code)
-    agency_1 = SubTierAgency(sub_tier_agency_code='0000', cgac_id=1, frec_id=1, is_frec=False)
+    agency_1 = SubTierAgency(sub_tier_agency_code='a000', cgac_id=1, frec_id=1, is_frec=False)
     agency_2 = SubTierAgency(sub_tier_agency_code='0001', cgac_id=1, frec_id=1, is_frec=True)
 
     # Same agency for cgac
     det_award_1 = DetachedAwardFinancialAssistanceFactory(awarding_sub_tier_agency_c=agency_1.sub_tier_agency_code,
                                                           awarding_office_code=office_1.office_code)
     # Same agency for cgac (uppercased)
-    det_award_2 = DetachedAwardFinancialAssistanceFactory(awarding_sub_tier_agency_c=agency_1.sub_tier_agency_code,
+    det_award_2 = DetachedAwardFinancialAssistanceFactory(awarding_sub_tier_agency_c=agency_1.sub_tier_agency_code.
+                                                          upper(),
                                                           awarding_office_code=office_1.office_code.upper())
     # Same agency for frec
     det_award_3 = DetachedAwardFinancialAssistanceFactory(awarding_sub_tier_agency_c=agency_2.sub_tier_agency_code,


### PR DESCRIPTION
**High level description:**
Subtier codes can have letters now, they should be case insensitive

**Technical details:**
Updating FABS 21 and FABS 23 rules to ignore case (all others don't use sub tier codes or are already case insensitive)

**Link to JIRA Ticket:**
[DEV-2685](https://federal-spending-transparency.atlassian.net/browse/DEV-2685)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed