### PR TITLE
Fix: reporting_start, reporting_end to list_submissions sorting

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1208,7 +1208,7 @@ This endpoint lists submissions for all agencies for which the current user is a
     - `submission_id`: submission id
     - `modified`: last modified date
     - `reporting_start`: reporting start date
-    - `reporting_end`: reporting start date
+    - `reporting_end`: reporting end date
     - `agency`: agency name
     - `submitted_by`: name of user that created the submission
     - `certified_date`: latest certified date

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1207,7 +1207,8 @@ This endpoint lists submissions for all agencies for which the current user is a
 - `sort`: (string) what value to sort by. Defaults to `modified` if not provided. Valid values are:
     - `submission_id`: submission id
     - `modified`: last modified date
-    - `reporting`: reporting start date
+    - `reporting_start`: reporting start date
+    - `reporting_end`: reporting start date
     - `agency`: agency name
     - `submitted_by`: name of user that created the submission
     - `certified_date`: latest certified date

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1664,7 +1664,8 @@ def list_submissions(page, limit, certified, sort='modified', order='desc', is_f
     options = {
         'submission_id': {'model': Submission, 'col': 'submission_id'},
         'modified': {'model': submission_updated_view, 'col': 'updated_at'},
-        'reporting': {'model': Submission, 'col': 'reporting_start_date'},
+        'reporting_start': {'model': Submission, 'col': 'reporting_start_date'},
+        'reporting_end': {'model': Submission, 'col': 'reporting_end_date'},
         'agency': {'model': CGAC, 'col': 'agency_name'},
         'submitted_by': {'model': User, 'col': 'name'},
         'certified_date': {'model': sub_query.c, 'col': 'certified_date'},

--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -51,7 +51,7 @@ def test_list_submissions_sort_success(database, monkeypatch):
     add_models(database, [user1, user2, sub1, sub2, sub3, sub4, sub5])
 
     monkeypatch.setattr(filters_helper, 'g', Mock(user=user1))
-    result = list_submissions_sort('reporting', 'desc')
+    result = list_submissions_sort('reporting_start', 'desc')
     assert result['total'] == 5
     sub = result['submissions'][0]
     index = 0
@@ -60,11 +60,27 @@ def test_list_submissions_sort_success(database, monkeypatch):
         assert subit['reporting_start_date'] <= sub['reporting_start_date']
         sub = subit
 
-    result = list_submissions_sort('reporting', 'asc')
+    result = list_submissions_sort('reporting_start', 'asc')
     assert result['total'] == 5
     sub = result['submissions'][0]
     for subit in result['submissions']:
         assert subit['reporting_start_date'] >= sub['reporting_start_date']
+        sub = subit
+
+    result = list_submissions_sort('reporting_end', 'desc')
+    assert result['total'] == 5
+    sub = result['submissions'][0]
+    index = 0
+    for subit in result['submissions']:
+        index += 1
+        assert subit['reporting_end_date'] <= sub['reporting_end_date']
+        sub = subit
+
+    result = list_submissions_sort('reporting_end', 'asc')
+    assert result['total'] == 5
+    sub = result['submissions'][0]
+    for subit in result['submissions']:
+        assert subit['reporting_end_date'] >= sub['reporting_end_date']
         sub = subit
 
     result = list_submissions_sort('submitted_by', 'asc')


### PR DESCRIPTION
**High level description:**
Updating the reporting sort to `reporting_start` and `reporting_end` for list submissions to help sorting the submissions on the historic dabs dashboard.

**Technical details:**
N/A

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed (@ebdabbs)
- [x] Documentation Updated