### PR TITLE
DEV-5395: period 2 submissions

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -309,7 +309,7 @@ curl -i -X POST
 - `reporting_period_end_date`: (string) ending date of submission (MM/YYYY)
 - `existing_submission_id`: (integer) ID of previous submission, use only if submitting an update.
 
-**NOTE**: for monthly submissions, start/end date are the same
+**NOTE**: for monthly submissions, start/end date are the same except in the case of period 1/2, which must be done together (start: 10/YYYY, end: 11/YYYY)
 
 ##### Response (JSON):
 ```
@@ -329,6 +329,7 @@ Possible HTTP Status Codes:
 - 400:
     - Missing parameter
     - Submission does not exist
+    - Invalid start/end date combination
 - 401: Login required
 - 403: Permission denied, user does not have permission to view this submission
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -123,8 +123,8 @@ class FileHandler:
             # Single period checks
             if not is_quarter:
                 data = {
-                    'message': 'A monthly submission must be exactly one month with the exception of period 2, which'
-                               ' must span both periods 1 and 2.'
+                    'message': 'A monthly submission must be exactly one month with the exception of periods 1 and 2,'
+                               ' which must be selected together.'
                 }
                 period1 = 10
                 period2 = 11
@@ -139,8 +139,8 @@ class FileHandler:
                     return JsonResponse.create(StatusCode.CLIENT_ERROR, data)
 
                 # attempting to make just period 1 or period 2 submission without spanning both
-                if (formatted_start_date.month == period1 and formatted_end_date != period2) or \
-                        (formatted_start_date.month != period1 and formatted_end_date == period2):
+                if (formatted_start_date.month == period1 and formatted_end_date.month != period2) or \
+                        (formatted_start_date.month != period1 and formatted_end_date.month == period2):
                     return JsonResponse.create(StatusCode.CLIENT_ERROR, data)
         return self.submit(sess)
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -120,13 +120,28 @@ class FileHandler:
             formatted_start_date, formatted_end_date = FileHandler.check_submission_dates(start_date,
                                                                                           end_date, is_quarter)
 
-            if not is_quarter and not (formatted_start_date.month == formatted_end_date.month and
-                                       formatted_start_date.year == formatted_end_date.year):
+            # Single period checks
+            if not is_quarter:
                 data = {
-                    'message': 'A monthly submission must be exactly one month.'
+                    'message': 'A monthly submission must be exactly one month with the exception of period 2, which'
+                               ' must span both periods 1 and 2.'
                 }
-                return JsonResponse.create(StatusCode.CLIENT_ERROR, data)
+                period1 = 10
+                period2 = 11
 
+                # multiple years
+                if not formatted_start_date.year == formatted_end_date.year:
+                    return JsonResponse.create(StatusCode.CLIENT_ERROR, data)
+
+                # Not the same month, not period 2
+                if formatted_start_date.month != formatted_end_date.month and formatted_start_date.month != period1 \
+                        and formatted_end_date.month != period2:
+                    return JsonResponse.create(StatusCode.CLIENT_ERROR, data)
+
+                # attempting to make just period 1 or period 2 submission without spanning both
+                if (formatted_start_date.month == period1 and formatted_end_date != period2) or \
+                        (formatted_start_date.month != period1 and formatted_end_date == period2):
+                    return JsonResponse.create(StatusCode.CLIENT_ERROR, data)
         return self.submit(sess)
 
     @staticmethod

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -415,7 +415,8 @@ class FileTests(BaseTestAPI):
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={'x-session-id': self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month.')
+        self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month with the exception'
+                                                   ' of period 2, which must span both periods 1 and 2.')
 
         # wrong year
         monthly_submission_json = {
@@ -428,7 +429,8 @@ class FileTests(BaseTestAPI):
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={'x-session-id': self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month.')
+        self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month with the exception'
+                                                   ' of period 2, which must span both periods 1 and 2.')
 
     def test_revalidation_threshold_no_login(self):
         """ Test response with no login """

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -392,12 +392,25 @@ class FileTests(BaseTestAPI):
         self.assertEqual(response.json['message'], 'existing_submission_id must be a valid submission_id')
 
     def test_submit_file_monthly_submission(self):
+        # Single month
+        monthly_submission_json = {
+            'cgac_code': 'NOT',
+            'frec_code': None,
+            'is_quarter': False,
+            'reporting_period_start_date': '05/2015',
+            'reporting_period_end_date': '05/2015'}
+        response = self.app.post('/v1/upload_dabs_files/', monthly_submission_json,
+                                 upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
+                                 headers={'x-session-id': self.session_id}, expect_errors=False)
+        self.assertEqual(response.status_code, 200)
+
+        # Period 2 (with period 1)
         monthly_submission_json = {
             'cgac_code': 'NOT',
             'frec_code': None,
             'is_quarter': False,
             'reporting_period_start_date': '10/2015',
-            'reporting_period_end_date': '10/2015'}
+            'reporting_period_end_date': '11/2015'}
         response = self.app.post('/v1/upload_dabs_files/', monthly_submission_json,
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={'x-session-id': self.session_id}, expect_errors=False)
@@ -409,16 +422,30 @@ class FileTests(BaseTestAPI):
             'cgac_code': 'NOT',
             'frec_code': None,
             'is_quarter': False,
-            'reporting_period_start_date': '10/2015',
-            'reporting_period_end_date': '12/2015'}
+            'reporting_period_start_date': '03/2015',
+            'reporting_period_end_date': '04/2015'}
         response = self.app.post('/v1/upload_dabs_files/', monthly_submission_json,
                                  upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
                                  headers={'x-session-id': self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month with the exception'
-                                                   ' of period 2, which must span both periods 1 and 2.')
+                                                   ' of periods 1 and 2, which must be selected together.')
 
         # wrong year
+        monthly_submission_json = {
+            'cgac_code': 'NOT',
+            'frec_code': None,
+            'is_quarter': False,
+            'reporting_period_start_date': '05/2015',
+            'reporting_period_end_date': '05/2016'}
+        response = self.app.post('/v1/upload_dabs_files/', monthly_submission_json,
+                                 upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
+                                 headers={'x-session-id': self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month with the exception'
+                                                   ' of periods 1 and 2, which must be selected together.')
+
+        # Period 1
         monthly_submission_json = {
             'cgac_code': 'NOT',
             'frec_code': None,
@@ -430,7 +457,21 @@ class FileTests(BaseTestAPI):
                                  headers={'x-session-id': self.session_id}, expect_errors=True)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month with the exception'
-                                                   ' of period 2, which must span both periods 1 and 2.')
+                                                   ' of periods 1 and 2, which must be selected together.')
+
+        # Period 2 (without period 1)
+        monthly_submission_json = {
+            'cgac_code': 'NOT',
+            'frec_code': None,
+            'is_quarter': False,
+            'reporting_period_start_date': '11/2015',
+            'reporting_period_end_date': '11/2016'}
+        response = self.app.post('/v1/upload_dabs_files/', monthly_submission_json,
+                                 upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
+                                 headers={'x-session-id': self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month with the exception'
+                                                   ' of periods 1 and 2, which must be selected together.')
 
     def test_revalidation_threshold_no_login(self):
         """ Test response with no login """


### PR DESCRIPTION
**High level description:**
Combining periods 1 and 2 when creating monthly submissions

**Technical details:**
Periods 1 and 2 cannot be selected separately and must always go together. All other monthly submissions must still span exactly 1 month
- This WILL break frontend creation of periods 1/2 until the frontend is updated

**Link to JIRA Ticket:**
[DEV-5395](https://federal-spending-transparency.atlassian.net/browse/DEV-5395)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation Updated