### PR TITLE
Fix: Incorrect warning list SQL

### DIFF
--- a/dataactbroker/handlers/dashboard_handler.py
+++ b/dataactbroker/handlers/dashboard_handler.py
@@ -672,7 +672,7 @@ def active_submission_table(submission, file, error_level, page=1, limit=5, sort
     elif error_level == 'warning':
         table_query = table_query.filter(ErrorMetadata.severity_id == RULE_SEVERITY_DICT['warning'])
 
-    table_query = file_filter(table_query, ErrorMetadata, [file])
+    table_query = file_filter(table_query, RuleSql, [file])
 
     # Total number of entries in the table
     response['page_metadata']['total'] = table_query.count()


### PR DESCRIPTION
**High level description:**
We want the file filter to be based on RuleSql to cover for the one rule label that we use twice

**Technical details:**
The way we were joining and filtering on file type was allowing for the single instance of 2 rules with the same label to duplicate results in the active dashboard table. Fixing that here.

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed