### PR TITLE
DEV-2598: Keeping Monthly Submissions to a Month

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -114,6 +114,13 @@ class FileHandler:
             formatted_start_date, formatted_end_date = FileHandler.check_submission_dates(start_date,
                                                                                           end_date, is_quarter)
 
+            if not is_quarter and not (formatted_start_date.month == formatted_end_date.month and
+                                       formatted_start_date.year == formatted_end_date.year):
+                data = {
+                    "message": "A monthly submission cannot extend beyond a month."
+                }
+                return JsonResponse.create(StatusCode.CLIENT_ERROR, data)
+
             submissions = sess.query(Submission).filter(
                 Submission.cgac_code == submission_request.get('cgac_code'),
                 Submission.frec_code == submission_request.get('frec_code'),

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -117,7 +117,7 @@ class FileHandler:
             if not is_quarter and not (formatted_start_date.month == formatted_end_date.month and
                                        formatted_start_date.year == formatted_end_date.year):
                 data = {
-                    "message": "A monthly submission cannot extend beyond a month."
+                    "message": "A monthly submission must be exactly one month."
                 }
                 return JsonResponse.create(StatusCode.CLIENT_ERROR, data)
 

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -155,7 +155,8 @@ class FileTests(BaseTestAPI):
         update_json = {"existing_submission_id": self.updateSubmissionId,
                        "award_financial": file_path,
                        "reporting_period_start_date": "04/2016",
-                       "reporting_period_end_date": "06/2016"}
+                       "reporting_period_end_date": "06/2016",
+                       "is_quarter": True}
 
         # Mark submission as published
         with create_app().app_context():
@@ -975,7 +976,8 @@ class FileTests(BaseTestAPI):
         # Call a generation to test resetting the status, make sure the call succeeded
         update_json = {"existing_submission_id": submission.submission_id,
                        "reporting_period_start_date": "04/2016",
-                       "reporting_period_end_date": "06/2016"}
+                       "reporting_period_end_date": "06/2016",
+                       "is_quarter": True}
         update_response = self.app.post("/v1/upload_dabs_files/", update_json,
                                         upload_files=[APPROP_FILE_T],
                                         headers={"x-session-id": self.session_id})

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -372,7 +372,7 @@ class FileTests(BaseTestAPI):
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json['message'], 'A monthly submission cannot extend beyond a month.')
+        self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month.')
 
         # wrong year
         monthly_submission_json = {
@@ -385,7 +385,7 @@ class FileTests(BaseTestAPI):
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json['message'], 'A monthly submission cannot extend beyond a month.')
+        self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month.')
 
     def test_revalidation_threshold_no_login(self):
         """ Test response with no login """

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -360,20 +360,32 @@ class FileTests(BaseTestAPI):
                                  headers={"x-session-id": self.session_id}, expect_errors=False)
         self.assertEqual(response.status_code, 200)
 
-    # TODO: validate that monthly submissions only include one month
-    # def test_submit_file_monthly_submission_wrong_dates(self):
-    #     self.login_user()
-    #     monthly_submission_json = {
-    #         "cgac_code": "NOT",
-    #         "frec_code": None,
-    #         "is_quarter": False,
-    #         "reporting_period_start_date": "10/2015",
-    #         "reporting_period_end_date": "12/2015"}
-    #     response = self.app.post("/v1/upload_dabs_files/", monthly_submission_json,
-    #                              upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
-    #                              headers={"x-session-id": self.session_id}, expect_errors=True)
-    #     self.assertEqual(response.status_code, 400)
-    #     self.assertEqual()
+    def test_submit_file_monthly_submission_wrong_dates(self):
+        # wrong month
+        monthly_submission_json = {
+            "cgac_code": "NOT",
+            "frec_code": None,
+            "is_quarter": False,
+            "reporting_period_start_date": "10/2015",
+            "reporting_period_end_date": "12/2015"}
+        response = self.app.post("/v1/upload_dabs_files/", monthly_submission_json,
+                                 upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
+                                 headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'A monthly submission cannot extend beyond a month.')
+
+        # wrong year
+        monthly_submission_json = {
+            "cgac_code": "NOT",
+            "frec_code": None,
+            "is_quarter": False,
+            "reporting_period_start_date": "10/2015",
+            "reporting_period_end_date": "10/2016"}
+        response = self.app.post("/v1/upload_dabs_files/", monthly_submission_json,
+                                 upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
+                                 headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'A monthly submission cannot extend beyond a month.')
 
     def test_revalidation_threshold_no_login(self):
         """ Test response with no login """


### PR DESCRIPTION
**High level description:**
Preventing API users to upload dabs files with monthly submissions over several months.

**Technical details:**
n/a

**Link to JIRA Ticket:**
[DEV-2598](https://federal-spending-transparency.atlassian.net/browse/DEV-2598)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Tested locally