### PR TITLE
DEV-3804: Prevent duplicate agencies listing

### DIFF
--- a/dataactbroker/handlers/agency_handler.py
+++ b/dataactbroker/handlers/agency_handler.py
@@ -55,10 +55,15 @@ def get_accessible_agencies():
         cgac_affiliations = [aff for aff in g.user.affiliations if aff.cgac]
         frec_affiliations = [aff for aff in g.user.affiliations if aff.frec]
 
-        cgac_list = [{'agency_name': aff.cgac.agency_name, 'cgac_code': aff.cgac.cgac_code} for aff in
-                     cgac_affiliations]
-        frec_list = [{'agency_name': aff.frec.agency_name, 'frec_code': aff.frec.frec_code} for aff in
-                     frec_affiliations]
+        # Start with an object of objects to prevent duplicates
+        cgac_list = {aff.cgac.cgac_code: {'agency_name': aff.cgac.agency_name, 'cgac_code': aff.cgac.cgac_code} for
+                     aff in cgac_affiliations}
+        frec_list = {aff.frec.frec_code: {'agency_name': aff.frec.agency_name, 'frec_code': aff.frec.frec_code} for
+                     aff in frec_affiliations}
+
+        # Convert the values in the objects to lists
+        cgac_list = list(cgac_list.values())
+        frec_list = list(frec_list.values())
 
         return {'cgac_agency_list': cgac_list, 'frec_agency_list': frec_list}
 

--- a/tests/unit/dataactbroker/test_domain_routes.py
+++ b/tests/unit/dataactbroker/test_domain_routes.py
@@ -18,7 +18,9 @@ def domain_app(test_app):
 
 @pytest.mark.usefixtures("user_constants")
 def test_list_agencies_limits(domain_app, database):
-    """List agencies should limit to only the user's agencies"""
+    """ List agencies should limit to only the user's agencies and should not duplicate the same agency even if there
+        are multiple instances of the same agency in the user permissions.
+    """
     user = UserFactory()
     cgac = CGACFactory()
     frec_cgac = CGACFactory()
@@ -28,7 +30,9 @@ def test_list_agencies_limits(domain_app, database):
                  SubTierAgencyFactory(sub_tier_agency_code='1', cgac=frec_cgac, frec=frec, is_frec=True,
                                       sub_tier_agency_name="Test Subtier Agency 1")]
     user.affiliations = [UserAffiliation(cgac=cgac, frec=None, permission_type_id=PERMISSION_SHORT_DICT['w']),
-                         UserAffiliation(cgac=None, frec=frec, permission_type_id=PERMISSION_SHORT_DICT['w'])]
+                         UserAffiliation(cgac=cgac, frec=None, permission_type_id=PERMISSION_SHORT_DICT['f']),
+                         UserAffiliation(cgac=None, frec=frec, permission_type_id=PERMISSION_SHORT_DICT['w']),
+                         UserAffiliation(cgac=None, frec=frec, permission_type_id=PERMISSION_SHORT_DICT['f'])]
     database.session.add_all([cgac] + [frec_cgac] + [frec] + sub_tiers + [user])
     database.session.commit()
 
@@ -44,7 +48,7 @@ def test_list_agencies_limits(domain_app, database):
 
 
 def test_list_agencies_superuser(domain_app, database):
-    """All agencies should be visible to website admins"""
+    """ All agencies should be visible to website admins """
     user = UserFactory(website_admin=True)
     cgacs = [CGACFactory(cgac_code=str(i)) for i in range(3)]
     frec_cgac = CGACFactory()
@@ -67,7 +71,7 @@ def test_list_agencies_superuser(domain_app, database):
 
 @pytest.mark.usefixtures("user_constants")
 def test_list_agencies_all(domain_app, database):
-    """All agencies should be visible to website admins"""
+    """ All agencies should be visible to website admins """
     user = UserFactory()
     cgacs = [CGACFactory(cgac_code=str(i)) for i in range(3)]
     frec_cgac = CGACFactory()


### PR DESCRIPTION
**High level description:**
Making sure agencies aren't duplicated in the agency list

**Technical details:**
Preventing duplication of agencies that the user has more than one permission for in the database (DABS and FABS) when calling `list_agencies`

**Link to JIRA Ticket:**
[DEV-3804](https://federal-spending-transparency.atlassian.net/browse/DEV-3804)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed