### PR TITLE
DEV-5095: c23 record type

### DIFF
--- a/dataactvalidator/config/sqlrules/c23_award_financial_3.sql
+++ b/dataactvalidator/config/sqlrules/c23_award_financial_3.sql
@@ -28,6 +28,7 @@ award_financial_assistance_c23_3_{0} AS
                     END), 0) AS sum_fed_act_ob_amount
     FROM award_financial_assistance
     WHERE submission_id = {0}
+        AND record_type IN ('2', '3')
     GROUP BY UPPER(fain))
 SELECT
     NULL AS "source_row_number",

--- a/dataactvalidator/config/sqlrules/c23_award_financial_4.sql
+++ b/dataactvalidator/config/sqlrules/c23_award_financial_4.sql
@@ -28,6 +28,7 @@ award_financial_assistance_c23_4_{0} AS
                     END), 0) AS sum_fed_act_ob_amount
     FROM award_financial_assistance
     WHERE submission_id = {0}
+        AND record_type = '1'
     GROUP BY UPPER(uri))
 SELECT
     NULL AS "source_row_number",

--- a/tests/unit/dataactvalidator/test_c23_award_financial_3.py
+++ b/tests/unit/dataactvalidator/test_c23_award_financial_3.py
@@ -39,24 +39,27 @@ def test_success(database):
 
     # Fain sums for AFA
     afa_1_row_1 = AwardFinancialAssistanceFactory(fain=fain_1, federal_action_obligation=-1100,
-                                                  original_loan_subsidy_cost=None)
+                                                  original_loan_subsidy_cost=None, record_type='2')
     afa_1_row_2 = AwardFinancialAssistanceFactory(fain=fain_1.lower(), federal_action_obligation=-10,
-                                                  original_loan_subsidy_cost=None)
+                                                  original_loan_subsidy_cost=None, record_type='3')
     # original loan subsidy cost used in this row because assistance type is '08'
     afa_1_row_3 = AwardFinancialAssistanceFactory(fain=fain_1, original_loan_subsidy_cost=-1, assistance_type='08',
-                                                  federal_action_obligation=None)
+                                                  federal_action_obligation=None, record_type='2')
     # federal action obligation used in this row (it's 0), because assistance type is not 07 and 08
     afa_1_row_4 = AwardFinancialAssistanceFactory(fain=fain_1, original_loan_subsidy_cost=-2222, assistance_type='09',
-                                                  federal_action_obligation=None)
+                                                  federal_action_obligation=None, record_type='3')
+    # Ignored because record type 1
+    afa_1_row_5 = AwardFinancialAssistanceFactory(fain=fain_1, federal_action_obligation=-1100,
+                                                  original_loan_subsidy_cost=None, record_type='1')
     # Fain 2 Test for non-ignored ATA
     afa_2 = AwardFinancialAssistanceFactory(fain=fain_2, federal_action_obligation=-9999,
-                                            original_loan_subsidy_cost=None)
+                                            original_loan_subsidy_cost=None, record_type='2')
     # Fain 3 test for ignoring a non-matching ATA/AID
-    afa_3 = AwardFinancialAssistanceFactory(fain=fain_3, federal_action_obligation=-9999)
+    afa_3 = AwardFinancialAssistanceFactory(fain=fain_3, federal_action_obligation=-9999, record_type='3')
 
     errors = number_of_errors(_FILE, database, models=[af_1_row_1, af_1_row_2, af_2_row_1, af_2_row_2, af_3,
-                                                       afa_1_row_1, afa_1_row_2, afa_1_row_3, afa_1_row_4, afa_2,
-                                                       afa_3])
+                                                       afa_1_row_1, afa_1_row_2, afa_1_row_3, afa_1_row_4, afa_1_row_5,
+                                                       afa_2, afa_3])
     assert errors == 0
 
 
@@ -82,16 +85,18 @@ def test_failure(database):
 
     # Sum of this fain doesn't add up to af fain sum
     afa_1_row_1 = AwardFinancialAssistanceFactory(fain=fain_1, federal_action_obligation=-1100,
-                                                  original_loan_subsidy_cost=None)
+                                                  original_loan_subsidy_cost=None, record_type='2')
     afa_1_row_2 = AwardFinancialAssistanceFactory(fain=fain_1.lower(), federal_action_obligation=-10,
-                                                  original_loan_subsidy_cost=None)
+                                                  original_loan_subsidy_cost=None, record_type='3')
     # Both of these rows use the column that isn't filled in for summing so neither results in the correct number
     afa_2_row_1 = AwardFinancialAssistanceFactory(fain=fain_2, federal_action_obligation=-9999,
-                                                  original_loan_subsidy_cost=None)
+                                                  original_loan_subsidy_cost=None, record_type='2')
     afa_2_row_2 = AwardFinancialAssistanceFactory(fain=fain_2, federal_action_obligation=None,
-                                                  original_loan_subsidy_cost=-9999, assistance_type='07')
+                                                  original_loan_subsidy_cost=-9999, assistance_type='07',
+                                                  record_type='3')
     # This shouldn't be ignored
-    afa_3 = AwardFinancialAssistanceFactory(fain=fain_3, federal_action_obligation=0, original_loan_subsidy_cost=None)
+    afa_3 = AwardFinancialAssistanceFactory(fain=fain_3, federal_action_obligation=0, original_loan_subsidy_cost=None,
+                                            record_type='2')
 
     errors = number_of_errors(_FILE, database, models=[af_1_row_1, af_1_row_2, af_2, af_3, afa_1_row_1, afa_1_row_2,
                                                        afa_2_row_1, afa_2_row_2, afa_3])

--- a/tests/unit/dataactvalidator/test_c23_award_financial_4.py
+++ b/tests/unit/dataactvalidator/test_c23_award_financial_4.py
@@ -39,23 +39,27 @@ def test_success(database):
 
     # Correct sum
     afa_1_row_1 = AwardFinancialAssistanceFactory(uri=uri_1, federal_action_obligation=-1100,
-                                                  original_loan_subsidy_cost=None)
+                                                  original_loan_subsidy_cost=None, record_type='1')
     afa_1_row_2 = AwardFinancialAssistanceFactory(uri=uri_1, federal_action_obligation=-10,
-                                                  original_loan_subsidy_cost=None)
+                                                  original_loan_subsidy_cost=None, record_type='1')
     # original loan subsidy cost used in this row because assistance type is '08'
     afa_1_row_3 = AwardFinancialAssistanceFactory(uri=uri_1, original_loan_subsidy_cost=-1, assistance_type='08',
-                                                  federal_action_obligation=None)
+                                                  federal_action_obligation=None, record_type='1')
     # federal action obligation used in this row (it's 0), because assistance type is not 07 and 08
     afa_1_row_4 = AwardFinancialAssistanceFactory(uri=uri_1, original_loan_subsidy_cost=-2222, assistance_type='09',
-                                                  federal_action_obligation=None)
+                                                  federal_action_obligation=None, record_type='1')
+    # Ignored because record type isn't 1
+    afa_1_row_5 = AwardFinancialAssistanceFactory(uri=uri_1, federal_action_obligation=-1100,
+                                                  original_loan_subsidy_cost=None, record_type='2')
     # Uri 2 Test for non-ignored ATA
-    afa_2 = AwardFinancialAssistanceFactory(uri=uri_2, federal_action_obligation=-9999, original_loan_subsidy_cost=None)
+    afa_2 = AwardFinancialAssistanceFactory(uri=uri_2, federal_action_obligation=-9999, original_loan_subsidy_cost=None,
+                                            record_type='1')
     # Uri 3 test for ignoring a non-matching ATA/AID
-    afa_3 = AwardFinancialAssistanceFactory(uri=uri_3, federal_action_obligation=-9999)
+    afa_3 = AwardFinancialAssistanceFactory(uri=uri_3, federal_action_obligation=-9999, record_type='1')
 
     errors = number_of_errors(_FILE, database, models=[af_1_row_1, af_1_row_2, af_2_row_1, af_2_row_2, af_3,
-                                                       afa_1_row_1, afa_1_row_2, afa_1_row_3, afa_1_row_4, afa_2,
-                                                       afa_3])
+                                                       afa_1_row_1, afa_1_row_2, afa_1_row_3, afa_1_row_4, afa_1_row_5,
+                                                       afa_2, afa_3])
     assert errors == 0
 
 
@@ -81,16 +85,18 @@ def test_failure(database):
 
     # Sum of this uri doesn't add up to af uri sum
     afa_1_row_1 = AwardFinancialAssistanceFactory(uri=uri_1, federal_action_obligation=-1100,
-                                                  original_loan_subsidy_cost=None)
+                                                  original_loan_subsidy_cost=None, record_type='1')
     afa_1_row_2 = AwardFinancialAssistanceFactory(uri=uri_1, federal_action_obligation=-10,
-                                                  original_loan_subsidy_cost=None)
+                                                  original_loan_subsidy_cost=None, record_type='1')
     # Both of these rows use the column that isn't filled in for summing so neither results in the correct number
     afa_2_row_1 = AwardFinancialAssistanceFactory(uri=uri_2, federal_action_obligation=-9999,
-                                                  original_loan_subsidy_cost=None)
+                                                  original_loan_subsidy_cost=None, record_type='1')
     afa_2_row_2 = AwardFinancialAssistanceFactory(uri=uri_2, federal_action_obligation=None,
-                                                  original_loan_subsidy_cost=-1000, assistance_type='07')
+                                                  original_loan_subsidy_cost=-1000, assistance_type='07',
+                                                  record_type='1')
     # This shouldn't be ignored
-    afa_3 = AwardFinancialAssistanceFactory(uri=uri_3, federal_action_obligation=0, original_loan_subsidy_cost=None)
+    afa_3 = AwardFinancialAssistanceFactory(uri=uri_3, federal_action_obligation=0, original_loan_subsidy_cost=None,
+                                            record_type='1')
 
     errors = number_of_errors(_FILE, database, models=[af_1_row_1, af_1_row_2, af_2, af_3, afa_1_row_1, afa_1_row_2,
                                                        afa_2_row_1, afa_2_row_2, afa_3])


### PR DESCRIPTION
**High level description:**
Updating C23.3 and C23.4 to only sum the relevant rows based on record type

**Technical details:**
C23.3 (fain) only sums D2 rows with record type 2 or 3
C23.4 (uri) only sums D2 rows with record type 1

**Link to JIRA Ticket:**
[DEV-5095](https://federal-spending-transparency.atlassian.net/browse/DEV-5095)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated