### PR TITLE
DEV-5017: certification workflow locks

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -255,7 +255,7 @@ class FileHandler:
                 published_submission_ids = published_qtr_subs.union(published_mon_subs)
                 submission_data['published_submission_ids'] = [pub_sub.submission_id for pub_sub
                                                                in published_submission_ids]
-                if len(published_submission_ids) > 0:
+                if len(submission_data['published_submission_ids']) > 0:
                     test_submission = True
 
             submission = create_submission(g.user.user_id, submission_data, existing_submission_obj, test_submission)

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -231,6 +231,9 @@ class FileHandler:
             reporting_fiscal_period = generate_fiscal_period(submission_data['reporting_end_date'])
             reporting_fiscal_year = generate_fiscal_year(submission_data['reporting_end_date'])
 
+            test_submission = request_params.get('test_submission')
+            test_submission = str(test_submission).upper() == 'TRUE'
+
             # set published_submission_ids for new submissions
             if not existing_submission:
                 published_qtr_subs = get_existing_submission_list(submission_data['cgac_code'],
@@ -249,12 +252,12 @@ class FileHandler:
                                                                   filter_quarter=submission_data['is_quarter_format'],
                                                                   filter_published='published',
                                                                   filter_sub_type='monthly')
-                published_submissions_ids = published_qtr_subs.union(published_mon_subs)
+                published_submission_ids = published_qtr_subs.union(published_mon_subs)
                 submission_data['published_submission_ids'] = [pub_sub.submission_id for pub_sub
-                                                               in published_submissions_ids]
+                                                               in published_submission_ids]
+                if len(published_submission_ids) > 0:
+                    test_submission = True
 
-            test_submission = request_params.get('test_submission')
-            test_submission = str(test_submission).upper() == 'TRUE'
             submission = create_submission(g.user.user_id, submission_data, existing_submission_obj, test_submission)
             sess.add(submission)
             sess.commit()

--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -819,6 +819,7 @@ def certify_dabs_submission(submission, file_manager):
         related_unpub_subs = related_unpub_mon_subs.union(related_unpub_qtr_subs)
         for related_unpub_sub in related_unpub_subs.all():
             related_unpub_sub.published_submission_ids.append(submission.submission_id)
+            related_unpub_sub.test_submission = True
         sess.commit()
 
     return response

--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -125,12 +125,16 @@ def test_create_submission_already_pub_mon(database, monkeypatch):
 
     # monthly same period -> published monthly sub
     assert new_mon_same_sub.published_submission_ids == [pub_mon1_sub.submission_id]
+    assert new_mon_same_sub.test_submission is True
     # monthly different period unaffected
     assert new_mon_diff_sub.published_submission_ids == []
+    assert new_mon_diff_sub.test_submission is False
     # quarterly same quarter -> multiple published monthly subs
     assert new_qtr_same_sub.published_submission_ids == [pub_mon1_sub.submission_id, pub_mon2_sub.submission_id]
+    assert new_qtr_same_sub.test_submission is True
     # quarterly different quarter unaffected
     assert new_qtr_diff_sub.published_submission_ids == []
+    assert new_qtr_diff_sub.test_submission is False
 
 
 @pytest.mark.usefixtures("job_constants")
@@ -202,12 +206,16 @@ def test_create_submission_already_pub_qtr(database, monkeypatch):
 
     # monthly same period -> published quarter sub
     assert new_mon_same_sub.published_submission_ids == [pub_qtr_sub.submission_id]
+    assert new_mon_same_sub.test_submission is True
     # monthly different period unaffected
     assert new_mon_diff_sub.published_submission_ids == []
+    assert new_mon_diff_sub.test_submission is False
     # quarterly same quarter -> published quarter sub
     assert new_qtr_same_sub.published_submission_ids == [pub_qtr_sub.submission_id]
+    assert new_qtr_same_sub.test_submission is True
     # quarterly different quarter unaffected
     assert new_qtr_diff_sub.published_submission_ids == []
+    assert new_qtr_diff_sub.test_submission is False
 
 
 @pytest.mark.usefixtures("job_constants")

--- a/tests/unit/dataactbroker/test_submission_handler.py
+++ b/tests/unit/dataactbroker/test_submission_handler.py
@@ -608,16 +608,20 @@ def test_published_submission_ids_month_same_periods(database, monkeypatch):
         # monthly same period -> published monthly sub
         sess.refresh(non_pub_same_mon_submission)
         assert non_pub_same_mon_submission.published_submission_ids == [pub_mon1_submission.submission_id]
+        assert non_pub_same_mon_submission.test_submission is True
         # monthly different period unaffected
         sess.refresh(non_pub_diff_mon_submission)
         assert non_pub_diff_mon_submission.published_submission_ids == []
+        assert non_pub_diff_mon_submission.test_submission is False
         # quarterly same period -> published monthly subs for said quarter
         sess.refresh(non_pub_same_qtr_submission)
         assert non_pub_same_qtr_submission.published_submission_ids == [pub_mon1_submission.submission_id,
                                                                         pub_mon2_submission.submission_id]
+        assert non_pub_same_qtr_submission.test_submission is True
         # quarterly different period unaffected
         sess.refresh(non_pub_diff_qtr_submission)
         assert non_pub_diff_qtr_submission.published_submission_ids == []
+        assert non_pub_diff_qtr_submission.test_submission is False
 
 
 @pytest.mark.usefixtures('job_constants')
@@ -682,15 +686,19 @@ def test_published_submission_ids_quarter_same_periods(database, monkeypatch):
         # monthly same quarter -> published quarter submission
         sess.refresh(non_pub_same_mon_submission)
         assert non_pub_same_mon_submission.published_submission_ids == [pub_qtr_submission.submission_id]
+        assert non_pub_same_mon_submission.test_submission is True
         # monthly different quarter unaffected
         sess.refresh(non_pub_diff_mon_submission)
         assert non_pub_diff_mon_submission.published_submission_ids == []
+        assert non_pub_diff_mon_submission.test_submission is False
         # quarterly same quarter -> published quarter submission
         sess.refresh(non_pub_same_qtr_submission)
         assert non_pub_same_qtr_submission.published_submission_ids == [pub_qtr_submission.submission_id]
+        assert non_pub_same_qtr_submission.test_submission is True
         # quarterly different quarter unaffected
         sess.refresh(non_pub_diff_qtr_submission)
         assert non_pub_diff_qtr_submission.published_submission_ids == []
+        assert non_pub_diff_qtr_submission.test_submission is False
 
 
 @pytest.mark.usefixtures('job_constants')


### PR DESCRIPTION
**High level description:**
Setting submissions to `test_submission` using the same logic as setting their `published_submission_ids`

**Technical details:**
The updates to `test_submission` flag should handle all of these situations, since they're the same situations as filling in `published_submission_ids`

**Link to JIRA Ticket:**
[DEV-5017](https://federal-spending-transparency.atlassian.net/browse/DEV-5017)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- Documentation Updated