### PR TITLE
DEV-5015: dabs upload test submission flag

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -278,6 +278,7 @@ curl -i -X POST
       -F 'cgac_code=020' 
       -F 'frec_code=null' 
       -F 'is_quarter=true' 
+      -F 'test_submission=true'
       -F 'reporting_period_start_date=04/2018' 
       -F 'reporting_period_end_date=06/2018' 
       -F "appropriations=@/local/path/to/a.csv" 
@@ -303,6 +304,7 @@ curl -i -X POST
 - `program_activity`: (string) local path to file using @ notation
 - `award_financial`: (string) local path to file using @ notation
 - `is_quarter`: (boolean) True for quarterly submissions
+- `test_submission`: (boolean) True when you want to create a test submission. Defaults to false (will not update existing submissions)
 - `reporting_period_start_date`: (string) starting date of submission (MM/YYYY)
 - `reporting_period_end_date`: (string) ending date of submission (MM/YYYY)
 - `existing_submission_id`: (integer) ID of previous submission, use only if submitting an update.

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -228,7 +228,9 @@ class FileHandler:
             if submission_data.get('is_quarter_format'):
                 submission_data['is_quarter_format'] = (str(submission_data.get('is_quarter_format')).upper() == 'TRUE')
 
-            submission = create_submission(g.user.user_id, submission_data, existing_submission_obj)
+            test_submission = request_params.get('test_submission')
+            test_submission = str(test_submission).upper() == 'TRUE'
+            submission = create_submission(g.user.user_id, submission_data, existing_submission_obj, test_submission)
             sess.add(submission)
             sess.commit()
 

--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -34,18 +34,21 @@ from dataactcore.utils.stringCleaner import StringCleaner
 logger = logging.getLogger(__name__)
 
 
-def create_submission(user_id, submission_values, existing_submission):
+def create_submission(user_id, submission_values, existing_submission, test_submission=False):
     """ Create a new submission if one doesn't exist, otherwise update the existing one
 
         Args:
             user_id:  user to associate with this submission
             submission_values: metadata about the submission
             existing_submission: id of existing submission (blank for new submissions)
+            test_submission: a boolean flag to indicate whether the submission being created is a test or not, only
+                used with new submissions
 
         Returns:
             submission object
     """
     if existing_submission is None:
+        submission_values['test_submission'] = test_submission
         submission = Submission(created_at=datetime.utcnow(), **submission_values)
         submission.user_id = user_id
         submission.publish_status_id = PUBLISH_STATUS_DICT['unpublished']


### PR DESCRIPTION
**High level description:**
Adding a `test_submission` flag to the `upload_dabs_files` endpoint

**Technical details:**
If a submission is a DABS submission and new, it can be set to `test` from the start

**Link to JIRA Ticket:**
[DEV-5015](https://federal-spending-transparency.atlassian.net/browse/DEV-5015)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation Updated