### PR TITLE
DEV-4617: submission metadata test flag

### DIFF
--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -133,6 +133,10 @@ def get_submission_metadata(submission):
         filter_by(submission_id=submission.submission_id).\
         scalar() or 0
 
+    test_sub = find_existing_submissions_in_period(submission.cgac_code, submission.frec_code,
+                                                   submission.reporting_fiscal_year,
+                                                   submission.reporting_fiscal_period, submission.submission_id)
+
     return {
         'cgac_code': submission.cgac_code,
         'frec_code': submission.frec_code,
@@ -147,6 +151,7 @@ def get_submission_metadata(submission):
         'reporting_period': reporting_date(submission),
         'publish_status': submission.publish_status.name,
         'quarterly_submission': submission.is_quarter_format,
+        'test_submission': test_sub.status_code != StatusCode.OK,
         'fabs_submission': submission.d2_submission,
         'fabs_meta': fabs_meta
     }
@@ -536,7 +541,8 @@ def find_existing_submissions_in_period(cgac_code, frec_code, reporting_fiscal_y
         (Submission.cgac_code == cgac_code) if cgac_code else (Submission.frec_code == frec_code),
         Submission.reporting_fiscal_year == reporting_fiscal_year,
         Submission.reporting_fiscal_period == reporting_fiscal_period,
-        Submission.publish_status_id != PUBLISH_STATUS_DICT['unpublished'])
+        Submission.publish_status_id != PUBLISH_STATUS_DICT['unpublished'],
+        Submission.d2_submission.is_(False))
 
     # Filter out the submission we are potentially re-certifying if one is provided
     if submission_id:

--- a/tests/unit/dataactbroker/test_submission_handler.py
+++ b/tests/unit/dataactbroker/test_submission_handler.py
@@ -66,6 +66,7 @@ def test_get_submission_metadata_quarterly_dabs_cgac(database):
         'reporting_period': 'Q1/2017',
         'publish_status': 'updated',
         'quarterly_submission': True,
+        'test_submission': False,
         'fabs_submission': False,
         'fabs_meta': None
     }
@@ -105,6 +106,7 @@ def test_get_submission_metadata_quarterly_dabs_frec(database):
         'reporting_period': 'Q2/2010',
         'publish_status': 'published',
         'quarterly_submission': True,
+        'test_submission': False,
         'fabs_submission': False,
         'fabs_meta': None
     }
@@ -145,6 +147,7 @@ def test_get_submission_metadata_monthly_dabs(database):
         'reporting_period': start_date.strftime('%m/%Y'),
         'publish_status': 'unpublished',
         'quarterly_submission': False,
+        'test_submission': False,
         'fabs_submission': False,
         'fabs_meta': None
     }
@@ -186,6 +189,7 @@ def test_get_submission_metadata_unpublished_fabs(database):
         'reporting_period': start_date.strftime('%m/%Y'),
         'publish_status': 'unpublished',
         'quarterly_submission': False,
+        'test_submission': False,
         'fabs_submission': True,
         'fabs_meta': {'publish_date': None, 'published_file': None, 'total_rows': 0, 'valid_rows': 0}
     }
@@ -232,6 +236,7 @@ def test_get_submission_metadata_published_fabs(database):
         'reporting_period': start_date.strftime('%m/%Y'),
         'publish_status': 'published',
         'quarterly_submission': False,
+        'test_submission': False,
         'fabs_submission': True,
         'fabs_meta': {
             'publish_date': now_plus_10.strftime('%-I:%M%p %m/%d/%Y'),


### PR DESCRIPTION
**High level description:**
Adding a flag to the submission_metadata endpoint to indicate whether it's a test submission or not

**Technical details:**
The test flag checks to see if there are any other DABS submissions with the same start/end periods that have already been certified.

**Link to JIRA Ticket:**
[DEV-4617](https://federal-spending-transparency.atlassian.net/browse/DEV-4617)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed