### PR TITLE
Backfill display_tas sf133 script

### DIFF
--- a/dataactcore/scripts/backfill_displaytas_sf133.py
+++ b/dataactcore/scripts/backfill_displaytas_sf133.py
@@ -9,12 +9,13 @@ logger = logging.getLogger(__name__)
 
 BACKFILL_DISPLAYTAS_SF133_SQL = """
     UPDATE sf_133
-    SET display_tas = 
+    SET display_tas =
         CONCAT(
             COALESCE(allocation_transfer_agency || '-', ''),
             COALESCE(agency_identifier || '-', ''),
-            CASE WHEN availability_type_code IS NOT NULL THEN availability_type_code 
-                WHEN beginning_period_of_availa IS NOT NULL AND ending_period_of_availabil IS NOT NULL THEN beginning_period_of_availa || '/' || ending_period_of_availabil
+            CASE WHEN availability_type_code IS NOT NULL THEN availability_type_code
+                WHEN beginning_period_of_availa IS NOT NULL AND ending_period_of_availabil IS NOT NULL
+                    THEN beginning_period_of_availa || '/' || ending_period_of_availabil
                 ELSE ''
                 END,
             COALESCE('-' || main_account_code, ''),

--- a/dataactcore/scripts/backfill_displaytas_sf133.py
+++ b/dataactcore/scripts/backfill_displaytas_sf133.py
@@ -1,0 +1,38 @@
+import logging
+
+from dataactcore.interfaces.db import GlobalDB
+from dataactcore.logging import configure_logging
+
+from dataactvalidator.health_check import create_app
+
+logger = logging.getLogger(__name__)
+
+BACKFILL_DISPLAYTAS_SF133_SQL = """
+    UPDATE sf_133
+    SET display_tas = 
+        CONCAT(
+            COALESCE(allocation_transfer_agency || '-', ''),
+            COALESCE(agency_identifier || '-', ''),
+            CASE WHEN availability_type_code IS NOT NULL THEN availability_type_code 
+                WHEN beginning_period_of_availa IS NOT NULL AND ending_period_of_availabil IS NOT NULL THEN beginning_period_of_availa || '/' || ending_period_of_availabil
+                ELSE ''
+                END,
+            COALESCE('-' || main_account_code, ''),
+            COALESCE('-' || sub_account_code, '')
+        )
+    WHERE display_tas IS NULL;
+"""
+
+if __name__ == '__main__':
+    configure_logging()
+
+    with create_app().app_context():
+        sess = GlobalDB.db().session
+
+        logger.info('Backfilling empty display_tas values in the sf_133 table.')
+        executed = sess.execute(BACKFILL_DISPLAYTAS_SF133_SQL)
+        sess.commit()
+
+        logger.info('Backfill completed, {} rows affected\n'.format(executed.rowcount))
+
+        sess.close()

--- a/dataactvalidator/scripts/load_sf133.py
+++ b/dataactvalidator/scripts/load_sf133.py
@@ -158,6 +158,9 @@ def load_sf133(filename, fiscal_year, fiscal_period, force_sf133_load=False, met
         # NULL in the db.
         data = data.applymap(lambda x: str(x).strip() if len(str(x).strip()) else None)
 
+        # Keeping display_tas out here as it depends on empty allocation_transfer_agency being None and not 000
+        data['display_tas'] = data.apply(lambda row: concat_display_tas_dict(row), axis=1)
+
         # insert to db
         table_name = SF133.__table__.name
         num = insert_dataframe(data, table_name, sess.connection())
@@ -212,7 +215,7 @@ def clean_sf133_data(filename, sf133_data):
 
     # add concatenated TAS field for internal use (i.e., joining to staging tables)
     data['tas'] = data.apply(lambda row: format_internal_tas(row), axis=1)
-    data['display_tas'] = data.apply(lambda row: concat_display_tas_dict(row), axis=1)
+    data['display_tas'] = ''
     data['amount'] = data['amount'].astype(float)
 
     data = fill_blank_sf133_lines(data)


### PR DESCRIPTION
**High level description:**
Simple script to backfill the display_tas column in SF-133 table.

**Technical details:**
- Also fixed the SF-133 loader so that display_tas is more accurate.
- Performance in comment

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed