### PR TITLE
DEV-2890: B20 logic error

### DIFF
--- a/dataactvalidator/config/sqlrules/b20_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b20_object_class_program_activity.sql
@@ -42,7 +42,7 @@ WHERE NOT EXISTS (
             )
             AND (COALESCE(af.object_class, '') = COALESCE(op.object_class, '')
                 OR (af.object_class IN ('0', '00', '000', '0000')
-                    AND af.object_class IN ('0', '00', '000', '0000')
+                    AND op.object_class IN ('0', '00', '000', '0000')
                 )
             )
     );

--- a/tests/unit/dataactvalidator/test_b20_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b20_object_class_program_activity.py
@@ -18,31 +18,40 @@ def test_column_headers(database):
 def test_success(database):
     """ Tests that all combinations of TAS, program activity code, and object class in File C exist in File B """
     tas = TASFactory()
-    database.session.add(tas)
+    tas2 = TASFactory()
+    database.session.add_all([tas, tas2])
     database.session.flush()
 
     op = ObjectClassProgramActivityFactory(tas_id=tas.tas_id, program_activity_code='1', object_class='1')
+    op2 = ObjectClassProgramActivityFactory(tas_id=tas2.tas_id, program_activity_code='2', object_class='0')
+
     af = AwardFinancialFactory(tas_id=tas.tas_id, program_activity_code='1', object_class='1')
     # Allow program activity code to be null, empty, or zero
     af2 = AwardFinancialFactory(tas_id=tas.tas_id, program_activity_code='', object_class='1')
     af3 = AwardFinancialFactory(tas_id=tas.tas_id, program_activity_code='0000', object_class='1')
     af4 = AwardFinancialFactory(tas_id=tas.tas_id, program_activity_code=None, object_class='1')
+    # Allow different object classes if pacs are the same and tas IDs are the same and object classes are just
+    # different numbers of zeroes
+    af5 = AwardFinancialFactory(tas_id=tas2.tas_id, program_activity_code='2', object_class='00')
 
-    assert number_of_errors(_FILE, database, models=[op, af, af2, af3, af4]) == 0
+    assert number_of_errors(_FILE, database, models=[op, op2, af, af2, af3, af4, af5]) == 0
 
 
 def test_failure(database):
     """ Tests that all combinations of TAS, program activity code, and object class in File C do not exist in File B """
     tas1 = TASFactory()
     tas2 = TASFactory()
-    database.session.add_all([tas1, tas2])
+    tas3 = TASFactory()
+    database.session.add_all([tas1, tas2, tas3])
     database.session.flush()
 
     op = ObjectClassProgramActivityFactory(tas_id=tas1.tas_id, program_activity_code='1', object_class='1')
+    op2 = ObjectClassProgramActivityFactory(tas_id=tas2.tas_id, program_activity_code='1', object_class='2')
 
-    af1 = AwardFinancialFactory(tas_id=tas1.tas_id, program_activity_code='1', object_class='1')
-    af2 = AwardFinancialFactory(tas_id=tas2.tas_id, program_activity_code='1', object_class='1')
-    af3 = AwardFinancialFactory(tas_id=tas1.tas_id, program_activity_code='2', object_class='1')
-    af4 = AwardFinancialFactory(tas_id=tas1.tas_id, program_activity_code='1', object_class='2')
+    af1 = AwardFinancialFactory(tas_id=tas3.tas_id, program_activity_code='1', object_class='1')
+    af2 = AwardFinancialFactory(tas_id=tas1.tas_id, program_activity_code='2', object_class='1')
+    af3 = AwardFinancialFactory(tas_id=tas1.tas_id, program_activity_code='1', object_class='2')
+    # Should error even if object class is 0 because it doesn't match the object class of the op
+    af4 = AwardFinancialFactory(tas_id=tas2.tas_id, program_activity_code='1', object_class='0')
 
-    assert number_of_errors(_FILE, database, models=[op, af1, af2, af3, af4]) == 3
+    assert number_of_errors(_FILE, database, models=[op, op2, af1, af2, af3, af4]) == 4


### PR DESCRIPTION
**High level description:**
Fixing an edge case of B20 where we allow any number of zeroes (1-4) in the object class if the pac and tas are the same

**Technical details:**
Fixing B20 rule to not AND on the same value

**Link to JIRA Ticket:**
[DEV-2890](https://federal-spending-transparency.atlassian.net/browse/DEV-2890)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed