### PR TITLE
OPS-1036 remove debug log level for supervisor

### DIFF
--- a/dataactbroker/config/supervisord.conf
+++ b/dataactbroker/config/supervisord.conf
@@ -21,5 +21,4 @@ startsecs=1
 startretries=10
 
 [supervisord]
-loglevel=debug
 environment=

--- a/dataactvalidator/config/supervisord.conf
+++ b/dataactvalidator/config/supervisord.conf
@@ -26,4 +26,3 @@ environment=PYTHONPATH=%(ENV_PATH)s:/data-act/backend
 command=python3 health_check.py
 
 [supervisord]
-loglevel=debug


### PR DESCRIPTION
**High level description:**
Reduce verbosity of supervisord.log by not duplicating app logs in it.

**Technical details:**
It turns out that having this set at debug will duplicate any console logging output from the running python processes to the supervisor logs

- see: debug puts process output into the normal log: http://supervisord.org/logging.html#activity-log-levels
- see: about how child process stderr and stdout gets logged when defaulted to AUTO: http://supervisord.org/logging.html#child-process-logs
- see that the defaults when not set puts it in the /tmp dir with 50MB rotated files up to a max of 10 files: http://supervisord.org/configuration.html

**Link to JIRA Ticket:**
[OPS-1036](https://federal-spending-transparency.atlassian.net/browse/DEV-1036)

The following are ALL required for the PR to be merged:
- [NA] Backend review completed
- [NA] Merged concurrently with [Frontend#1234](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1234)
- [NA] Unit & integration tests updated with relevant test cases
- [NA] Frontend impact assessment completed