### PR TITLE
DEV-4317: get_significance_counts

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -2311,6 +2311,7 @@ This endpoint gets the breakdown of rules and their counts by their categories o
             "rule_label": "C23.3",
             "category": "Accuracy",
             "significance": 3,
+            "impact": "high",
             "instances": 36,
             "percentage": 0.0
         },
@@ -2318,6 +2319,7 @@ This endpoint gets the breakdown of rules and their counts by their categories o
             "rule_label": "C9",
             "category": "Completeness",
             "significance": 4,
+            "impact": "low",
             "instances": 73,
             "percentage": 0.1
         },
@@ -2325,6 +2327,7 @@ This endpoint gets the breakdown of rules and their counts by their categories o
             "rule_label": "C8",
             "category": "Completeness",
             "significance": 9,
+            "impact": "medium",
             "instances": 42240,
             "percentage": 99.7
         }
@@ -2340,6 +2343,7 @@ The response is a dictionary representing the rules and their significances/cate
     - `rule_label`: (string) the label of the rule
     - `category`: (string) the category of the rule
     - `significance`: (integer) the significance of the rule
+    - `impact`: (string) the impact of the rule
     - `instances`: (integer) the number of times this rule was triggered
     - `percentage`: (float, rounded to tenth) the number of times this rule was triggered
 

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -2281,6 +2281,78 @@ Possible HTTP Status Codes:
 - 401: Login required
 - 403: Permission denied, user does not have permission to view this submission
 
+#### GET "/v1/get\_significance\_counts/"
+This endpoint gets the breakdown of rules and their counts by their categories or significances in a given submission/file, returning the total number of rules and the rule counts.
+
+##### Sample Request
+`/v1/get_significance_counts/?submission_id=1234&file=A&error_level=warning`
+
+##### Request Params
+- `submission_id`: (required, integer) the ID of the submission to view
+- `file`: (required, string) The file to get the warning or error data for. Allowed values are:
+    - `A`: Appropriations
+    - `B`: Program Activity
+    - `C`: Award Financial
+    - `cross-AB`: cross-file between Appropriations and Program Activity
+    - `cross-BC`: cross-file between Program Activity and Award Financial
+    - `cross-CD1`: cross-file between Award Financial and Award Procurement
+    - `cross-CD2`: cross-file between Award Financial and Award Financial Assistance
+- `error_level`: (string) The level of error data to gather an overview for. Defaults to warning. Allowed values:
+    - `warning`
+    - `error`
+    - `mixed`
+
+##### Response (JSON)
+```
+{
+    "total_instances": 42349
+    "rules": [
+        {
+            "rule_label": "C23.3",
+            "category": "Accuracy",
+            "significance": 3,
+            "instances": 36,
+            "percentage": 0.0
+        },
+        {
+            "rule_label": "C9",
+            "category": "Completeness",
+            "significance": 4,
+            "instances": 73,
+            "percentage": 0.1
+        },
+        {
+            "rule_label": "C8",
+            "category": "Completeness",
+            "significance": 9,
+            "instances": 42240,
+            "percentage": 99.7
+        }
+    ]
+}
+```
+
+##### Response Attributes
+The response is a dictionary representing the rules and their significances/categories/counts with the following:
+
+- `total_instances`: (integer) the total number of instances (errors or warnings) for this file in this submission
+- `rules `: ([dict]) a detailed breakdown of each rule that is present in this submission/file containing the following keys:
+    - `rule_label`: (string) the label of the rule
+    - `category`: (string) the category of the rule
+    - `significance`: (integer) the significance of the rule
+    - `instances`: (integer) the number of times this rule was triggered
+    - `percentage`: (float, rounded to tenth) the number of times this rule was triggered
+
+##### Errors
+Possible HTTP Status Codes:
+
+- 400:
+    - Invalid parameter
+    - Missing required parameter
+    - FABS submission requested
+- 401: Login required
+- 403: Permission denied, user does not have permission to view this submission
+
 ## Settings Routes
 
 ### GET "/v1/rule\_settings"

