### PR TITLE
DEV-3362: prevent split error metadata

### DIFF
--- a/dataactvalidator/filestreaming/csvReader.py
+++ b/dataactvalidator/filestreaming/csvReader.py
@@ -155,6 +155,8 @@ class CsvReader(object):
             # We skip headers which aren't expected and aren't flex
             elif self.expected_headers[idx] is not None:
                 return_dict[self.expected_headers[idx]] = cell
+        # Sort flex fields so they always come back in the same order
+        flex_fields.sort(key=lambda x: x.header)
         return return_dict, flex_fields
 
     def _get_line(self):

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -539,6 +539,7 @@ class ValidationManager:
                 # write to warnings file
                 warning_writer.writerow([field_name, error_msg, str(failure.row), failure.failed_value,
                                          failure.original_label])
+            # labeled errors
             error_list.record_row_error(job_id, job.filename, field_name, failure.error, row_number,
                                         failure.original_label, failure.file_type_id, failure.target_file_id,
                                         failure.severity_id)
@@ -748,18 +749,18 @@ def insert_staging_model(model, job, writer, error_list):
 def write_errors(failures, job, short_colnames, writer, warning_writer, row_number, error_list, flex_cols):
     """ Write errors to error database
 
-    Args:
-        failures: List of Failures to be written
-        job: Current job
-        short_colnames: Dict mapping short names to long names
-        writer: CsvWriter object
-        warning_writer: CsvWriter object
-        row_number: Current row number
-        error_list: instance of ErrorInterface to keep track of errors
-        flex_cols: all flex columns for this row
+        Args:
+            failures: List of Failures to be written
+            job: Current job
+            short_colnames: Dict mapping short names to long names
+            writer: CsvWriter object
+            warning_writer: CsvWriter object
+            row_number: Current row number
+            error_list: instance of ErrorInterface to keep track of errors
+            flex_cols: all flex columns for this row
 
-    Returns:
-        True if any fatal errors were found, False if only warnings are present
+        Returns:
+            True if any fatal errors were found, False if only warnings are present
     """
     fatal_error_found = False
     # prepare flex cols for all the errors for this row
@@ -806,6 +807,7 @@ def write_errors(failures, job, short_colnames, writer, warning_writer, row_numb
         elif failure.severity == 'warning':
             # write to warnings file
             warning_writer.writerow([combined_field_names, error_msg, str(row_number), fail_value, failure.label])
+        # Non-labeled errors
         error_list.record_row_error(job.job_id, job.filename, combined_field_names, failure.description, row_number,
                                     failure.label, severity_id=severity_id)
     return fatal_error_found

--- a/dataactvalidator/validation_handlers/validator.py
+++ b/dataactvalidator/validation_handlers/validator.py
@@ -380,6 +380,7 @@ def relevant_flex_data(failures, job_id):
             "FROM flex_field " +
             "WHERE job_id=" + str(job_id) +
             " AND EXISTS (SELECT * FROM all_values WHERE flex_field.row_number = all_values.row_number)"
+            "ORDER BY flex_field.header"
         )
         query_result = sess.execute(query)
         for flex_field in query_result:


### PR DESCRIPTION
**High level description:**
Sometimes with flex fields error metadata gets split up, causing some strange data and bad visuals. This fix prevents this problem going forward.

**Technical details:**
Always sort flex fields as they are pulled so they're always in order of header name and don't mess up the key, causing split data.

**Link to JIRA Ticket:**
[DEV-3362](https://federal-spending-transparency.atlassian.net/browse/DEV-3362)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed