### PR TITLE
DEV-4505: Adding email to list_submission_users endpoint

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1287,7 +1287,7 @@ This endpoint lists all users with submissions that the requesting user can view
 `/v1/list_submission_users/?d2_submission=False`
 
 ##### Request Params
-- `d2_submission` - **optional** - a boolean indicating if the submissions checked should be FABS or DABS (True for FABS). Defaults to `False` if not provided.
+- `d2_submission`: (boolean) if the submissions checked should be FABS or DABS (True for FABS). Defaults to `False` if not provided.
 
 ##### Response (JSON)
 
@@ -1296,11 +1296,13 @@ This endpoint lists all users with submissions that the requesting user can view
   "users": [
     {
       "user_id": 4,
-      "name": "Another User"
+      "name": "Another User",
+      "email": "another_user@domain.com"
     },
     {
       "user_id": 1,
-      "name": "User One"
+      "name": "User One",
+      "email": "user1@domain.com"
     }
   ]
 }
@@ -1308,9 +1310,10 @@ This endpoint lists all users with submissions that the requesting user can view
 
 ##### Response Attributes
 
-- `users` - An array of objects that contain the user's ID and name:
-    - `user_id` - an integer indicating ID of the user
-    - `name` - a string containing the name of the user
+- `users`: ([dict]) contain the user's ID, name, and email:
+    - `user_id`: (int) ID of the user
+    - `name`: (string) name of the user
+    - `email`: (string) email of the user
 
 ##### Errors
 Possible HTTP Status Codes:

--- a/dataactbroker/handlers/account_handler.py
+++ b/dataactbroker/handlers/account_handler.py
@@ -516,11 +516,11 @@ def list_submission_users(d2_submission):
     exists_query = exists_query.exists()
 
     # Get all the relevant users
-    user_results = sess.query(User.user_id, User.name).filter(exists_query).order_by(User.name).all()
+    user_results = sess.query(User.user_id, User.name, User.email).filter(exists_query).order_by(User.name).all()
 
     # Create an array containing relevant users in a readable format
     user_list = []
     for user in user_results:
-        user_list.append({'user_id': user[0], 'name': user[1]})
+        user_list.append({'user_id': user[0], 'name': user[1], 'email': user[2]})
 
     return JsonResponse.create(StatusCode.OK, {"users": user_list})

--- a/tests/unit/dataactbroker/test_user_routes.py
+++ b/tests/unit/dataactbroker/test_user_routes.py
@@ -51,8 +51,8 @@ def test_list_user_emails(database, user_app):
 def test_list_submission_users_admin(database):
     """ Test listing all users with a submission (admin called the function) """
     cgacs = [CGACFactory(cgac_code='000'), CGACFactory(cgac_code='111')]
-    admin_user = UserFactory(website_admin=True, name='Admin User')
-    other_user = UserFactory.with_cgacs(cgacs[0], name='Test User')
+    admin_user = UserFactory(website_admin=True, name='Admin User', email='admin@domain.com')
+    other_user = UserFactory.with_cgacs(cgacs[0], name='Test User', email='test@domain.com')
     database.session.add_all(cgacs + [admin_user, other_user])
     database.session.commit()
 
@@ -68,6 +68,7 @@ def test_list_submission_users_admin(database):
     assert len(user_response) == 1
     assert user_response[0]['user_id'] == other_user.user_id
     assert user_response[0]['name'] == other_user.name
+    assert user_response[0]['email'] == other_user.email
 
 
 @pytest.mark.usefixtures("user_constants")
@@ -75,8 +76,8 @@ def test_list_submission_users_admin(database):
 def test_list_submission_users_cgac_affil(database):
     """ Test listing users based on cgac affiliations """
     cgacs = [CGACFactory(cgac_code='000'), CGACFactory(cgac_code='111')]
-    first_user = UserFactory.with_cgacs(cgacs[0], name='Test User 1')
-    other_user = UserFactory.with_cgacs(cgacs[1], name='Test User')
+    first_user = UserFactory.with_cgacs(cgacs[0], name='Test User 1', email='test1@domain.com')
+    other_user = UserFactory.with_cgacs(cgacs[1], name='Test User', email='test@domain.com')
     database.session.add_all(cgacs + [first_user, other_user])
     database.session.commit()
 
@@ -93,6 +94,7 @@ def test_list_submission_users_cgac_affil(database):
     assert len(user_response) == 2
     assert {user_response[0]['user_id'], user_response[1]['user_id']} == {first_user.user_id, other_user.user_id}
     assert {user_response[0]['name'], user_response[1]['name']} == {first_user.name, other_user.name}
+    assert {user_response[0]['email'], user_response[1]['email']} == {first_user.email, other_user.email}
 
     g.user = other_user
     response = list_submission_users(False)
@@ -102,6 +104,7 @@ def test_list_submission_users_cgac_affil(database):
     assert len(user_response) == 1
     assert user_response[0]['user_id'] == other_user.user_id
     assert user_response[0]['name'] == other_user.name
+    assert user_response[0]['email'] == other_user.email
 
 
 @pytest.mark.usefixtures("user_constants")
@@ -110,9 +113,9 @@ def test_list_submission_users_frec_affil(database):
     """ Test listing users based on frec affiliations """
     cgacs = [CGACFactory(cgac_code='000'), CGACFactory(cgac_code='111')]
     frecs = [FRECFactory(frec_code='0000', cgac=cgacs[0]), FRECFactory(frec_code='1111', cgac=cgacs[1])]
-    first_user = UserFactory.with_cgacs(cgacs[0], name='Test User 1')
-    other_user = UserFactory.with_cgacs(cgacs[1], name='Test User')
-    third_user = UserFactory(name='Frec User')
+    first_user = UserFactory.with_cgacs(cgacs[0], name='Test User 1', email='test1@domain.com')
+    other_user = UserFactory.with_cgacs(cgacs[1], name='Test User', email='test@domain.com')
+    third_user = UserFactory(name='Frec User', email='frec@domain.com')
     third_user.affiliations = [UserAffiliation(frec=frecs[0], user_id=third_user.user_id,
                                                permission_type_id=PERMISSION_TYPE_DICT['reader'])]
     database.session.add_all(cgacs + frecs + [first_user, other_user])
@@ -132,6 +135,7 @@ def test_list_submission_users_frec_affil(database):
     assert len(user_response) == 1
     assert user_response[0]['user_id'] == first_user.user_id
     assert user_response[0]['name'] == first_user.name
+    assert user_response[0]['email'] == first_user.email
 
 
 @pytest.mark.usefixtures("user_constants")
@@ -140,9 +144,9 @@ def test_list_submission_users_cgac_frec_affil(database):
     """ Test listing users based on both cgac and frec affiliations """
     cgacs = [CGACFactory(cgac_code='000'), CGACFactory(cgac_code='111')]
     frecs = [FRECFactory(frec_code='0000', cgac=cgacs[0]), FRECFactory(frec_code='1111', cgac=cgacs[1])]
-    first_user = UserFactory.with_cgacs(cgacs[0], name='Test User 1')
-    other_user = UserFactory.with_cgacs(cgacs[1], name='Test User')
-    third_user = UserFactory.with_cgacs(cgacs[1], name='Frec User')
+    first_user = UserFactory.with_cgacs(cgacs[0], name='Test User 1', email='test1@domain.com')
+    other_user = UserFactory.with_cgacs(cgacs[1], name='Test User', email='test@domain.com')
+    third_user = UserFactory.with_cgacs(cgacs[1], name='Frec User', email='frec@domain.com')
     third_user.affiliations =\
         third_user.affiliations + [UserAffiliation(frec=frecs[0], user_id=third_user.user_id,
                                                    permission_type_id=PERMISSION_TYPE_DICT['reader'])]
@@ -164,6 +168,7 @@ def test_list_submission_users_cgac_frec_affil(database):
     assert len(user_response) == 2
     assert {user_response[0]['user_id'], user_response[1]['user_id']} == {first_user.user_id, other_user.user_id}
     assert {user_response[0]['name'], user_response[1]['name']} == {first_user.name, other_user.name}
+    assert {user_response[0]['email'], user_response[1]['email']} == {first_user.email, other_user.email}
 
 
 @pytest.mark.usefixtures("user_constants")
@@ -171,8 +176,8 @@ def test_list_submission_users_cgac_frec_affil(database):
 def test_list_submission_users_owned(database):
     """ Test listing users based on owned submissions """
     cgacs = [CGACFactory(cgac_code='000'), CGACFactory(cgac_code='111')]
-    first_user = UserFactory.with_cgacs(cgacs[0], name='Test User 1')
-    other_user = UserFactory.with_cgacs(cgacs[0], name='Test User')
+    first_user = UserFactory.with_cgacs(cgacs[0], name='Test User 1', email='test1@domain.com')
+    other_user = UserFactory.with_cgacs(cgacs[0], name='Test User', email='test@domain.com')
     database.session.add_all(cgacs + [first_user, other_user])
     database.session.commit()
 
@@ -195,6 +200,7 @@ def test_list_submission_users_owned(database):
     assert len(user_response) == 1
     assert user_response[0]['user_id'] == other_user.user_id
     assert user_response[0]['name'] == other_user.name
+    assert user_response[0]['email'] == other_user.email
 
 
 @pytest.mark.usefixtures("user_constants")
@@ -202,8 +208,8 @@ def test_list_submission_users_owned(database):
 def test_list_submission_users_fabs_dabs(database):
     """ Test listing DABS vs FABS users """
     cgacs = [CGACFactory(cgac_code='000'), CGACFactory(cgac_code='111')]
-    first_user = UserFactory.with_cgacs(cgacs[0], name='Test User 1')
-    other_user = UserFactory.with_cgacs(cgacs[1], name='Test User')
+    first_user = UserFactory.with_cgacs(cgacs[0], name='Test User 1', email='test1@domain.com')
+    other_user = UserFactory.with_cgacs(cgacs[1], name='Test User', email='test@domain.com')
     database.session.add_all(cgacs + [first_user, other_user])
     database.session.commit()
 
@@ -228,3 +234,4 @@ def test_list_submission_users_fabs_dabs(database):
     assert len(user_response) == 1
     assert user_response[0]['user_id'] == other_user.user_id
     assert user_response[0]['name'] == other_user.name
+    assert user_response[0]['email'] == other_user.email


### PR DESCRIPTION
**High level description:**
Simply adding the user's email to the `list_submission_users` endpoint. 

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-4505](https://federal-spending-transparency.atlassian.net/browse/DEV-4505)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed (@ebdabbs)