--- a/dataactbroker/handlers/dashboard_handler.py
+++ b/dataactbroker/handlers/dashboard_handler.py
@@ -687,7 +687,8 @@ def get_significance_counts(submission, file, error_level):
 
     # Initial query
     significance_query = sess.query(ErrorMetadata.original_rule_label, ErrorMetadata.occurrences,
-                                    ErrorMetadata.rule_failed, RuleSetting.priority, RuleSql.category).\
+                                    ErrorMetadata.rule_failed, RuleSetting.priority, RuleSql.category,
+                                    RuleSetting.impact_id).\
         join(Job, Job.job_id == ErrorMetadata.job_id). \
         join(RuleSetting, RuleSetting.rule_label == ErrorMetadata.original_rule_label). \
         join(RuleSql, RuleSql.rule_label == ErrorMetadata.original_rule_label). \
@@ -706,6 +707,7 @@ def get_significance_counts(submission, file, error_level):
             'rule_label': result.original_rule_label,
             'category': result.category,
             'significance': result.priority,
+            'impact': RULE_IMPACT_DICT_ID[result.impact_id],
             'instances': result.occurrences
         })
         response['total_instances'] += result.occurrences

--- a/dataactbroker/handlers/dashboard_handler.py
+++ b/dataactbroker/handlers/dashboard_handler.py
@@ -663,10 +663,10 @@ def get_significance_counts(submission, file, error_level):
     """ Gathers information for the signficances section of the active DABS dashboard.
 
             Args:
-                submission: submission to get the impact counts for
-                file: The type of file to get the impact counts for
-                error_level: whether to get warning or error counts for the impact counts (possible: warning, error,
-                    mixed)
+                submission: submission to get the significance counts for
+                file: The type of file to get the significance counts for
+                error_level: whether to get warning or error counts for the significance counts (possible: warning,
+                             error, mixed)
 
             Returns:
                 A response containing significance data of the provided submission for the active DABS dashboard.

--- a/dataactbroker/helpers/dashboard_helper.py
+++ b/dataactbroker/helpers/dashboard_helper.py
@@ -41,3 +41,23 @@ def agency_has_settings(sess, agency_code, file):
     query = sess.query(RuleSetting).filter(RuleSetting.agency_code == agency_code)
     query = file_filter(query, RuleSetting, [file])
     return query.count() > 0
+
+
+def agency_settings_filter(sess, query, agency_code, file):
+    """ Given the provided query, determine to filter on the default settings or not
+
+        Arguments:
+            sess: the database connection
+            query: the sqlalchemy query to apply the filters to
+            agency_code: the agency code to see if they have saved settings already
+            file:
+
+        Returns:
+            the same queryset provided with agency settings filter included
+    """
+    has_settings = agency_has_settings(sess, agency_code, file)
+    if has_settings:
+        query = query.filter(RuleSetting.agency_code == agency_code)
+    else:
+        query = query.filter(RuleSetting.agency_code.is_(None))
+    return query

--- a/dataactbroker/helpers/filters_helper.py
+++ b/dataactbroker/helpers/filters_helper.py
@@ -1,6 +1,6 @@
 from sqlalchemy import or_, and_
 from flask import g
-from dataactcore.models.lookups import FILE_TYPE_DICT_LETTER_ID
+from dataactcore.models.lookups import FILE_TYPE_DICT_LETTER_ID, RULE_SEVERITY_DICT
 
 from dataactcore.models.domainModels import CGAC, FREC
 from dataactcore.models.errorModels import CertifiedErrorMetadata, ErrorMetadata
@@ -114,3 +114,23 @@ def file_filter(query, file_model, files):
                 file_type_filters.append(and_(file_id == FILE_TYPE_DICT_LETTER_ID[file_types[1:]],
                                               target_file_id == FILE_TYPE_DICT_LETTER_ID[file_types[:1]]))
     return query.filter(or_(*file_type_filters))
+
+
+def rule_severity_filter(query, error_level, error_model=ErrorMetadata):
+    """ Given the provided query, add a filter by files provided the files list.
+
+        Arguments:
+            query: the sqlalchemy query to apply the filters to
+            error_level: the error level to filter on (could be 'error' or 'warning')
+            error_model: the model to apply the filter to (must have a severity_id field)
+
+        Returns:
+            the same queryset provided with rule severity filter included
+    """
+    # If the error level isn't "mixed" add a filter on which severity to pull
+    if error_level == 'error':
+        query = query.filter(error_model.severity_id == RULE_SEVERITY_DICT['fatal'])
+    elif error_level == 'warning':
+        query = query.filter(error_model.severity_id == RULE_SEVERITY_DICT['warning'])
+
+    return query

--- a/dataactbroker/routes/dashboard_routes.py
+++ b/dataactbroker/routes/dashboard_routes.py
@@ -7,7 +7,7 @@ from dataactbroker.permissions import requires_login, requires_submission_perms
 from dataactbroker.handlers.dashboard_handler import (historic_dabs_warning_summary, historic_dabs_warning_table,
                                                       list_rule_labels, historic_dabs_warning_graphs,
                                                       active_submission_overview, active_submission_table,
-                                                      get_impact_counts)
+                                                      get_impact_counts, get_significance_counts)
 from dataactbroker.helpers.dashboard_helper import FILE_TYPES
 
 
@@ -104,6 +104,24 @@ def add_dashboard_routes(app):
         """ Returns the impact counts of the requested submission for the active dashboard """
         error_level = kwargs.get('error_level')
         return get_impact_counts(submission, file, error_level)
+
+    @app.route("/v1/get_significance_counts/", methods=["GET"])
+    @convert_to_submission_id
+    @requires_submission_perms('reader')
+    @use_kwargs({
+        'file': webargs_fields.String(validate=webargs_validate.
+                                      OneOf(['A', 'B', 'C', 'cross-AB', 'cross-BC', 'cross-CD1', 'cross-CD2'],
+                                            error='Must be A, B, C, cross-AB, cross-BC, cross-CD1, or cross-CD2'),
+                                      required=True),
+        'error_level': webargs_fields.String(validate=webargs_validate.
+                                             OneOf(['warning', 'error', 'mixed'],
+                                                   error='Must be either warning, error, or mixed'),
+                                             missing='warning')
+    })
+    def significance_counts(submission, file, **kwargs):
+        """ Returns the impact counts of the requested submission for the active dashboard """
+        error_level = kwargs.get('error_level')
+        return get_significance_counts(submission, file, error_level)
 
     @app.route("/v1/active_submission_table/", methods=["GET"])
     @convert_to_submission_id

--- a/dataactbroker/routes/dashboard_routes.py
+++ b/dataactbroker/routes/dashboard_routes.py
@@ -119,7 +119,7 @@ def add_dashboard_routes(app):
                                              missing='warning')
     })
     def significance_counts(submission, file, **kwargs):
-        """ Returns the impact counts of the requested submission for the active dashboard """
+        """ Returns the significance counts of the requested submission for the active dashboard """
         error_level = kwargs.get('error_level')
         return get_significance_counts(submission, file, error_level)
 

--- a/tests/integration/dashboard_tests.py
+++ b/tests/integration/dashboard_tests.py
@@ -398,7 +398,7 @@ class DashboardTests(BaseTestAPI):
         self.assertEqual(response.json['message'], 'file: Missing data for required field.')
 
     def test_get_significance_counts(self):
-        """ Test successfully getting the impact counts for a submission """
+        """ Test successfully getting the significance counts for a submission """
         # Error type not specified
         params = {'submission_id': self.quarter_sub, 'file': 'A'}
         response = self.app.get('/v1/get_significance_counts/', params, headers={'x-session-id': self.session_id})
@@ -410,7 +410,7 @@ class DashboardTests(BaseTestAPI):
         self.assertEqual(response.status_code, 200)
 
     def test_get_significance_counts_fail(self):
-        """ Test failing to get impact counts for a submission """
+        """ Test failing to get significance counts for a submission """
         # Invalid submission ID
         params = {'submission_id': -1, 'file': 'A'}
         response = self.app.get('/v1/get_significance_counts/', params, expect_errors=True,

--- a/tests/integration/dashboard_tests.py
+++ b/tests/integration/dashboard_tests.py
@@ -396,3 +396,52 @@ class DashboardTests(BaseTestAPI):
                                 headers={'x-session-id': self.session_id})
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], 'file: Missing data for required field.')
+
+    def test_get_significance_counts(self):
+        """ Test successfully getting the impact counts for a submission """
+        # Error type not specified
+        params = {'submission_id': self.quarter_sub, 'file': 'A'}
+        response = self.app.get('/v1/get_significance_counts/', params, headers={'x-session-id': self.session_id})
+        self.assertEqual(response.status_code, 200)
+
+        # Error type specified
+        params = {'submission_id': self.quarter_sub, 'file': 'A', 'error_level': 'mixed'}
+        response = self.app.get('/v1/get_significance_counts/', params, headers={'x-session-id': self.session_id})
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_significance_counts_fail(self):
+        """ Test failing to get impact counts for a submission """
+        # Invalid submission ID
+        params = {'submission_id': -1, 'file': 'A'}
+        response = self.app.get('/v1/get_significance_counts/', params, expect_errors=True,
+                                headers={'x-session-id': self.session_id})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'No such submission')
+
+        # Invalid file type
+        params = {'submission_id': self.quarter_sub, 'file': 'Q'}
+        response = self.app.get('/v1/get_significance_counts/', params, expect_errors=True,
+                                headers={'x-session-id': self.session_id})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'file: Must be A, B, C, cross-AB, cross-BC, cross-CD1, or cross-CD2')
+
+        # Invalid error level
+        params = {'submission_id': self.quarter_sub, 'file': 'A', 'error_level': 'all'}
+        response = self.app.get('/v1/get_significance_counts/', params, expect_errors=True,
+                                headers={'x-session-id': self.session_id})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'error_level: Must be either warning, error, or mixed')
+
+        # Missing submission ID
+        params = {'file': 'A'}
+        response = self.app.get('/v1/get_significance_counts/', params, expect_errors=True,
+                                headers={'x-session-id': self.session_id})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'submission_id is required')
+
+        # Missing file
+        params = {'submission_id': self.quarter_sub}
+        response = self.app.get('/v1/get_significance_counts/', params, expect_errors=True,
+                                headers={'x-session-id': self.session_id})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'file: Missing data for required field.')

--- a/tests/unit/dataactbroker/test_dashboard_handler.py
+++ b/tests/unit/dataactbroker/test_dashboard_handler.py
@@ -1312,6 +1312,7 @@ def test_get_significance_counts(database, monkeypatch):
             {
                 'rule_label': 'A1',
                 'significance': 1,
+                'impact': 'high',
                 "category": 'completeness',
                 'instances': 20,
                 "percentage": 40.0
@@ -1319,6 +1320,7 @@ def test_get_significance_counts(database, monkeypatch):
             {
                 'rule_label': 'A2',
                 'significance': 2,
+                'impact': 'high',
                 "category": 'accuracy',
                 'instances': 30,
                 "percentage": 60.0
@@ -1335,6 +1337,7 @@ def test_get_significance_counts(database, monkeypatch):
             {
                 'rule_label': 'B1',
                 'significance': 1,
+                'impact': 'high',
                 "category": 'existence',
                 'instances': 130,
                 "percentage": 65.0
@@ -1342,6 +1345,7 @@ def test_get_significance_counts(database, monkeypatch):
             {
                 'rule_label': 'A3',
                 'significance': 2,
+                'impact': 'low',
                 "category": 'existence',
                 'instances': 70,
                 "percentage": 35.0
@@ -1359,6 +1363,7 @@ def test_get_significance_counts(database, monkeypatch):
             {
                 'rule_label': 'A3',
                 'significance': 2,
+                'impact': 'low',
                 "category": 'existence',
                 'instances': 70,
                 "percentage": 100.0

--- a/tests/unit/dataactbroker/test_dashboard_handler.py
+++ b/tests/unit/dataactbroker/test_dashboard_handler.py
@@ -50,6 +50,12 @@ def get_impact_counts_endpoint(submission, file, error_level):
     return json.loads(json_response.get_data().decode('UTF-8'))
 
 
+def get_significance_counts_endpoint(submission, file, error_level):
+    json_response = dashboard_handler.get_significance_counts(submission, file, error_level)
+    assert json_response.status_code == 200
+    return json.loads(json_response.get_data().decode('UTF-8'))
+
+
 def active_submission_table_endpoint(submission, file, error_level, page=1, limit=5, sort='significance', order='desc'):
     json_response = dashboard_handler.active_submission_table(submission, file, error_level, page, limit, sort, order)
     assert json_response.status_code == 200
@@ -268,6 +274,7 @@ def setup_submissions(sess, admin=False):
     setting_ab2 = RuleSetting(agency_code=None, rule_label=rule_ab2.rule_label, priority=2,
                               impact_id=RULE_IMPACT_DICT['high'], file_id=rule_ab2.file_id,
                               target_file_id=rule_ab2.target_file_id)
+    # Flipping the priorities based on a specific agency
     setting_ab1_cgac = RuleSetting(agency_code=sub1.cgac_code, rule_label=rule_ab1.rule_label, priority=2,
                                    impact_id=RULE_IMPACT_DICT['low'], file_id=rule_ab1.file_id,
                                    target_file_id=rule_ab1.target_file_id)
@@ -1268,6 +1275,97 @@ def test_get_impact_counts(database, monkeypatch):
         }
     }
     response = get_impact_counts_endpoint(sub1, 'cross-AB', 'mixed')
+    assert response == expected_response
+
+
+@pytest.mark.usefixtures('job_constants')
+@pytest.mark.usefixtures('user_constants')
+@pytest.mark.usefixtures('validation_constants')
+def test_get_significance_counts(database, monkeypatch):
+    sess = database.session
+
+    user = setup_submissions(sess, admin=True)
+    monkeypatch.setattr(filters_helper, 'g', Mock(user=user))
+
+    # FABS submissions should throw an error
+    fabs_sub = sess.query(Submission).filter(Submission.d2_submission.is_(True)).first()
+    expected_error = 'Submission must be a DABS submission.'
+    with pytest.raises(ResponseException) as resp_except:
+        dashboard_handler.get_significance_counts(fabs_sub, 'B', 'warning')
+    assert str(resp_except.value) == expected_error
+
+    # No occurrences of rules that have settings
+    monthly_sub = sess.query(Submission).filter(Submission.d2_submission.is_(False),
+                                                Submission.is_quarter_format.is_(False)).first()
+    expected_response = {
+        'total_instances': 0,
+        'rules': []
+    }
+    response = get_significance_counts_endpoint(monthly_sub, 'cross-AB', 'mixed')
+    assert response == expected_response
+
+    # Rule with occurrences
+    sub1 = sess.query(Submission).filter(Submission.submission_id == 1).first()
+    expected_response = {
+        'total_instances': 50,
+        'rules': [
+            {
+                'rule_label': 'A1',
+                'significance': 1,
+                "category": 'completeness',
+                'instances': 20,
+                "percentage": 40.0
+            },
+            {
+                'rule_label': 'A2',
+                'significance': 2,
+                "category": 'accuracy',
+                'instances': 30,
+                "percentage": 60.0
+            }
+        ]
+    }
+    response = get_significance_counts_endpoint(sub1, 'A', 'mixed')
+    assert response == expected_response
+
+    # Rule with occurrences at different significances (based on per-agency setting)
+    expected_response = {
+        'total_instances': 200,
+        'rules': [
+            {
+                'rule_label': 'B1',
+                'significance': 1,
+                "category": 'existence',
+                'instances': 130,
+                "percentage": 65.0
+            },
+            {
+                'rule_label': 'A3',
+                'significance': 2,
+                "category": 'existence',
+                'instances': 70,
+                "percentage": 35.0
+            }
+        ]
+    }
+    response = get_significance_counts_endpoint(sub1, 'cross-AB', 'mixed')
+    assert response == expected_response
+
+    # Removing all B1 instances to see if the endpoint still properly provides the right values
+    sess.query(ErrorMetadata).filter(ErrorMetadata.original_rule_label == 'B1').delete()
+    expected_response = {
+        'total_instances': 70,
+        'rules': [
+            {
+                'rule_label': 'A3',
+                'significance': 2,
+                "category": 'existence',
+                'instances': 70,
+                "percentage": 100.0
+            }
+        ]
+    }
+    response = get_significance_counts_endpoint(sub1, 'cross-AB', 'mixed')
     assert response == expected_response
 
 

--- a/tests/unit/dataactbroker/test_dashboard_helper.py
+++ b/tests/unit/dataactbroker/test_dashboard_helper.py
@@ -1,0 +1,61 @@
+import pytest
+
+from dataactbroker.helpers import dashboard_helper
+from dataactcore.models.validationModels import RuleSetting
+from dataactcore.models.lookups import FILE_TYPE_DICT_LETTER_ID
+
+
+def test_generate_file_type():
+    # Normal
+    assert dashboard_helper.generate_file_type(FILE_TYPE_DICT_LETTER_ID['A'], None) == 'A'
+    assert dashboard_helper.generate_file_type(FILE_TYPE_DICT_LETTER_ID['B'], None) == 'B'
+    assert dashboard_helper.generate_file_type(FILE_TYPE_DICT_LETTER_ID['C'], None) == 'C'
+    assert dashboard_helper.generate_file_type(FILE_TYPE_DICT_LETTER_ID['D1'], None) == 'D1'
+    assert dashboard_helper.generate_file_type(FILE_TYPE_DICT_LETTER_ID['D2'], None) == 'D2'
+    # Cross
+    assert dashboard_helper.generate_file_type(FILE_TYPE_DICT_LETTER_ID['A'],
+                                               FILE_TYPE_DICT_LETTER_ID['B']) == 'cross-AB'
+    assert dashboard_helper.generate_file_type(FILE_TYPE_DICT_LETTER_ID['B'],
+                                               FILE_TYPE_DICT_LETTER_ID['C']) == 'cross-BC'
+    assert dashboard_helper.generate_file_type(FILE_TYPE_DICT_LETTER_ID['C'],
+                                               FILE_TYPE_DICT_LETTER_ID['D1']) == 'cross-CD1'
+    assert dashboard_helper.generate_file_type(FILE_TYPE_DICT_LETTER_ID['C'],
+                                               FILE_TYPE_DICT_LETTER_ID['D2']) == 'cross-CD2'
+    # Bad
+    assert dashboard_helper.generate_file_type(None, FILE_TYPE_DICT_LETTER_ID['D2']) is None
+
+
+@pytest.mark.usefixtures('job_constants')
+@pytest.mark.usefixtures('validation_constants')
+def test_agency_has_settings(database):
+    sess = database.session
+
+    default = RuleSetting(file_id=FILE_TYPE_DICT_LETTER_ID['A'], target_file_id=None, agency_code=None,
+                          priority=1, impact_id=1, rule_label='A4')
+    setting_agency_a = RuleSetting(file_id=FILE_TYPE_DICT_LETTER_ID['A'], target_file_id=None, agency_code='001',
+                                   priority=1, impact_id=1, rule_label='A4')
+    setting_agency_b = RuleSetting(file_id=FILE_TYPE_DICT_LETTER_ID['A'], target_file_id=None, agency_code='002',
+                                   priority=1, impact_id=1, rule_label='A4')
+
+    sess.add_all([default, setting_agency_a])
+    assert dashboard_helper.agency_has_settings(sess, '002', 'A') is False
+
+    sess.add_all([setting_agency_b])
+    assert dashboard_helper.agency_has_settings(sess, '002', 'A') is True
+    assert dashboard_helper.agency_has_settings(sess, '002', 'B') is False
+
+
+@pytest.mark.usefixtures('job_constants')
+@pytest.mark.usefixtures('validation_constants')
+def test_agency_settings_filter(database):
+    sess = database.session
+
+    default_setting = RuleSetting(file_id=FILE_TYPE_DICT_LETTER_ID['A'], target_file_id=None, agency_code=None,
+                                  priority=1, impact_id=1, rule_label='A3')
+    agency_setting = RuleSetting(file_id=FILE_TYPE_DICT_LETTER_ID['A'], target_file_id=None, agency_code='001',
+                                 priority=1, impact_id=1, rule_label='A4')
+
+    base_query = sess.query(RuleSetting)
+    sess.add_all([default_setting, agency_setting])
+    assert dashboard_helper.agency_settings_filter(sess, base_query, '000', 'A').first() == default_setting
+    assert dashboard_helper.agency_settings_filter(sess, base_query, '001', 'A').first() == agency_setting

--- a/tests/unit/dataactbroker/test_filter_helper.py
+++ b/tests/unit/dataactbroker/test_filter_helper.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import Mock
 
 from dataactbroker.helpers import filters_helper
-from dataactcore.models.errorModels import CertifiedErrorMetadata
+from dataactcore.models.errorModels import ErrorMetadata, CertifiedErrorMetadata
 from dataactcore.models.jobModels import Submission
 from dataactcore.models.lookups import PERMISSION_TYPE_DICT, FILE_TYPE_DICT_LETTER_ID, RULE_SEVERITY_DICT
 from dataactcore.models.userModel import UserAffiliation
@@ -255,3 +255,24 @@ def test_file_filter_wrong_file_model(database):
     with pytest.raises(ResponseException) as resp_except:
         filters_helper.file_filter(base_query, Submission, [])
     assert str(resp_except.value) == error_text
+
+
+@pytest.mark.usefixtures('validation_constants')
+def test_rule_severity_filter(database):
+    sess = database.session
+
+    # Setup ErrorMetadata
+    error = ErrorMetadata(severity_id=RULE_SEVERITY_DICT['fatal'])
+    warning = ErrorMetadata(severity_id=RULE_SEVERITY_DICT['warning'])
+    sess.add_all([error, warning])
+    sess.commit()
+
+    # Ensure the filter is working correctly
+    base_query = sess.query(ErrorMetadata)
+    err_query = filters_helper.rule_severity_filter(base_query, 'error', ErrorMetadata)
+    warning_query = filters_helper.rule_severity_filter(base_query, 'warning', ErrorMetadata)
+    mixed_query = filters_helper.rule_severity_filter(base_query, 'mixed', ErrorMetadata)
+
+    assert err_query.first() == error
+    assert warning_query.first() == warning
+    assert mixed_query.count() == 2


### PR DESCRIPTION
**High level description:**
Slight deviation from `get_impact_counts`, this endpoint returns the counts of errors/warnings ordered by their significance.

**Technical details:**
* Refactored a bit of the filter logic out to share.

**Link to JIRA Ticket:**
[DEV-4317](https://federal-spending-transparency.atlassian.net/browse/DEV-4317)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [ ] Frontend impact assessment completed @ebdabbs 