### PR TITLE
DEV-4196 (hotfix): Updating B14 difference column to be the difference and not the double

### DIFF
--- a/dataactvalidator/config/sqlrules/b14_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b14_object_class_program_activity.sql
@@ -47,7 +47,7 @@ SELECT DISTINCT
         SUM(ussgl490800_authority_outl_cpe) - SUM(ussgl490800_authority_outl_fyb) +
         SUM(ussgl498100_upward_adjustm_cpe) +
         SUM(ussgl498200_upward_adjustm_cpe)
-    ) - sf.amount AS "difference",
+    ) + sf.amount AS "difference",
     op.display_tas AS "uniqueid_TAS"
 FROM object_class_program_activity_b14_{0} AS op
     INNER JOIN sf_133 AS sf


### PR DESCRIPTION
**High level description:**
Fixing miscalculation when generating the difference value for warning B14.

**Technical details:**
Since the amount is negative, the difference is (total - (-1 * amount)) => total + amount, not total - amount

**Link to JIRA Ticket:**
[DEV-4196](https://federal-spending-transparency.atlassian.net/browse/DEV-4196)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- [x] Tested locally