### PR TITLE
DEV-1761: list submissions min last mod

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1051,7 +1051,7 @@ This endpoint lists submissions for all agencies for which the current user is a
       "files": ["file1.csv", "file2.csv"],
       "agency": "Department of the Treasury (TREAS)"
       "status": "validation_successful",
-      "last_modified": "2016-08-31 12:59:37.053424",
+      "last_modified": "2016-08-30 12:59:37.053424",
       "publish_status": "published",
       "certifying_user": "Certifier",
       "certified_on": "2016-08-30 12:53:37.053424"
@@ -1073,13 +1073,15 @@ This endpoint lists submissions for all agencies for which the current user is a
       "certified_on": ""
     }
   ],
-  "total": 2
+  "total": 2,
+  "min_last_modified": "2016-08-30 12:59:37.053424"
 }
 ```
 
 ##### Response Attributes
 
 - `total` - An integer indicating the total submissions that match the provided parameters (including those that didn't fit within the limit)
+- `min_last_modified` - A string indicating the minimum last modified date for submissions with the same type (FABS/DABS) and certify status (certified/published, unpublished, both) as the request (additional filters do not affect this number)
 - `submissions` - An array of objects that contain details about submissions. Contents of each object are:
     - `submission_id` - an integer indicating ID of the submission
     - `reporting_start_date` - a string containing the start date of the submission (`YYYY-MM-DD`)

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1569,7 +1569,7 @@ def list_submissions(page, limit, certified, sort='modified', order='desc', is_f
     return JsonResponse.create(StatusCode.OK, {
         'submissions': [serialize_submission(submission) for submission in query],
         'total': total_submissions,
-        'min_last_modified': str(min_last_mod)
+        'min_last_modified': str(min_last_mod) if min_last_mod else None
     })
 
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1502,6 +1502,8 @@ def list_submissions(page, limit, certified, sort='modified', order='desc', is_f
         outerjoin(submission_updated_view.table, submission_updated_view.submission_id == Submission.submission_id).\
         outerjoin(sub_query, Submission.submission_id == sub_query.c.submission_id).\
         filter(Submission.d2_submission.is_(is_fabs))
+    min_mod_query = sess.query(func.min(Submission.updated_at).label('min_last_mod_date')).\
+        filter(Submission.d2_submission.is_(is_fabs))
 
     # Limit the data coming back to only what the given user is allowed to see
     if not g.user.website_admin:
@@ -1514,13 +1516,16 @@ def list_submissions(page, limit, certified, sort='modified', order='desc', is_f
         if frec_codes:
             affiliation_filters.append(Submission.frec_code.in_(frec_codes))
         query = query.filter(sa.or_(*affiliation_filters))
+        min_mod_query = min_mod_query.filter(sa.or_(*affiliation_filters))
 
     # Determine what types of submissions (published/unpublished/both) to display
     if certified != 'mixed':
         if certified == 'true':
             query = query.filter(Submission.publish_status_id != PUBLISH_STATUS_DICT['unpublished'])
+            min_mod_query = min_mod_query.filter(Submission.publish_status_id != PUBLISH_STATUS_DICT['unpublished'])
         else:
             query = query.filter(Submission.publish_status_id == PUBLISH_STATUS_DICT['unpublished'])
+            min_mod_query = min_mod_query.filter(Submission.publish_status_id == PUBLISH_STATUS_DICT['unpublished'])
 
     # Add additional filters where applicable
     if filters:
@@ -1557,12 +1562,14 @@ def list_submissions(page, limit, certified, sort='modified', order='desc', is_f
     query = query.order_by(sort_order)
 
     total_submissions = query.count()
+    min_last_mod = min_mod_query.one()[0]
 
     query = query.slice(offset, offset + limit)
 
     return JsonResponse.create(StatusCode.OK, {
-        "submissions": [serialize_submission(submission) for submission in query],
-        "total": total_submissions
+        'submissions': [serialize_submission(submission) for submission in query],
+        'total': total_submissions,
+        'min_last_modified': str(min_last_mod)
     })
 
 

--- a/tests/integration/integration_test_helper.py
+++ b/tests/integration/integration_test_helper.py
@@ -51,3 +51,8 @@ def insert_job(sess, filetype, status, type_id, submission, job_id=None, filenam
     sess.add(job)
     sess.commit()
     return job
+
+
+def get_submission(sess, sub_id):
+    """ Get back the requested submission """
+    return sess.query(Submission).filter_by(submission_id=sub_id).one_or_none()


### PR DESCRIPTION
**High level description:**
Include the minimum last modified date in the `list_submissions` endpoint

**Technical details:**
Filters should not affect the minimum date, only the type (FABS/DABS) and the publish status (true/false/both) along with user permissions

**Link to JIRA Ticket:**
[DEV-1761](https://federal-spending-transparency.atlassian.net/browse/DEV-1761)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed