### PR TITLE
DEV-5131: Updating C5.2 Triggers

### DIFF
--- a/dataactvalidator/config/sqlrules/c5_award_financial_2.sql
+++ b/dataactvalidator/config/sqlrules/c5_award_financial_2.sql
@@ -18,10 +18,10 @@ SELECT
 FROM award_financial
 WHERE submission_id = {0}
     AND gross_outlay_amount_by_awa_cpe IS NOT NULL
-    AND (COALESCE(gross_outlays_undelivered_cpe, 0) > 0
-         OR COALESCE(gross_outlays_undelivered_fyb, 0) > 0
-         OR COALESCE(gross_outlays_delivered_or_cpe, 0) > 0
-         OR COALESCE(gross_outlays_delivered_or_fyb, 0) > 0
+    AND (COALESCE(gross_outlays_undelivered_cpe, 0) <> 0
+         OR COALESCE(gross_outlays_undelivered_fyb, 0) <> 0
+         OR COALESCE(gross_outlays_delivered_or_cpe, 0) <> 0
+         OR COALESCE(gross_outlays_delivered_or_fyb, 0) <> 0
     )
     AND COALESCE(gross_outlay_amount_by_awa_cpe, 0) <>
         (COALESCE(gross_outlays_undelivered_cpe, 0) - COALESCE(gross_outlays_undelivered_fyb, 0)) +

--- a/dataactvalidator/config/sqlrules/c5_award_financial_2.sql
+++ b/dataactvalidator/config/sqlrules/c5_award_financial_2.sql
@@ -17,6 +17,12 @@ SELECT
     uri AS "uniqueid_URI"
 FROM award_financial
 WHERE submission_id = {0}
+    AND gross_outlay_amount_by_awa_cpe IS NOT NULL
+    AND (COALESCE(gross_outlays_undelivered_cpe, 0) > 0
+         OR COALESCE(gross_outlays_undelivered_fyb, 0) > 0
+         OR COALESCE(gross_outlays_delivered_or_cpe, 0) > 0
+         OR COALESCE(gross_outlays_delivered_or_fyb, 0) > 0
+    )
     AND COALESCE(gross_outlay_amount_by_awa_cpe, 0) <>
         (COALESCE(gross_outlays_undelivered_cpe, 0) - COALESCE(gross_outlays_undelivered_fyb, 0)) +
         (COALESCE(gross_outlays_delivered_or_cpe, 0) - COALESCE(gross_outlays_delivered_or_fyb, 0));

--- a/tests/unit/dataactvalidator/test_c5_award_financial_2.py
+++ b/tests/unit/dataactvalidator/test_c5_award_financial_2.py
@@ -45,9 +45,26 @@ def test_success(database):
                                         gross_outlays_delivered_or_cpe=value_two,
                                         gross_outlays_undelivered_fyb=value_three,
                                         gross_outlays_delivered_or_fyb=None)
+    # accounting for case where none of the other values are provided as they're optional
+    award_fin_6 = AwardFinancialFactory(gross_outlay_amount_by_awa_cpe=value_one,
+                                        gross_outlays_undelivered_cpe=None,
+                                        gross_outlays_delivered_or_cpe=None,
+                                        gross_outlays_undelivered_fyb=None,
+                                        gross_outlays_delivered_or_fyb=None)
+    award_fin_7 = AwardFinancialFactory(gross_outlay_amount_by_awa_cpe=0,
+                                        gross_outlays_undelivered_cpe=None,
+                                        gross_outlays_delivered_or_cpe=None,
+                                        gross_outlays_undelivered_fyb=None,
+                                        gross_outlays_delivered_or_fyb=None)
+    # Ignore if gross_outlay_amount_by_awa_cpe is not provided
+    award_fin_8 = AwardFinancialFactory(gross_outlay_amount_by_awa_cpe=None,
+                                        gross_outlays_undelivered_cpe=value_one,
+                                        gross_outlays_delivered_or_cpe=value_two,
+                                        gross_outlays_undelivered_fyb=value_three,
+                                        gross_outlays_delivered_or_fyb=None)
 
     assert number_of_errors(_FILE, database, models=[award_fin, award_fin_2, award_fin_3, award_fin_4,
-                                                     award_fin_5]) == 0
+                                                     award_fin_5, award_fin_6, award_fin_7, award_fin_8]) == 0
 
 
 def test_failure(database):
@@ -66,5 +83,11 @@ def test_failure(database):
                                         gross_outlays_delivered_or_cpe=value_two,
                                         gross_outlays_undelivered_fyb=value_three,
                                         gross_outlays_delivered_or_fyb=value_four)
+    # Accounting for gross_outlay_amount_by_awa_cpe being 0
+    award_fin_3 = AwardFinancialFactory(gross_outlay_amount_by_awa_cpe=0,
+                                        gross_outlays_undelivered_cpe=value_one,
+                                        gross_outlays_delivered_or_cpe=value_two,
+                                        gross_outlays_undelivered_fyb=value_two,
+                                        gross_outlays_delivered_or_fyb=value_two)
 
-    assert number_of_errors(_FILE, database, models=[award_fin, award_fin_2]) == 2
+    assert number_of_errors(_FILE, database, models=[award_fin, award_fin_2, award_fin_3]) == 3


### PR DESCRIPTION
**High level description:**
Updating C5.2 to only trigger when:
* gross_outlay_amount_by_awa_cpe is not null
* any of the optional values is non-zero

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-5131](https://federal-spending-transparency.atlassian.net/browse/DEV-5131)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated