### PR TITLE
DEV-4871: "Running" states for D1/D2 File Generation, Lock for new generations

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1582,6 +1582,8 @@ Possible HTTP Status Codes not covered by `check_generation_status` documentatio
 - 400:
     - Start and end date not provided for D1/D2 generation
     - Start and end date not formatted properly
+    - Prerequisite jobs are not finished
+    - Job requested is already running
 
 
 ### POST "/v1/generate\_detached\_file/"

--- a/dataactbroker/handlers/generation_handler.py
+++ b/dataactbroker/handlers/generation_handler.py
@@ -69,6 +69,10 @@ def generate_file(submission, file_type, start, end, agency_type, file_format):
     if not generation_helper.check_generation_prereqs(submission.submission_id, file_type):
         return JsonResponse.error(ResponseException('Must wait for completion of prerequisite validation job',
                                                     StatusCode.CLIENT_ERROR), StatusCode.CLIENT_ERROR)
+    # Check to make sure the generation jobs aren't already running
+    if not generation_helper.check_generation_running(submission.submission_id, file_type):
+        return JsonResponse.error(ResponseException('Must wait for completion of current generation job',
+                                                    StatusCode.CLIENT_ERROR), StatusCode.CLIENT_ERROR)
     try:
         if file_type in ['D1', 'D2']:
             generation_helper.start_d_generation(job, start, end, agency_type, file_format=file_format)

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -271,7 +271,7 @@ def validator_process_job(job_id, agency_code, is_retry=False):
         }
 
         if job:
-            error_data.update({'submission_id': job.submission_id, 'file_type': job.file_type.name})
+            error_data.update({'submission_id': job.submission_id, 'file_type': job.file_type})
             logger.error(error_data)
 
             sess.refresh(job)

--- a/dataactvalidator/validation_handlers/file_generation_manager.py
+++ b/dataactvalidator/validation_handlers/file_generation_manager.py
@@ -63,6 +63,8 @@ class FileGenerationManager:
         log_data = {'message': 'Finished file {} generation'.format(self.file_type), 'message_type': 'ValidatorInfo',
                     'file_type': self.file_type, 'file_path': file_path}
         if self.file_generation:
+            if self.job:
+                mark_job_status(self.job.job_id, 'running')
             self.generate_d_file(file_path)
 
             log_data.update({


### PR DESCRIPTION
**High level description:**
Simply adding "running" states for attached D1/D2 File Generations. Adding a lock when starting generations to check to see if said jobs are already running.

**Technical details:**
* Resolving minor typo in the dispatcher not handling cross-file errros discovered while testing

**Link to JIRA Ticket:**
[DEV-4871](https://federal-spending-transparency.atlassian.net/browse/DEV-4871)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Tested the DABS submission process locally, tested file caching, and tested D1/D2 detached file generation
- [x] Documentation Updated