### PR TITLE
Hotfix: formatting error metadata

### DIFF
--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -352,6 +352,10 @@ class ValidationManager:
 
         # Adding formatting errors to error file
         format_error_df = process_formatting_errors(self.short_rows, self.long_rows, self.report_headers)
+        for index, row in format_error_df.iterrows():
+            self.error_list.record_row_error(self.job.job_id, self.file_name, row['Field Name'],
+                                             row['error_type'], row['Row Number'], row['Rule Label'],
+                                             self.file_type.file_type_id, None, RULE_SEVERITY_DICT['fatal'])
         format_error_df.to_csv(self.error_file_path, columns=self.report_headers, index=False, quoting=csv.QUOTE_ALL,
                                mode='a', header=False)
 


### PR DESCRIPTION
**High level description:**
Actually storing error metadata for formatting errors

**Technical details:**
Formatting errors were not being stored in the error metadata table, which is bad

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated