### PR TITLE
DEV-5235: c9 c12 ignore blank toa

### DIFF
--- a/dataactvalidator/config/sqlrules/c12_cross_file.sql
+++ b/dataactvalidator/config/sqlrules/c12_cross_file.sql
@@ -11,7 +11,8 @@ award_financial_c12_{0} AS
     (SELECT piid,
         parent_award_id
     FROM award_financial
-    WHERE submission_id = {0})
+    WHERE submission_id = {0}
+        AND transaction_obligated_amou IS NOT NULL)
 SELECT
     ap.row_number AS "source_row_number",
     ap.piid AS "source_value_piid",

--- a/dataactvalidator/config/sqlrules/c9_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/c9_award_financial.sql
@@ -19,7 +19,8 @@ award_financial_c9_{0} AS
         fain,
         uri
     FROM award_financial
-    WHERE submission_id = {0})
+    WHERE submission_id = {0}
+        AND transaction_obligated_amou IS NOT NULL)
 SELECT
     afa.row_number AS "source_row_number",
     afa.fain AS "source_value_fain",

--- a/tests/unit/dataactvalidator/test_c12_cross_file.py
+++ b/tests/unit/dataactvalidator/test_c12_cross_file.py
@@ -18,7 +18,7 @@ def test_success(database):
     """
 
     ap = AwardProcurementFactory(piid='some_pIId', parent_award_id='some_PArent_award_id', federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_AWard_id')
+    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_AWard_id', transaction_obligated_amou=1)
 
     assert number_of_errors(_FILE, database, models=[ap, af]) == 0
 
@@ -30,7 +30,7 @@ def test_success(database):
 
     # Checks null = null
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id=None, federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_pIId', parent_award_id=None)
+    af = AwardFinancialFactory(piid='some_pIId', parent_award_id=None, transaction_obligated_amou=0)
 
     assert number_of_errors(_FILE, database, models=[ap, af]) == 0
 
@@ -41,11 +41,20 @@ def test_failure(database):
     """
 
     ap = AwardProcurementFactory(piid='some_pIId', parent_award_id='some_parent_AWArd_id', federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_other_piid', parent_award_id='some_pARent_award_id')
+    af = AwardFinancialFactory(piid='some_other_piid', parent_award_id='some_pARent_award_id',
+                               transaction_obligated_amou=1)
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 1
 
     ap = AwardProcurementFactory(piid='some_piid', parent_award_id='some_Parent_award_id', federal_action_obligation=1)
-    af = AwardFinancialFactory(piid='some_pIId', parent_award_id='some_other_parenT_award_id')
+    af = AwardFinancialFactory(piid='some_pIId', parent_award_id='some_other_parenT_award_id',
+                               transaction_obligated_amou=1)
 
     assert number_of_errors(_FILE, database, models=[af, ap]) == 1
+
+    # Check to see that NULL TOA causes an error
+    ap = AwardProcurementFactory(piid='some_pIId', parent_award_id='some_PArent_award_id', federal_action_obligation=1)
+    af = AwardFinancialFactory(piid='some_piid', parent_award_id='some_parent_AWard_id',
+                               transaction_obligated_amou=None)
+
+    assert number_of_errors(_FILE, database, models=[ap, af]) == 1

--- a/tests/unit/dataactvalidator/test_c9_award_financial.py
+++ b/tests/unit/dataactvalidator/test_c9_award_financial.py
@@ -18,7 +18,8 @@ def test_equal_fain(database):
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='aBc', uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='1', record_type='2')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=afa.fain.lower(), uri=None)
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=afa.fain.lower(), uri=None,
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 0
@@ -29,7 +30,8 @@ def test_equal_uri(database):
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain=None, uri='xYz', federal_action_obligation=1,
                                           original_loan_subsidy_cost='1', record_type='1')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=afa.uri.lower())
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=afa.uri.lower(),
+                               transaction_obligated_amou=0)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 0
@@ -42,7 +44,8 @@ def test_null_uri_fain(database):
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain=None, uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='1')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain='abc', uri='def')
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain='abc', uri='def',
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 0
@@ -55,8 +58,10 @@ def test_both_fain_and_url_supplied(database):
                                             original_loan_subsidy_cost='1', record_type='2')
     afa_2 = AwardFinancialAssistanceFactory(tas=tas, fain='dEf', uri='gHi', federal_action_obligation=1,
                                             original_loan_subsidy_cost='1', record_type='1')
-    af_1 = AwardFinancialFactory(tas=tas, submisson_id=afa_1.submission_id, fain=afa_1.fain.lower(), uri=None)
-    af_2 = AwardFinancialFactory(tas=tas, submisson_id=afa_2.submission_id, fain=None, uri=afa_2.uri.lower())
+    af_1 = AwardFinancialFactory(tas=tas, submisson_id=afa_1.submission_id, fain=afa_1.fain.lower(), uri=None,
+                                 transaction_obligated_amou=1)
+    af_2 = AwardFinancialFactory(tas=tas, submisson_id=afa_2.submission_id, fain=None, uri=afa_2.uri.lower(),
+                                 transaction_obligated_amou=0)
 
     errors = number_of_errors(_FILE, database, models=[afa_1, afa_2, af_1, af_2])
     assert errors == 0
@@ -67,7 +72,8 @@ def test_unequal_fain(database):
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='1', record_type='3')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain='xyz', uri=None)
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain='xyz', uri=None,
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 1
@@ -78,7 +84,8 @@ def test_unequal_uri(database):
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain=None, uri='abc', federal_action_obligation=1,
                                           original_loan_subsidy_cost='1', record_type='1')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri='xyz')
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri='xyz',
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 1
@@ -89,7 +96,8 @@ def test_unequal_fain_null(database):
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='1', record_type='2')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 1
@@ -100,7 +108,8 @@ def test_unequal_fain_aggregate(database):
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri='xyz', federal_action_obligation=1,
                                           original_loan_subsidy_cost='1', record_type='2')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain='abc', uri='abc')
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain='abc', uri='abc',
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 0
@@ -111,7 +120,8 @@ def test_unequal_uri_non_aggregate(database):
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri='xyz', federal_action_obligation=1,
                                           original_loan_subsidy_cost='1', record_type='1')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain='xyz', uri='xyz')
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain='xyz', uri='xyz',
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 0
@@ -122,7 +132,8 @@ def test_unequal_uri_null(database):
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain=None, uri=None, federal_action_obligation=1,
                                           original_loan_subsidy_cost='1', record_type='1')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri='abc')
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri='abc',
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 0
@@ -135,7 +146,8 @@ def test_zero_federal_action_obligation_and_original_loan_subsidy_cost(database)
     tas = _TAS
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=0,
                                           original_loan_subsidy_cost='0', record_type='3')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 0
@@ -151,7 +163,8 @@ def test_ignored_and_failed_federal_action_obligation_values(database):
                                           original_loan_subsidy_cost='1', assistance_type='08', record_type='2')
     afa_2 = AwardFinancialAssistanceFactory(tas=tas, fain='aBc', uri=None, federal_action_obligation=2,
                                             original_loan_subsidy_cost='1', assistance_type='09', record_type='3')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af, afa_2])
     assert errors == 2
@@ -159,7 +172,8 @@ def test_ignored_and_failed_federal_action_obligation_values(database):
     # Test that this is ignored if assistance type is 09
     afa = AwardFinancialAssistanceFactory(tas=tas, fain='abc', uri=None, federal_action_obligation=0,
                                           original_loan_subsidy_cost='1', assistance_type='09', record_type='2')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af])
     assert errors == 0
@@ -177,7 +191,8 @@ def test_ignored_and_failed_original_loan_subsidy_cost_values(database):
                                             original_loan_subsidy_cost='-2.3', assistance_type='09', record_type='2')
     afa_3 = AwardFinancialAssistanceFactory(tas=tas, fain='abC', uri=None, federal_action_obligation=1,
                                             original_loan_subsidy_cost='2.3', assistance_type='08', record_type='3')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af, afa_2, afa_3])
     assert errors == 3
@@ -187,7 +202,20 @@ def test_ignored_and_failed_original_loan_subsidy_cost_values(database):
                                           original_loan_subsidy_cost='0', assistance_type='08', record_type='2')
     afa_2 = AwardFinancialAssistanceFactory(tas=tas, fain='aBc', uri=None, federal_action_obligation=1,
                                             original_loan_subsidy_cost='-2.3', assistance_type='08', record_type='3')
-    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None)
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=None, uri=None,
+                               transaction_obligated_amou=1)
 
     errors = number_of_errors(_FILE, database, models=[afa, af, afa_2])
     assert errors == 0
+
+
+def test_null_toa(database):
+    """ Tests that null TOA is ignored even though everything else matches. """
+    tas = _TAS
+    afa = AwardFinancialAssistanceFactory(tas=tas, fain='aBc', uri=None, federal_action_obligation=1,
+                                          original_loan_subsidy_cost='1', record_type='2')
+    af = AwardFinancialFactory(tas=tas, submisson_id=afa.submission_id, fain=afa.fain.lower(), uri=None,
+                               transaction_obligated_amou=None)
+
+    errors = number_of_errors(_FILE, database, models=[afa, af])
+    assert errors == 1


### PR DESCRIPTION
**High level description:**
Updating C9 and C12 to ignore rows with blank TOA when making sure all rows from D1/D2 are in file C

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-5235](https://federal-spending-transparency.atlassian.net/browse/DEV-5235)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated