### PR TITLE
Warmfix: Fixing B15 Difference Logic

### DIFF
--- a/dataactvalidator/config/sqlrules/b15_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b15_object_class_program_activity.sql
@@ -47,7 +47,7 @@ SELECT DISTINCT
         SUM(ussgl490800_authority_outl_cpe) - SUM(ussgl490800_authority_outl_fyb) +
         SUM(ussgl498100_upward_adjustm_cpe) +
         SUM(ussgl498200_upward_adjustm_cpe)
-    ) - sf.amount AS "difference",
+    ) + sf.amount AS "difference",
     op.display_tas AS "uniqueid_TAS"
 FROM object_class_program_activity_b15_{0} AS op
     INNER JOIN sf_133 AS sf


### PR DESCRIPTION
**High level description:**
Like B14 (https://github.com/fedspendingtransparency/data-act-broker-backend/pull/1754), B15 has the negative difference applied to it. This PR, like the previous, should resolve it. 

**Technical details:**
N/A

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed