### PR TITLE
DEV-3704: error report nones

### DIFF
--- a/dataactvalidator/validation_handlers/validator.py
+++ b/dataactvalidator/validation_handlers/validator.py
@@ -463,8 +463,20 @@ def relevant_cross_flex_data(failed_rows, submission_id, file_id):
 
 
 def failure_row_to_tuple(rule, flex_data, cols, col_headers, file_id, sql_failure):
-    """Convert a failure SQL row into a ValidationFailure"""
-    row = sql_failure['row_number']
+    """ Convert a failure SQL row into a ValidationFailure.
+
+        Args:
+            rule: the RuleSql object representing the rule failed
+            flex_data: the flex data for the subset of failures currently being converted into errors
+            cols: the column values for the columns that are relevant to the error failed
+            col_headers: the column names for the columns that are relevant to the error failed
+            file_id: the ID number of the file being validated
+            sql_failure: the failure returned from the SQL
+
+        Returns:
+            A ValidationFailure tuple that contains all values needed to write the row to the error report
+    """
+    row = sql_failure['row_number'] or ''
 
     # Determine the extra value for a rule
     expected_value = rule.expected_value
@@ -486,9 +498,8 @@ def failure_row_to_tuple(rule, flex_data, cols, col_headers, file_id, sql_failur
             unique_id_fields.append('{}: {}'.format(fail_header, str(sql_failure[failure_key] or '')))
 
     # Create strings for fields and values
-    values_list = ['{}: {}'.format(header, str(sql_failure[field])) for field, header in zip(cols, col_headers)]
-    flex_list = ['{}: {}'.format(flex_field.header, flex_field.cell if flex_field.cell else '')
-                 for flex_field in flex_data[row]]
+    values_list = ['{}: {}'.format(header, str(sql_failure[field] or '')) for field, header in zip(cols, col_headers)]
+    flex_list = ['{}: {}'.format(flex_field.header, flex_field.cell or '') for flex_field in flex_data[row]]
     # Create unique id string
     unique_id = ', '.join(unique_id_fields)
 

--- a/tests/integration/error_warning_file_tests.py
+++ b/tests/integration/error_warning_file_tests.py
@@ -281,7 +281,7 @@ class ErrorWarningTests(BaseTestValidator):
                 'Field Name': 'budgetauthorityunobligatedbalancebroughtforward_fyb',
                 'Error Message': 'All the elements that have FYB in file A are expected in the first submission'
                                  ' for a fiscal year',
-                'Value Provided': 'budgetauthorityunobligatedbalancebroughtforward_fyb: None',
+                'Value Provided': 'budgetauthorityunobligatedbalancebroughtforward_fyb: ',
                 'Expected Value': 'If the reporting period is Quarter 1, a non-null amount should be submitted for the'
                                   ' following elements: BudgetAuthorityUnobligatedBalanceBroughtForward_FYB',
                 'Difference': '',
@@ -396,7 +396,7 @@ class ErrorWarningTests(BaseTestValidator):
                               ' unobligatedbalance_cpe',
                 'Error Message': 'StatusOfBudgetaryResourcesTotal_CPE= ObligationsIncurredTotalByTAS_CPE'
                                  ' + UnobligatedBalance_CPE',
-                'Value Provided': 'statusofbudgetaryresourcestotal_cpe: None, obligationsincurredtotalbytas_cpe: 8.08,'
+                'Value Provided': 'statusofbudgetaryresourcestotal_cpe: , obligationsincurredtotalbytas_cpe: 8.08,'
                                   ' unobligatedbalance_cpe: 2.02',
                 'Expected Value': 'StatusOfBudgetaryResourcesTotal_CPE must equal the sum of these elements:'
                                   ' ObligationsIncurredTotalByTAS_CPE + UnobligatedBalance_CPE. The Broker cannot'
@@ -412,7 +412,7 @@ class ErrorWarningTests(BaseTestValidator):
                 'Unique ID': 'TAS: 019-2016/2016-0113-000',
                 'Field Name': 'statusofbudgetaryresourcestotal_cpe, totalbudgetaryresources_cpe',
                 'Error Message': 'StatusOfBudgetaryResourcesTotal_CPE = TotalBudgetaryResources_CPE',
-                'Value Provided': 'statusofbudgetaryresourcestotal_cpe: None, totalbudgetaryresources_cpe: 10.1',
+                'Value Provided': 'statusofbudgetaryresourcestotal_cpe: , totalbudgetaryresources_cpe: 10.1',
                 'Expected Value': 'StatusOfBudgetaryResourcesTotal_CPE must equal TotalBudgetaryResources_CPE. The'
                                   ' Broker cannot distinguish which side of the equation is correct for this rule.'
                                   ' Refer to related rule errors and warnings in this report (rules A6, A23) to'


### PR DESCRIPTION
**High level description:**
Removing the last instances where we put `None` in the error/warning reports instead of blanks

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-3704](https://federal-spending-transparency.atlassian.net/browse/DEV-3704)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed