### PR TITLE
DEV-5020: check_year_quarter updates

### DIFF
--- a/APISubmissionGuide.md
+++ b/APISubmissionGuide.md
@@ -29,8 +29,8 @@ While the Submission API has been designed to be as easy to understand as possib
 ### Upload A, B, C Files
 - Step 1: call `/v1/upload_dabs_files/` (POST) to create the submission.
 - For details on its use, click [here](./dataactbroker/README.md#post-v1upload_dabs_files)
-- **NOTE**: If you would like to certify this submission, call `/v1/check_year_period/` (GET) to see ensure there are no other submissions already published by the same agency in the same period.
-    - For details on its use, click [here](./dataactbroker/README.md#post-v1upload_dabs_files)
+- **NOTE**: If you would like to certify this submission, call `/v1/check_year_period/` (GET) to ensure there are no other submissions already published by the same agency in the same period.
+    - For details on its use, click [here](./dataactbroker/README.md#get-v1check_year_period)
 
 ### Validate A, B, C Files
 - File-level validation begins automatically on upload completion.

--- a/APISubmissionGuide.md
+++ b/APISubmissionGuide.md
@@ -29,6 +29,8 @@ While the Submission API has been designed to be as easy to understand as possib
 ### Upload A, B, C Files
 - Step 1: call `/v1/upload_dabs_files/` (POST) to create the submission.
 - For details on its use, click [here](./dataactbroker/README.md#post-v1upload_dabs_files)
+- **NOTE**: If you would like to certify this submission, call `/v1/check_year_period/` (GET) to see ensure there are no other submissions already published by the same agency in the same period.
+    - For details on its use, click [here](./dataactbroker/README.md#post-v1upload_dabs_files)
 
 ### Validate A, B, C Files
 - File-level validation begins automatically on upload completion.

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -423,6 +423,7 @@ or
 Possible HTTP Status Codes:
 
 - 400: There are already published submissions in this period
+- 400: CGAC or FREC code not provided
 
 
 #### GET "/v1/revalidation\_threshold/"

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -388,6 +388,43 @@ Possible HTTP Status Codes:
 - 403: Permission denied, user does not have permission to view this submission
 
 
+#### GET "/v1/check\_year\_period/"
+This endpoint checks to see if there are any published submissions for a given agency and fiscal period or quarter.
+
+##### Sample Request
+`/v1/check_year_period/`
+
+##### Request Params
+- `cgac_code`: (required if not FREC, string) CGAC of agency (null if FREC agency)
+- `frec_code`: (required if not CGAC, string) FREC of agency (null if CGAC agency)
+- `is_quarter`: (boolean) True for quarterly submissions
+- `reporting_fiscal_year`: (string) starting date of submission (MM/YYYY)
+- `reporting_fiscal_period`: (string) ending date of submission (MM/YYYY)
+
+##### Response (JSON)
+```
+{
+    "message": "Success"
+}
+```
+or
+```
+{
+    "message": "This period already has published submission(s) by this agency."
+    "submissionIds": [143, 145]
+}
+```
+
+##### Response Attributes
+- `message`: (string) indicates whether or not the agency is cleared to make a certifiable submission in this period or quarter.
+- `submissionIds`: ([integer]) ids of published submissions by said agency in the period requested. 
+
+##### Errors
+Possible HTTP Status Codes:
+
+- 400: There are already published submissions in this period
+
+
 #### GET "/v1/revalidation\_threshold/"
 This endpoint returns the revalidation threshold for the broker application. This is the date that denotes the earliest validation date a submission must have in order to be certifiable.
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql.expression import case
 
 from dataactbroker.handlers.submission_handler import (create_submission, get_submission_status, get_submission_files,
-                                                       reporting_date, job_to_dict, get_existing_submission_list)
+                                                       reporting_date, job_to_dict, get_submissions_in_period)
 from dataactbroker.helpers.fabs_derivations_helper import fabs_derivations
 from dataactbroker.helpers.filters_helper import permissions_filter, agency_filter
 from dataactbroker.permissions import current_user_can_on_submission
@@ -234,25 +234,10 @@ class FileHandler:
 
             # set published_submission_ids for new submissions
             if not existing_submission:
-                published_qtr_subs = get_existing_submission_list(submission_data['cgac_code'],
-                                                                  submission_data['frec_code'],
-                                                                  reporting_fiscal_year,
-                                                                  reporting_fiscal_period,
-                                                                  None,
-                                                                  filter_quarter=True,
-                                                                  filter_published='published',
-                                                                  filter_sub_type='quarterly')
-                published_mon_subs = get_existing_submission_list(submission_data['cgac_code'],
-                                                                  submission_data['frec_code'],
-                                                                  reporting_fiscal_year,
-                                                                  reporting_fiscal_period,
-                                                                  None,
-                                                                  filter_quarter=submission_data['is_quarter_format'],
-                                                                  filter_published='published',
-                                                                  filter_sub_type='monthly')
-                published_submissions_ids = published_qtr_subs.union(published_mon_subs)
-                submission_data['published_submission_ids'] = [pub_sub.submission_id for pub_sub
-                                                               in published_submissions_ids]
+                pub_subs = get_submissions_in_period(submission_data['cgac_code'], submission_data['frec_code'],
+                                                     reporting_fiscal_year, reporting_fiscal_period,
+                                                     submission_data['is_quarter_format'], filter_published='published')
+                submission_data['published_submission_ids'] = [pub_sub.submission_id for pub_sub in pub_subs]
 
             test_submission = request_params.get('test_submission')
             test_submission = str(test_submission).upper() == 'TRUE'

--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -143,9 +143,8 @@ def get_submission_metadata(submission):
         filter_by(submission_id=submission.submission_id).\
         scalar() or 0
 
-    test_sub = get_existing_submission_list(submission.cgac_code, submission.frec_code,
-                                            submission.reporting_fiscal_year, submission.reporting_fiscal_period,
-                                            submission.submission_id)
+    test_sub = filter_submissions(submission.cgac_code, submission.frec_code, submission.reporting_fiscal_year,
+                                  submission.reporting_fiscal_period, submission.submission_id)
     certified_submission = None
 
     if test_sub.count() > 0:
@@ -532,23 +531,18 @@ def check_current_submission_page(submission):
         return JsonResponse.error(ValueError('The submission ID returns no response'), StatusCode.CLIENT_ERROR)
 
 
-def find_existing_submissions_in_period(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
-                                        submission_id=None, filter_published='published', filter_quarter=False,
-                                        filter_sub_type='mixed'):
-    """ Find all the submissions in the given period for the given CGAC or FREC code
+def check_year_and_period(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period, is_quarter_format,
+                          submission_id=None):
+    """ Check to see if there are any published submissions by the same agency in the same period
 
         Args:
             cgac_code: the CGAC code to check against or None if checking a FREC agency
             frec_code: the FREC code to check against or None if checking a CGAC agency
             reporting_fiscal_year: the year to check for
             reporting_fiscal_period: the period in the year to check for
+            is_quarter_format: whether the submission being checked is a quarterly or monthly submission
             submission_id: the submission ID to check against (used when checking if this submission is being
                 re-certified)
-            filter_published: whether to filter published/unpublished submissions
-                       (options are: "mixed", "published" (default), and "unpublished")
-            filter_quarter: whether to include submissions in the same quarter (True) or period (False, default)
-            filter_sub_type: whether to include submissions in the same period or quarter
-                             (options are: "monthly", "quarterly", and "mixed" (default))
 
         Returns:
             A JsonResponse containing a success message to indicate there are no existing submissions in the given
@@ -558,24 +552,51 @@ def find_existing_submissions_in_period(cgac_code, frec_code, reporting_fiscal_y
     if not cgac_code and not frec_code:
         return JsonResponse.error(ValueError('CGAC or FR Entity Code required'), StatusCode.CLIENT_ERROR)
 
-    submission_query = get_existing_submission_list(cgac_code, frec_code, reporting_fiscal_year,
-                                                    reporting_fiscal_period, submission_id,
-                                                    filter_quarter=filter_quarter, filter_published=filter_published,
-                                                    filter_sub_type=filter_sub_type)
+    pub_subs = get_submissions_in_period(cgac_code, frec_code, int(reporting_fiscal_year), int(reporting_fiscal_period),
+                                         is_quarter_format, submission_id=submission_id, filter_published='published')
 
-    if submission_query.count() > 0:
+    if pub_subs.count() > 0:
         data = {
-            'message': 'A submission with the same period already exists.',
-            'submissionId': submission_query[0].submission_id
+            'message': 'This period already has published submission(s) by this agency.',
+            'submissionIds': [pub_sub.submission_id for pub_sub in pub_subs]
         }
         return JsonResponse.create(StatusCode.CLIENT_ERROR, data)
     return JsonResponse.create(StatusCode.OK, {'message': 'Success'})
 
 
-def get_existing_submission_list(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
-                                 submission_id=None, filter_published='published', filter_quarter=False,
-                                 filter_sub_type='mixed'):
-    """ Get the list of the submissions in the given period for the given CGAC or FREC code
+def get_submissions_in_period(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period, is_quarter_format,
+                              submission_id=None, filter_published='published'):
+    """ Find all the submissions in the given period for the given CGAC or FREC code and submission type
+
+        Args:
+            cgac_code: the CGAC code to check against or None if checking a FREC agency
+            frec_code: the FREC code to check against or None if checking a CGAC agency
+            reporting_fiscal_year: the year to check for
+            reporting_fiscal_period: the period in the year to check for
+            is_quarter_format: whether the submission being checked is a quarterly or monthly submission
+            submission_id: the submission ID to check against (used when checking if this submission is being
+                re-certified)
+            filter_published: whether to filter published/unpublished submissions
+                       (options are: "mixed", "published" (default), and "unpublished")
+
+        Returns:
+            query including all the submissions for a given period
+    """
+    qtr_subs = filter_submissions(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
+                                  submission_id, filter_quarter=True, filter_published=filter_published,
+                                  filter_sub_type='quarterly')
+    mon_subs = filter_submissions(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
+                                  submission_id, filter_quarter=is_quarter_format,
+                                  filter_published=filter_published,
+                                  filter_sub_type='monthly')
+    subs_in_period = mon_subs.union(qtr_subs)
+    return subs_in_period
+
+
+def filter_submissions(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
+                       submission_id=None, filter_published='published', filter_quarter=False,
+                       filter_sub_type='mixed'):
+    """ Get the list of the submissions based on the filters provided
 
         Args:
             cgac_code: the CGAC code to check against or None if checking a FREC agency
@@ -591,7 +612,7 @@ def get_existing_submission_list(cgac_code, frec_code, reporting_fiscal_year, re
                              (options are: "monthly", "quarterly", and "mixed" (default))
 
         Returns:
-            A query to get the certified submissions in the given period
+            A query to get submissions based on the filters provided
     """
     sess = GlobalDB.db().session
 
@@ -776,11 +797,13 @@ def certify_dabs_submission(submission, file_manager):
     if blank_files > 0:
         return JsonResponse.error(ValueError('Cannot certify while file A or B is blank.'), StatusCode.CLIENT_ERROR)
 
-    response = find_existing_submissions_in_period(submission.cgac_code, submission.frec_code,
-                                                   submission.reporting_fiscal_year,
-                                                   submission.reporting_fiscal_period, submission.submission_id)
+    response = check_year_and_period(submission.cgac_code, submission.frec_code, submission.reporting_fiscal_year,
+                                     submission.reporting_fiscal_period, is_quarter_format=submission.is_quarter_format,
+                                     submission_id=submission.submission_id)
 
     if response.status_code == StatusCode.OK:
+        first_publish = (submission.publish_status_id == PUBLISH_STATUS_DICT['unpublished'])
+
         # create the publish_history and certify_history entry
         publish_history = PublishHistory(created_at=datetime.utcnow(), user_id=current_user_id,
                                          submission_id=submission.submission_id)
@@ -804,25 +827,15 @@ def certify_dabs_submission(submission, file_manager):
         submission.publish_status_id = PUBLISH_STATUS_DICT['published']
         submission.certified = True
 
-        # update any other submissions by the same agency in the same quarter/period to point to this submission
-        related_unpub_qtr_subs = get_existing_submission_list(submission.cgac_code, submission.frec_code,
-                                                              submission.reporting_fiscal_year,
-                                                              submission.reporting_fiscal_period,
-                                                              submission.submission_id,
-                                                              filter_quarter=True,
-                                                              filter_published='unpublished',
-                                                              filter_sub_type='quarterly')
-        related_unpub_mon_subs = get_existing_submission_list(submission.cgac_code, submission.frec_code,
-                                                              submission.reporting_fiscal_year,
-                                                              submission.reporting_fiscal_period,
-                                                              submission.submission_id,
-                                                              filter_quarter=submission.is_quarter_format,
-                                                              filter_published='unpublished',
-                                                              filter_sub_type='monthly')
-        related_unpub_subs = related_unpub_mon_subs.union(related_unpub_qtr_subs)
-        for related_unpub_sub in related_unpub_subs.all():
-            related_unpub_sub.published_submission_ids.append(submission.submission_id)
-        sess.commit()
+        if first_publish:
+            # update any other submissions by the same agency in the same quarter/period to point to this submission
+            unpub_subs = get_submissions_in_period(submission.cgac_code, submission.frec_code,
+                                                   submission.reporting_fiscal_year, submission.reporting_fiscal_period,
+                                                   submission.is_quarter_format, submission.submission_id,
+                                                   filter_published='unpublished')
+            for unpub_sub in unpub_subs.all():
+                unpub_sub.published_submission_ids.append(submission.submission_id)
+            sess.commit()
 
     return response
 

--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -835,7 +835,7 @@ def certify_dabs_submission(submission, file_manager):
                                                    filter_published='unpublished')
             for unpub_sub in unpub_subs.all():
                 unpub_sub.published_submission_ids.append(submission.submission_id)
-                related_unpub_sub.test_submission = True
+                unpub_sub.test_submission = True
             sess.commit()
 
     return response

--- a/dataactbroker/routes/file_routes.py
+++ b/dataactbroker/routes/file_routes.py
@@ -228,7 +228,7 @@ def add_file_routes(app, is_local, server_path):
         """ Check if cgac (or frec) code, year, and quarter already has a published submission """
         cgac_code = kwargs.get('cgac_code')
         frec_code = kwargs.get('frec_code')
-        is_quarter = kwargs.get('is_quarter_format')
+        is_quarter = kwargs.get('is_quarter')
         return check_year_and_period(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period, is_quarter)
 
     @app.route("/v1/certify_submission/", methods=['POST'])

--- a/dataactbroker/routes/file_routes.py
+++ b/dataactbroker/routes/file_routes.py
@@ -8,7 +8,7 @@ from dataactbroker.handlers.fileHandler import (
     list_certifications, file_history_url, get_comments_file)
 from dataactbroker.handlers.submission_handler import (
     delete_all_submission_data, get_submission_stats, list_windows, check_current_submission_page,
-    certify_dabs_submission, find_existing_submissions_in_period, get_submission_metadata, get_submission_data,
+    certify_dabs_submission, check_year_and_period, get_submission_metadata, get_submission_data,
     get_revalidation_threshold, get_latest_publication_period, revert_to_certified)
 from dataactbroker.decorators import convert_to_submission_id
 from dataactbroker.permissions import (requires_login, requires_submission_perms, requires_agency_perms,
@@ -217,17 +217,19 @@ def add_file_routes(app, is_local, server_path):
         """
         return delete_all_submission_data(submission)
 
-    @app.route("/v1/check_year_quarter/", methods=["GET"])
+    @app.route("/v1/check_year_period/", methods=["GET"])
     @requires_login
     @use_kwargs({'reporting_fiscal_year': webargs_fields.String(required=True),
                  'reporting_fiscal_period': webargs_fields.String(required=True),
                  'cgac_code': webargs_fields.String(),
-                 'frec_code': webargs_fields.String()})
-    def check_year_and_quarter(reporting_fiscal_year, reporting_fiscal_period, **kwargs):
+                 'frec_code': webargs_fields.String(),
+                 'is_quarter': webargs_fields.Bool()})
+    def check_year_period(reporting_fiscal_year, reporting_fiscal_period, **kwargs):
         """ Check if cgac (or frec) code, year, and quarter already has a published submission """
         cgac_code = kwargs.get('cgac_code')
         frec_code = kwargs.get('frec_code')
-        return find_existing_submissions_in_period(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period)
+        is_quarter = kwargs.get('is_quarter_format')
+        return check_year_and_period(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period, is_quarter)
 
     @app.route("/v1/certify_submission/", methods=['POST'])
     @convert_to_submission_id

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -757,36 +757,36 @@ class FileTests(BaseTestAPI):
                                       expect_errors=True)
         self.assertEqual(response.json['message'], 'Submissions that have been published cannot be deleted')
 
-    def test_check_year_quarter_success(self):
+    def test_check_year_period_success(self):
         params = {'cgac_code': 'SYS',
                   'submission_id': '1',
                   'reporting_fiscal_year': '2015',
                   'reporting_fiscal_period': '3'}
-        response = self.app.get('/v1/check_year_quarter/', params, headers={'x-session-id': self.session_id},
+        response = self.app.get('/v1/check_year_period/', params, headers={'x-session-id': self.session_id},
                                 expect_errors=False)
         self.assertEqual(response.json['message'], 'Success')
 
-    def test_check_year_quarter_already_published(self):
+    def test_check_year_period_already_published(self):
         params = {'cgac_code': 'SYS',
                   'submission_id': '1',
                   'reporting_fiscal_year': '2015',
                   'reporting_fiscal_period': '12'}
 
-        response = self.app.get('/v1/check_year_quarter/', params, headers={'x-session-id': self.session_id},
+        response = self.app.get('/v1/check_year_period/', params, headers={'x-session-id': self.session_id},
                                 expect_errors=True)
-        self.assertEqual(response.json['message'], 'A submission with the same period already exists.')
-        self.assertEqual(response.json['submissionId'], self.test_published_submission_id)
+        self.assertEqual(response.json['message'], 'This period already has published submission(s) by this agency.')
+        self.assertEqual(response.json['submissionIds'], [self.test_published_submission_id])
 
-    def test_check_year_quarter_updated(self):
+    def test_check_year_period_updated(self):
         params = {'cgac_code': 'SYS',
                   'submission_id': '1',
                   'reporting_fiscal_year': '2016',
                   'reporting_fiscal_period': '12'}
 
-        response = self.app.get('/v1/check_year_quarter/', params, headers={'x-session-id': self.session_id},
+        response = self.app.get('/v1/check_year_period/', params, headers={'x-session-id': self.session_id},
                                 expect_errors=True)
-        self.assertEqual(response.json['message'], 'A submission with the same period already exists.')
-        self.assertEqual(response.json['submissionId'], self.test_updated_submission_id)
+        self.assertEqual(response.json['message'], 'This period already has published submission(s) by this agency.')
+        self.assertEqual(response.json['submissionIds'], [self.test_updated_submission_id])
 
     def test_certify_submission(self):
         post_json = {'submission_id': self.row_error_submission_id}

--- a/tests/unit/dataactbroker/test_submission_handler.py
+++ b/tests/unit/dataactbroker/test_submission_handler.py
@@ -608,6 +608,11 @@ def test_published_submission_ids_month_same_periods(database, monkeypatch):
 
         certify_dabs_submission(pub_mon1_submission, file_handler)
         certify_dabs_submission(pub_mon2_submission, file_handler)
+        # repeating one to ensure the values don't duplicate
+        pub_mon2 = sess.query(Submission).filter(Submission.submission_id == pub_mon2_submission.submission_id).one()
+        pub_mon2.publish_status_id = PUBLISH_STATUS_DICT['updated']
+        sess.commit()
+        certify_dabs_submission(pub_mon2_submission, file_handler)
 
         # monthly same period -> published monthly sub
         sess.refresh(non_pub_same_mon_submission)


### PR DESCRIPTION
**High level description:**
Updating `check_year_quarter` to `check_year_period` which will handle both monthly and quarterly submissions.

**Technical details:**
* Added documentation for endpoint and the APIsubmission guide.
* `check_year_period` also requires `is_quarter` for the logic.
* Refactored a bunch of the published submission ids logic.
* Added a check for publishing submission ids logic to only apply on first publish.

**Link to JIRA Ticket:**
[DEV-5020](https://federal-spending-transparency.atlassian.net/browse/DEV-5020)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Merged concurrently with [Frontend#1371](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1371)
- Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation Updated