### PR TITLE
DEV-4456: PPOP Scope Fix

### DIFF
--- a/dataactcore/scripts/backfill_ppop_scope_fabs.py
+++ b/dataactcore/scripts/backfill_ppop_scope_fabs.py
@@ -18,6 +18,8 @@ BACKFILL_FABS_PPOP_SCOPE_SQL_1 = """
              THEN 'County-wide'
              WHEN UPPER(place_of_performance_code) = '00FORGN'
              THEN 'Foreign'
+             WHEN place_of_performance_code ~ '^[a-zA-Z]{2}\d{4}[\dRr]$'
+             THEN 'City-wide'
          END
     WHERE (place_of_performance_zip4a IS NULL
         AND place_of_performance_scope IS NULL);
@@ -52,6 +54,6 @@ if __name__ == '__main__':
         affected += executed.rowcount
         sess.commit()
 
-        logger.info('Backfill completed, {} rows affected\n'.format(executed.rowcount))
+        logger.info('Backfill completed, {} rows affected\n'.format(affected))
 
         sess.close()


### PR DESCRIPTION
**High level description:**
* Resolving bug with ppop scope derivation by moving it after most of the derivations.
* Adding case where ppop zip is blank and the code is XX##### or XX####R -> 'City-wide'

**Technical details:**
* Updating backfill ppop script which should be run again to account for the missed derivations.

**Link to JIRA Ticket:**
[DEV-4456](https://federal-spending-transparency.atlassian.net/browse/DEV-4456)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases