### PR TITLE
DEV-3234/DEV-3235: Update FREC Transactions Agency Codes/Names

### DIFF
--- a/dataactbroker/scripts/update_transaction_agency_codes.py
+++ b/dataactbroker/scripts/update_transaction_agency_codes.py
@@ -79,8 +79,8 @@ def set_update_condition(agency_type, table, suffix, sess, subtier_codes=None):
     if subtier_codes and len(subtier_codes) == 1:
         sql_statement = "{}.{}_sub_tier_agency_c{} = '{}' ".format(table, agency_type, suffix, str(subtier_codes[0]))
     elif subtier_codes and len(subtier_codes) > 1:
-        subtier_list = '({})'.format(','.join(['\'{}\''.format(subtier_code) for subtier_code in subtier_codes]))
-        sql_statement = "{}.{}_sub_tier_agency_c{} IN {}".format(table, agency_type, suffix, subtier_list)
+        subtiers_str = '({})'.format(','.join(['\'{}\''.format(subtier_code) for subtier_code in subtier_codes]))
+        sql_statement = "{}.{}_sub_tier_agency_c{} IN {}".format(table, agency_type, suffix, subtiers_str)
     else:
         sql_statement = "{}.{}_agency_code = '999' ".format(table, agency_type)
 


### PR DESCRIPTION
**High level description:**
The solution to this ticket is just running a script we already have but this modifies it to support multiple subtiers

**Technical details:**
Updating `dataactbroker/scripts/update_transaction_agency_codes.py` to support multiple subtiers.

**Link to JIRA Ticket:**
[DEV-3234](https://federal-spending-transparency.atlassian.net/browse/DEV-3234)
[DEV-3235](https://federal-spending-transparency.atlassian.net/browse/DEV-3235)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [ ] [Sandbox Test](http://ec2-96-127-83-21.us-gov-west-1.compute.amazonaws.com:8080/view/Broker-Jobs/job/Broker-Custom-Script/174/console)
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed

See SQL fix in comments.