### PR TITLE
Fix: FABS 38 active records only

### DIFF
--- a/dataactvalidator/config/sqlrules/fabs38_detached_award_financial_assistance_2_2.sql
+++ b/dataactvalidator/config/sqlrules/fabs38_detached_award_financial_assistance_2_2.sql
@@ -32,7 +32,8 @@ funding_codes_{0} AS
 	JOIN min_dates_{0} AS md
 		ON md.unique_award_key = pafa.unique_award_key
 			AND md.min_date = cast_as_date(pafa.action_date)
-	WHERE COALESCE(pafa.funding_office_code, '') <> '')
+	WHERE COALESCE(pafa.funding_office_code, '') <> ''
+	    AND pafa.is_active IS TRUE)
 SELECT
     row_number,
     funding_office_code,

--- a/dataactvalidator/config/sqlrules/fabs38_detached_award_financial_assistance_4_2.sql
+++ b/dataactvalidator/config/sqlrules/fabs38_detached_award_financial_assistance_4_2.sql
@@ -32,7 +32,8 @@ awarding_codes_{0} AS
 	JOIN min_dates_{0} AS md
 		ON md.unique_award_key = pafa.unique_award_key
 			AND md.min_date = cast_as_date(pafa.action_date)
-	WHERE COALESCE(pafa.awarding_office_code, '') <> '')
+	WHERE COALESCE(pafa.awarding_office_code, '') <> ''
+	    AND pafa.is_active IS TRUE)
 SELECT
     row_number,
     awarding_office_code,

--- a/tests/unit/dataactvalidator/test_fabs38_detached_award_financial_assistance_2_2.py
+++ b/tests/unit/dataactvalidator/test_fabs38_detached_award_financial_assistance_2_2.py
@@ -34,11 +34,14 @@ def test_success_ignore_null_pafa(database):
     pub_award_4 = PublishedAwardFinancialAssistanceFactory(funding_office_code='12345A', unique_award_key='1234_abc',
                                                            action_date='20181019', award_modification_amendme='0',
                                                            is_active=True)
-    # Earliest record inactive, newer record has valid entry
+    # Earliest record inactive, newer record has valid entry, inactive date matching active doesn't mess it up
     pub_award_5 = PublishedAwardFinancialAssistanceFactory(funding_office_code='abc', unique_award_key='4321_cba',
                                                            action_date='20181018', award_modification_amendme='0',
                                                            is_active=False)
-    pub_award_6 = PublishedAwardFinancialAssistanceFactory(funding_office_code='12345b', unique_award_key='4321_cba',
+    pub_award_6 = PublishedAwardFinancialAssistanceFactory(funding_office_code='abc', unique_award_key='4321_cba',
+                                                           action_date='20181019', award_modification_amendme='1',
+                                                           is_active=False)
+    pub_award_7 = PublishedAwardFinancialAssistanceFactory(funding_office_code='12345b', unique_award_key='4321_cba',
                                                            action_date='20181019', award_modification_amendme='1',
                                                            is_active=True)
 
@@ -63,8 +66,8 @@ def test_success_ignore_null_pafa(database):
                                                           action_date='20181020', award_modification_amendme='2',
                                                           correction_delete_indicatr=None)
     errors = number_of_errors(_FILE, database, models=[office_1, office_2, pub_award_1, pub_award_2, pub_award_3,
-                                                       pub_award_4, pub_award_5, pub_award_6, det_award_1, det_award_2,
-                                                       det_award_3, det_award_4, det_award_5])
+                                                       pub_award_4, pub_award_5, pub_award_6, pub_award_7, det_award_1,
+                                                       det_award_2, det_award_3, det_award_4, det_award_5])
     assert errors == 0
 
 

--- a/tests/unit/dataactvalidator/test_fabs38_detached_award_financial_assistance_4_2.py
+++ b/tests/unit/dataactvalidator/test_fabs38_detached_award_financial_assistance_4_2.py
@@ -31,11 +31,14 @@ def test_success_ignore_null_pafa(database):
     pub_award_4 = PublishedAwardFinancialAssistanceFactory(awarding_office_code='12345A', unique_award_key='1234_abc',
                                                            action_date='20181019', award_modification_amendme='0',
                                                            is_active=True)
-    # Earliest record inactive, newer record has valid entry
+    # Earliest record inactive, newer record has valid entry, inactive date matching active doesn't mess it up
     pub_award_5 = PublishedAwardFinancialAssistanceFactory(awarding_office_code='abc', unique_award_key='4321_cba',
                                                            action_date='20181018', award_modification_amendme='0',
                                                            is_active=False)
-    pub_award_6 = PublishedAwardFinancialAssistanceFactory(awarding_office_code='12345a', unique_award_key='4321_cba',
+    pub_award_6 = PublishedAwardFinancialAssistanceFactory(awarding_office_code='abc', unique_award_key='4321_cba',
+                                                           action_date='20181019', award_modification_amendme='1',
+                                                           is_active=False)
+    pub_award_7 = PublishedAwardFinancialAssistanceFactory(awarding_office_code='12345a', unique_award_key='4321_cba',
                                                            action_date='20181019', award_modification_amendme='1',
                                                            is_active=True)
 
@@ -60,8 +63,8 @@ def test_success_ignore_null_pafa(database):
                                                           action_date='20181020', award_modification_amendme='2',
                                                           correction_delete_indicatr=None)
     errors = number_of_errors(_FILE, database, models=[office, pub_award_1, pub_award_2, pub_award_3, pub_award_4,
-                                                       pub_award_5, pub_award_6, det_award_1, det_award_2, det_award_3,
-                                                       det_award_4, det_award_5])
+                                                       pub_award_5, pub_award_6, pub_award_7, det_award_1, det_award_2,
+                                                       det_award_3, det_award_4, det_award_5])
     assert errors == 0
 
 


### PR DESCRIPTION
Making sure to check for only active published records when getting the office code

**High level description:**
Fixing the rule so it only checks active records in our database

**Technical details:**
N/A

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated