### PR TITLE
DEV-2618: max length fatal

### DIFF
--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -513,16 +513,10 @@ class ValidationManager:
                                              self.csv_schema, self.short_to_long_dict[self.file_type.file_type_id],
                                              flex_data, type_error_rows)
 
-                error_dfs = [req_errors, type_errors, length_errors]
-                warning_dfs = [pd.DataFrame(columns=list(self.report_headers + ['error_type']))]
-
-                total_errors = pd.concat(error_dfs, ignore_index=True)
-                total_warnings = pd.concat(warning_dfs, ignore_index=True)
+                total_errors = pd.concat([req_errors, type_errors, length_errors], ignore_index=True)
 
                 # Converting these to ints because pandas likes to change them to floats randomly
                 total_errors[['Row Number', 'error_type']] = total_errors[['Row Number', 'error_type']].astype(int)
-                total_warnings[['Row Number', 'error_type']] = total_warnings[['Row Number', 'error_type']]. \
-                    astype(int)
 
                 self.error_rows.extend([int(x) for x in total_errors['Row Number'].tolist()])
 
@@ -531,13 +525,7 @@ class ValidationManager:
                                                      row['error_type'], row['Row Number'], row['Rule Label'],
                                                      self.file_type.file_type_id, None, RULE_SEVERITY_DICT['fatal'])
 
-                for index, row in total_warnings.iterrows():
-                    self.error_list.record_row_error(self.job.job_id, self.file_name, row['Field Name'],
-                                                     row['error_type'], row['Row Number'], row['Rule Label'],
-                                                     self.file_type.file_type_id, None, RULE_SEVERITY_DICT['warning'])
-
                 total_errors.drop(['error_type'], axis=1, inplace=True, errors='ignore')
-                total_warnings.drop(['error_type'], axis=1, inplace=True, errors='ignore')
 
                 # Remove type error rows from original dataframe
                 chunk_df = chunk_df[~chunk_df['row_number'].isin(type_error_rows)]

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -513,12 +513,8 @@ class ValidationManager:
                                              self.csv_schema, self.short_to_long_dict[self.file_type.file_type_id],
                                              flex_data, type_error_rows)
 
-                if self.is_fabs:
-                    error_dfs = [req_errors, type_errors, length_errors]
-                    warning_dfs = [pd.DataFrame(columns=list(self.report_headers + ['error_type']))]
-                else:
-                    error_dfs = [req_errors, type_errors]
-                    warning_dfs = [length_errors]
+                error_dfs = [req_errors, type_errors, length_errors]
+                warning_dfs = [pd.DataFrame(columns=list(self.report_headers + ['error_type']))]
 
                 total_errors = pd.concat(error_dfs, ignore_index=True)
                 total_warnings = pd.concat(warning_dfs, ignore_index=True)

--- a/tests/integration/error_warning_file_tests.py
+++ b/tests/integration/error_warning_file_tests.py
@@ -254,24 +254,6 @@ class ErrorWarningTests(BaseTestValidator):
         assert report_headers == self.validator.report_headers
         assert len(report_content) == 0
 
-        # Length Error
-        report_headers, report_content = self.generate_file_report(LENGTH_ERROR, 'appropriations', warning=True)
-        assert report_headers == self.validator.report_headers
-        expected_values = [
-            {
-                'Unique ID': 'TAS: 069-013-X-2050-005',
-                'Field Name': 'grossoutlayamountbytas_cpe',
-                'Error Message': 'Value was longer than maximum length for this field.',
-                'Value Provided': 'grossoutlayamountbytas_cpe: 35000000000000000000000000',
-                'Expected Value': 'Max length: 21',
-                'Difference': '',
-                'Flex Field': 'flex_field_a: FLEX_A, flex_field_b: FLEX_B',
-                'Row Number': '6',
-                'Rule Label': ''
-            }
-        ]
-        assert report_content == expected_values
-
         # SQL Validation
         report_headers, report_content = self.generate_file_report(RULE_FAILED_WARNING, 'appropriations', warning=True)
         assert report_headers == self.validator.report_headers
@@ -378,6 +360,24 @@ class ErrorWarningTests(BaseTestValidator):
                                  ' fixed before the rest of the validation logic is applied to that line.',
                 'Value Provided': 'statusofbudgetaryresourcestotal_cpe: A',
                 'Expected Value': 'This field must be a decimal',
+                'Difference': '',
+                'Flex Field': 'flex_field_a: FLEX_A, flex_field_b: FLEX_B',
+                'Row Number': '6',
+                'Rule Label': ''
+            }
+        ]
+        assert report_content == expected_values
+
+        # Length Error
+        report_headers, report_content = self.generate_file_report(LENGTH_ERROR, 'appropriations', warning=False)
+        assert report_headers == self.validator.report_headers
+        expected_values = [
+            {
+                'Unique ID': 'TAS: 069-013-X-2050-005',
+                'Field Name': 'grossoutlayamountbytas_cpe',
+                'Error Message': 'Value was longer than maximum length for this field.',
+                'Value Provided': 'grossoutlayamountbytas_cpe: 35000000000000000000000000',
+                'Expected Value': 'Max length: 21',
                 'Difference': '',
                 'Flex Field': 'flex_field_a: FLEX_A, flex_field_b: FLEX_B',
                 'Row Number': '6',


### PR DESCRIPTION
**High level description:**
Max length violations are always fatal errors now.

**Technical details:**
- Removing the differentiation between FABS and DABS when writing length errors
- Removing some now-unnecessary processing of the initial warning dataframe because it will never be populated in the initial validations

**Link to JIRA Ticket:**
[DEV-2618](https://federal-spending-transparency.atlassian.net/browse/DEV-2618)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed