### PR TITLE
DEV-4285: Prevent FABS re-upload

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -492,6 +492,8 @@ class FileHandler:
                 if not existing_submission_obj.d2_submission:
                     raise ResponseException("Existing submission must be a FABS submission", StatusCode.CLIENT_ERROR)
                 jobs = sess.query(Job).filter(Job.submission_id == existing_submission_id)
+                if existing_submission_obj.publish_status_id != PUBLISH_STATUS_DICT['unpublished']:
+                    raise ResponseException("FABS submission has already been published", StatusCode.CLIENT_ERROR)
                 for job in jobs:
                     if job.job_status_id == JOB_STATUS_DICT['running']:
                         raise ResponseException("Submission already has a running job", StatusCode.CLIENT_ERROR)

--- a/tests/integration/fabs_upload_tests.py
+++ b/tests/integration/fabs_upload_tests.py
@@ -149,16 +149,24 @@ class FABSUploadTests(BaseTestAPI):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], "Existing submission must be a FABS submission")
 
+    def test_upload_published_fabs_submission(self):
+        response = self.app.post("/v1/upload_fabs_file/", {"existing_submission_id": str(self.published_submission)},
+                                 upload_files=[('fabs', 'fabs.csv',
+                                                open('tests/integration/data/fabs.csv', 'rb').read())],
+                                 headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], "FABS submission has already been published")
+
     def test_upload_fabs_duplicate_running(self):
         """ Test file submissions for when the job is already running """
         # Mark a job as already running
         self.session.add(Job(file_type_id=FILE_TYPE_DICT['fabs'], job_status_id=JOB_STATUS_DICT['running'],
-                             job_type_id=JOB_TYPE_DICT['file_upload'], submission_id=str(self.d2_submission),
+                             job_type_id=JOB_TYPE_DICT['file_upload'], submission_id=str(self.d2_submission_2),
                              original_filename=None, file_size=None, number_of_rows=None))
         self.session.commit()
 
         response = self.app.post("/v1/upload_fabs_file/",
-                                 {"existing_submission_id": str(self.d2_submission)},
+                                 {"existing_submission_id": str(self.d2_submission_2)},
                                  upload_files=[('fabs', 'fabs.csv',
                                                 open('tests/integration/data/fabs.csv', 'rb').read())],
                                  headers={"x-session-id": self.session_id}, expect_errors=True)


### PR DESCRIPTION
**High level description:**
It's been discovered that users on the frontend are able to re-upload FABS files post submission. This should resolve that.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-4285](https://federal-spending-transparency.atlassian.net/browse/DEV-4285)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Testing manually locally