### PR TITLE
DEV-5218: Updating check_year_period -> published_submissions

### DIFF
--- a/APISubmissionGuide.md
+++ b/APISubmissionGuide.md
@@ -29,8 +29,8 @@ While the Submission API has been designed to be as easy to understand as possib
 ### Upload A, B, C Files
 - Step 1: call `/v1/upload_dabs_files/` (POST) to create the submission.
 - For details on its use, click [here](./dataactbroker/README.md#post-v1upload_dabs_files)
-- **NOTE**: If you would like to certify this submission, call `/v1/check_year_period/` (GET) to ensure there are no other submissions already published by the same agency in the same period.
-    - For details on its use, click [here](./dataactbroker/README.md#get-v1check_year_period)
+- **NOTE**: If you would like to certify this submission, call `/v1/published_submissions/` (GET) to ensure there are no other submissions already published by the same agency in the same period.
+    - For details on its use, click [here](./dataactbroker/README.md#get-v1published_submissions)
 
 ### Validate A, B, C Files
 - File-level validation begins automatically on upload completion.

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -389,11 +389,11 @@ Possible HTTP Status Codes:
 - 403: Permission denied, user does not have permission to view this submission
 
 
-#### GET "/v1/check\_year\_period/"
-This endpoint checks to see if there are any published submissions for a given agency and fiscal period or quarter.
+#### GET "/v1/published\_submissions/"
+This endpoint returns a list of published submissions for a given agency and fiscal period or quarter.
 
 ##### Sample Request
-`/v1/check_year_period/`
+`/v1/published\_submissions/`
 
 ##### Request Params
 - `cgac_code`: (required if not FREC, string) CGAC of agency (null if FREC agency)
@@ -405,20 +405,23 @@ This endpoint checks to see if there are any published submissions for a given a
 ##### Response (JSON)
 ```
 {
-    "message": "Success"
-}
-```
-or
-```
-{
-    "message": "This period already has published submission(s) by this agency."
-    "submissionIds": [143, 145]
+    "published_submissions": [
+        {
+            "submission_id": 123,
+            "is_quarter": false
+        },
+        {
+            "submission_id": 234,
+            "is_quarter": false
+        },
+    ]
 }
 ```
 
 ##### Response Attributes
-- `message`: (string) indicates whether or not the agency is cleared to make a certifiable submission in this period or quarter.
-- `submissionIds`: ([integer]) ids of published submissions by said agency in the period requested. 
+- `published_submissions`: ([object]) each object represents a published submission by said agency in the period requested. 
+    - `submission_id`: (integer) an integer representing the ID of the submission
+    - `is_quarter`: (boolean) whether or not it is a quarter submission
 
 ##### Errors
 Possible HTTP Status Codes:

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -426,7 +426,6 @@ This endpoint returns a list of published submissions for a given agency and fis
 ##### Errors
 Possible HTTP Status Codes:
 
-- 400: There are already published submissions in this period
 - 400: CGAC or FREC code not provided
 
 

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -393,14 +393,14 @@ Possible HTTP Status Codes:
 This endpoint returns a list of published submissions for a given agency and fiscal period or quarter.
 
 ##### Sample Request
-`/v1/published\_submissions/`
+`/v1/published\_submissions/?cgac_code=&frec_code=1601&reporting_fiscal_year=2020&reporting_fiscal_period=12&is_quarter=true`
 
 ##### Request Params
 - `cgac_code`: (required if not FREC, string) CGAC of agency (null if FREC agency)
 - `frec_code`: (required if not CGAC, string) FREC of agency (null if CGAC agency)
-- `is_quarter`: (boolean) True for quarterly submissions
-- `reporting_fiscal_year`: (string) starting date of submission (MM/YYYY)
-- `reporting_fiscal_period`: (string) ending date of submission (MM/YYYY)
+- `is_quarter`: (boolean) whether or not a new submission being made in this time will be quarterly or not (True for quarterly submissions)
+- `reporting_fiscal_year`: (string) the fiscal year to check for published submissions
+- `reporting_fiscal_period`: (string) the fiscal period to check for published submissions
 
 ##### Response (JSON)
 ```
@@ -419,9 +419,9 @@ This endpoint returns a list of published submissions for a given agency and fis
 ```
 
 ##### Response Attributes
-- `published_submissions`: ([object]) each object represents a published submission by said agency in the period requested. 
+- `published_submissions`: ([object]) each object represents a published submission in the requested agency and period. 
     - `submission_id`: (integer) an integer representing the ID of the submission
-    - `is_quarter`: (boolean) whether or not it is a quarter submission
+    - `is_quarter`: (boolean) whether or not it is a quarterly submission
 
 ##### Errors
 Possible HTTP Status Codes:

--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -531,7 +531,7 @@ def check_current_submission_page(submission):
         return JsonResponse.error(ValueError('The submission ID returns no response'), StatusCode.CLIENT_ERROR)
 
 
-def get_published_submissions_ids(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
+def get_published_submission_ids(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
                                   is_quarter_format, submission_id=None):
     """ List any published submissions by the same agency in the same period
 

--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -531,9 +531,9 @@ def check_current_submission_page(submission):
         return JsonResponse.error(ValueError('The submission ID returns no response'), StatusCode.CLIENT_ERROR)
 
 
-def check_year_and_period(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period, is_quarter_format,
-                          submission_id=None):
-    """ Check to see if there are any published submissions by the same agency in the same period
+def get_published_submissions_ids(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
+                                  is_quarter_format, submission_id=None):
+    """ List any published submissions by the same agency in the same period
 
         Args:
             cgac_code: the CGAC code to check against or None if checking a FREC agency
@@ -545,8 +545,7 @@ def check_year_and_period(cgac_code, frec_code, reporting_fiscal_year, reporting
                 re-certified)
 
         Returns:
-            A JsonResponse containing a success message to indicate there are no existing submissions in the given
-            period or the error if there was one
+            A JsonResponse containing a list of the published submissions for that period
     """
     # We need either a cgac or a frec code for this function
     if not cgac_code and not frec_code:
@@ -554,14 +553,14 @@ def check_year_and_period(cgac_code, frec_code, reporting_fiscal_year, reporting
 
     pub_subs = get_submissions_in_period(cgac_code, frec_code, int(reporting_fiscal_year), int(reporting_fiscal_period),
                                          is_quarter_format, submission_id=submission_id, filter_published='published')
-
-    if pub_subs.count() > 0:
-        data = {
-            'message': 'This period already has published submission(s) by this agency.',
-            'submissionIds': [pub_sub.submission_id for pub_sub in pub_subs]
+    published_submissions = [
+        {
+            'submission_id': pub_sub.submission_id,
+            'is_quarter': pub_sub.is_quarter_format
         }
-        return JsonResponse.create(StatusCode.CLIENT_ERROR, data)
-    return JsonResponse.create(StatusCode.OK, {'message': 'Success'})
+        for pub_sub in pub_subs
+    ]
+    return JsonResponse.create(StatusCode.OK, {'published_submissions': published_submissions})
 
 
 def get_submissions_in_period(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period, is_quarter_format,
@@ -797,11 +796,12 @@ def certify_dabs_submission(submission, file_manager):
     if blank_files > 0:
         return JsonResponse.error(ValueError('Cannot certify while file A or B is blank.'), StatusCode.CLIENT_ERROR)
 
-    response = check_year_and_period(submission.cgac_code, submission.frec_code, submission.reporting_fiscal_year,
-                                     submission.reporting_fiscal_period, is_quarter_format=submission.is_quarter_format,
-                                     submission_id=submission.submission_id)
+    pub_subs = get_submissions_in_period(submission.cgac_code, submission.frec_code, submission.reporting_fiscal_year,
+                                         submission.reporting_fiscal_period,
+                                         is_quarter_format=submission.is_quarter_format,
+                                         submission_id=submission.submission_id, filter_published='published')
 
-    if response.status_code == StatusCode.OK:
+    if pub_subs.count() == 0:
         first_publish = (submission.publish_status_id == PUBLISH_STATUS_DICT['unpublished'])
 
         # create the publish_history and certify_history entry
@@ -837,6 +837,13 @@ def certify_dabs_submission(submission, file_manager):
                 unpub_sub.published_submission_ids.append(submission.submission_id)
                 unpub_sub.test_submission = True
             sess.commit()
+
+        response = JsonResponse.create(StatusCode.OK, {'message': 'Success'})
+    else:
+        # This theoretically shouldn't happen as this submission should already be marked as a test submission
+        # upon creation or when the other submission publishes. However, double check couldn't hurt.
+        response = JsonResponse.create(StatusCode.CLIENT_ERROR, {'message': 'This period already has published'
+                                                                            ' submission(s) by this agency.'})
 
     return response
 

--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -532,7 +532,7 @@ def check_current_submission_page(submission):
 
 
 def get_published_submission_ids(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
-                                  is_quarter_format, submission_id=None):
+                                 is_quarter_format, submission_id=None):
     """ List any published submissions by the same agency in the same period
 
         Args:

--- a/dataactbroker/routes/file_routes.py
+++ b/dataactbroker/routes/file_routes.py
@@ -230,7 +230,7 @@ def add_file_routes(app, is_local, server_path):
         frec_code = kwargs.get('frec_code')
         is_quarter = kwargs.get('is_quarter')
         return get_published_submission_ids(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
-                                             is_quarter)
+                                            is_quarter)
 
     @app.route("/v1/certify_submission/", methods=['POST'])
     @convert_to_submission_id

--- a/dataactbroker/routes/file_routes.py
+++ b/dataactbroker/routes/file_routes.py
@@ -8,7 +8,7 @@ from dataactbroker.handlers.fileHandler import (
     list_certifications, file_history_url, get_comments_file)
 from dataactbroker.handlers.submission_handler import (
     delete_all_submission_data, get_submission_stats, list_windows, check_current_submission_page,
-    certify_dabs_submission, get_published_submissions_ids, get_submission_metadata, get_submission_data,
+    certify_dabs_submission, get_published_submission_ids, get_submission_metadata, get_submission_data,
     get_revalidation_threshold, get_latest_publication_period, revert_to_certified)
 from dataactbroker.decorators import convert_to_submission_id
 from dataactbroker.permissions import (requires_login, requires_submission_perms, requires_agency_perms,
@@ -229,7 +229,7 @@ def add_file_routes(app, is_local, server_path):
         cgac_code = kwargs.get('cgac_code')
         frec_code = kwargs.get('frec_code')
         is_quarter = kwargs.get('is_quarter')
-        return get_published_submissions_ids(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
+        return get_published_submission_ids(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
                                              is_quarter)
 
     @app.route("/v1/certify_submission/", methods=['POST'])

--- a/dataactbroker/routes/file_routes.py
+++ b/dataactbroker/routes/file_routes.py
@@ -8,7 +8,7 @@ from dataactbroker.handlers.fileHandler import (
     list_certifications, file_history_url, get_comments_file)
 from dataactbroker.handlers.submission_handler import (
     delete_all_submission_data, get_submission_stats, list_windows, check_current_submission_page,
-    certify_dabs_submission, check_year_and_period, get_submission_metadata, get_submission_data,
+    certify_dabs_submission, get_published_submissions_ids, get_submission_metadata, get_submission_data,
     get_revalidation_threshold, get_latest_publication_period, revert_to_certified)
 from dataactbroker.decorators import convert_to_submission_id
 from dataactbroker.permissions import (requires_login, requires_submission_perms, requires_agency_perms,
@@ -217,19 +217,20 @@ def add_file_routes(app, is_local, server_path):
         """
         return delete_all_submission_data(submission)
 
-    @app.route("/v1/check_year_period/", methods=["GET"])
+    @app.route("/v1/published_submissions/", methods=["GET"])
     @requires_login
     @use_kwargs({'reporting_fiscal_year': webargs_fields.String(required=True),
                  'reporting_fiscal_period': webargs_fields.String(required=True),
                  'cgac_code': webargs_fields.String(),
                  'frec_code': webargs_fields.String(),
                  'is_quarter': webargs_fields.Bool()})
-    def check_year_period(reporting_fiscal_year, reporting_fiscal_period, **kwargs):
+    def get_published_submissions(reporting_fiscal_year, reporting_fiscal_period, **kwargs):
         """ Check if cgac (or frec) code, year, and quarter already has a published submission """
         cgac_code = kwargs.get('cgac_code')
         frec_code = kwargs.get('frec_code')
         is_quarter = kwargs.get('is_quarter')
-        return check_year_and_period(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period, is_quarter)
+        return get_published_submissions_ids(cgac_code, frec_code, reporting_fiscal_year, reporting_fiscal_period,
+                                             is_quarter)
 
     @app.route("/v1/certify_submission/", methods=['POST'])
     @convert_to_submission_id


### PR DESCRIPTION
**High level description:**
Updating `check_year_period` to `published_submissions` endpoint for ease of use on the front-end.

**Technical details:**
* Updated certify_dabs endpoint for these situations. Usually, the submission will be a test submission and stop based on that. I've also accounted for the special case if for some reason `test_submission` is not flagged and there are published submissions in the period.

**Link to JIRA Ticket:**
[DEV-5218](https://federal-spending-transparency.atlassian.net/browse/DEV-5218)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [ ] Merged concurrently with [Frontend#1374](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1374)
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation Updated