### PR TITLE
DEV-3568: Separate flex fields

### DIFF
--- a/dataactvalidator/validation_handlers/validator.py
+++ b/dataactvalidator/validation_handlers/validator.py
@@ -12,8 +12,8 @@ from dataactcore.interfaces.db import GlobalDB
 logger = logging.getLogger(__name__)
 
 Failure = namedtuple('Failure', ['field', 'description', 'value', 'label', 'severity'])
-ValidationFailure = namedtuple('ValidationFailure', ['field_name', 'error', 'failed_value', 'row', 'original_label',
-                                                     'file_type_id', 'target_file_id', 'severity_id'])
+ValidationFailure = namedtuple('ValidationFailure', ['field_name', 'error', 'failed_value', 'flex_fields', 'row',
+                                                     'original_label', 'file_type_id', 'target_file_id', 'severity_id'])
 
 
 class Validator(object):
@@ -417,12 +417,13 @@ def failure_row_to_tuple(rule, flex_data, cols, col_headers, file_id, sql_failur
     row = sql_failure["row_number"]
     # Create strings for fields and values
     values_list = ["{}: {}".format(header, str(sql_failure[field])) for field, header in zip(cols, col_headers)]
-    values_list.extend("{}: {}".format(flex_field.header, flex_field.cell) for flex_field in flex_data[row])
-    field_list = col_headers + [field.header for field in flex_data[row]]
+    flex_list = ["{}: {}".format(flex_field.header, flex_field.cell if flex_field.cell else '')
+                 for flex_field in flex_data[row]]
     return ValidationFailure(
-        ", ".join(field_list),
+        ", ".join(col_headers),
         rule.rule_error_message,
         ", ".join(values_list),
+        ", ".join(flex_list),
         row,
         rule.rule_label,
         file_id,

--- a/tests/unit/dataactvalidator/validation_handlers/test_validationManager.py
+++ b/tests/unit/dataactvalidator/validation_handlers/test_validationManager.py
@@ -107,7 +107,7 @@ def test_insert_staging_model_failure():
     job = JobFactory()
     assert not validationManager.insert_staging_model(model, job, writer, error_list)
     assert writer.writerow.call_args[0] == (
-        ['Formatting Error', 'Could not write this record into the staging table.', 1234, ''],
+        ['Formatting Error', 'Could not write this record into the staging table.', '', '', 1234, ''],
     )
     assert len(error_list.rowErrors) == 1
     error = list(error_list.rowErrors.values())[0]

--- a/tests/unit/dataactvalidator/validation_handlers/test_validator.py
+++ b/tests/unit/dataactvalidator/validation_handlers/test_validator.py
@@ -39,12 +39,13 @@ def test_relevant_flex_data(database):
 
 
 def test_failure_row_to_tuple_flex():
-    """Verify that flex data gets included in the failure row info"""
+    """ Verify that flex data gets included in the failure row info """
     flex_data = {
-        2: [FlexField(header='A', cell='a'), FlexField(header='B', cell='b')],
-        4: [FlexField(header='A', cell='c'), FlexField(header='B', cell='d')],
+        2: [FlexField(header='A', cell='a'), FlexField(header='B', cell='b'), FlexField(header='C', cell=None)],
+        4: [FlexField(header='A', cell='c'), FlexField(header='B', cell='d'), FlexField(header='C', cell='g')],
     }
 
     result = validator.failure_row_to_tuple(Mock(), flex_data, [], [], Mock(), {'row_number': 2})
-    assert result.field_name == 'A, B'
-    assert result.failed_value == 'A: a, B: b'
+    assert result.field_name == ''
+    assert result.flex_fields == 'A: a, B: b, C: '
+    assert result.failed_value == ''


### PR DESCRIPTION
**High level description:**
Separating flex fields for single file validations

**Technical details:**
Flex fields are no longer used in single-file validation error metadata storage. Flex fields also no longer appear in the field names column and have their own values column so they aren't part of the `Values Provided` column

**Link to JIRA Ticket:**
[DEV-3568](https://federal-spending-transparency.atlassian.net/browse/DEV-3568)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed