### PR TITLE
Hotfix: DUNS/Exec Comp loaders accounting for Socket Connection drops/closes

### DIFF
--- a/dataactcore/scripts/load_duns.py
+++ b/dataactcore/scripts/load_duns.py
@@ -106,7 +106,7 @@ def process_from_dir(root_dir, file_name, sess, sftp=None, monthly=False, benchm
         with open(file_path, "wb") as zip_file:
             try:
                 sftp.getfo(''.join([REMOTE_SAM_DUNS_DIR, '/', file_name]), zip_file)
-            except OSError:
+            except:
                 logger.debug("Socket closed. Reconnecting...")
                 ssh_client = get_client()
                 sftp = ssh_client.open_sftp()

--- a/dataactcore/scripts/load_exec_comp.py
+++ b/dataactcore/scripts/load_exec_comp.py
@@ -104,7 +104,7 @@ def process_from_dir(root_dir, file_name, sess, sftp=None, ssh_key=None, metrics
         with open(file_path, 'wb') as zip_file:
             try:
                 sftp.getfo(''.join([REMOTE_SAM_EXEC_COMP_DIR, '/', file_name]), zip_file)
-            except OSError:
+            except:
                 logger.debug("Socket closed. Reconnecting...")
                 ssh_client = get_client(ssh_key=ssh_key)
                 sftp = ssh_client.open_sftp()


### PR DESCRIPTION
**High level description:**
During the DUNS reload over the weekend, the pipeline stopped due to a socket error. This guarantees that we catch all forms of connection errors and reconnect if there is an issue.

**Technical details:**
The specific error in question is:
`2019-09-13 23:17:45,051 ERROR:paramiko.transport:Socket exception: Connection reset by peer (104)`
This is different from the Socket closed error previously caught by `OSError` so this will account for all the various cases.

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed