### PR TITLE
DEV-5314: split submission history

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1632,7 +1632,7 @@ Get a signed url for a specified history item
 ##### Body Description
 
 - `submission_id`: (required, integer) the submission ID
-- `published_files_history_id`: (required, integer) the `published_files_history_id` of the file (obtained through `list_certifications`)
+- `published_files_history_id`: (required, integer) the `published_files_history_id` of the file (obtained through `list_history`)
 - `is_warning`: (boolean) whether the file being obtained is a warning file or the file that was certified. True = warning file. Default is False
 
 ##### Response (JSON)

--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1507,70 +1507,97 @@ Possible HTTP Status Codes:
 - 401: Login required
 
 
-#### POST "/v1/list_certifications/"
-List certifications for a single submission
+#### GET "/v1/list\_history/"
+Lists all the publication and certification history for a submission along with the files associated with them.
 
-##### Body (JSON)
+##### Sample Request
+`/v1/list_history/?submission_id=12345`
 
-```
-{
-    "submission_id": 123
-}
-```
-
-##### Body Description
-
-- `submission_id`: (required, integer) the ID of the submission
+##### Request Params
+- `submission_id`: (required, integer) The ID of the submission to get publication/certification history for
 
 ##### Response (JSON)
-
 ```
 {
     "submission_id": 7,
+    "publications": [{
+        "publish_date": "2017-05-11 18:10:18",
+        "publishing_user": {
+            "name": "User Name",
+            "user_id": 1
+        },
+        "published_files": [{
+                "published_files_history_id": 1,
+                "filename": "1492041855_file_c.csv",
+                "is_warning": False,
+                "comment": "Comment on the file"
+            },
+            {
+                "published_files_history_id": 1,
+                "filename": "submission_7_File_C_award_financial_warning_report.csv",
+                "is_warning": True,
+                "comment": None
+            }
+        ]},
+        {
+            "publish_date": "2017-05-08 12:07:18",
+            "publishing_user": {
+                "name": "Admin User Name",
+                "user_id": 2
+            },
+            "published_files": [
+                {
+                    "published_files_history_id": 3,
+                    "filename": "1492041855_file_a.csv",
+                    "is_warning": False,
+                    "comment": "This is also a comment"
+                },
+                {
+                    "published_files_history_id": 6,
+                    "filename": "submission_280_crossfile_warning_File_A_to_B_appropriations_program_activity.csv",
+                    "is_warning": True,
+                    "comment": None
+                }
+            ]
+        }],
     "certifications": [{
         "certify_date": "2017-05-11 18:10:18",
-        "certify_history_id": 4,
         "certifying_user": {
             "name": "User Name",
             "user_id": 1
         },
-        "certified_files": [{
-            "published_files_history_id": 1,
-            "filename": "1492041855_file_c.csv",
-            "is_warning": False,
-            "comment": "Comment on the file"
+        "certified_files": [
+            {
+                "published_files_history_id": 1,
+                "filename": "1492041855_file_c.csv",
+                "is_warning": False,
+                "comment": "Comment on the file"
             },
-            {"published_files_history_id": 1,
-            "filename": "submission_7_File_C_award_financial_warning_report.csv",
-            "is_warning": True,
-            "comment": None}
-        ]},
-        {"certify_date": "2017-05-08 12:07:18",
-        "certify_history_id": 3,
-        "certifying_user": {
-            "name": "Admin User Name",
-            "user_id": 2
-        },
-        "certified_files": [{
-            "published_files_history_id": 3,
-            "filename": "1492041855_file_a.csv",
-            "is_warning": False,
-            "comment": "This is also a comment"
-            },
-            {"published_files_history_id": 6,
-            "filename": "submission_280_crossfile_warning_File_A_to_B_appropriations_program_activity.csv",
-            "is_warning": True,
-            "comment": None}
-        ]}
-    ]
+            {
+                "published_files_history_id": 1,
+                "filename": "submission_7_File_C_award_financial_warning_report.csv",
+                "is_warning": True,
+                "comment": None
+            }
+        ]
+    }]
 }
 ```
 
 ##### Response Attributes
 - `submission_id `: (integer) the ID of the submission
+- `publications`: ([object]) Each object contains the following values and represents one publication:
+    - `publish_date`: (string) the date of the publication
+    - `publishing_user`: (object) contains the following details about the user that published the submission:
+        - `name`: (string) the user's name
+        - `user_id`: (integer) the ID of the user in the database
+    - `published_files`: ([object]) Each object holds each of the published files in the submission with the following information:
+        - `published_files_history_id`: (integer) the ID of the file in the `published_files_history` table, used to download the file
+        - `filename`: (string) the name of the file
+        - `is_warning`: (boolean) whether the file is the warning file associated with that file or the file itself
+        - `comment`: (string) the comment associated with the file
 - `certifications`: ([object]) Each object contains the following values and represents one certification:
     - `certify_date`: (string) the date of the certification
-    - `certify_history_id`: (integer) the ID of the certify history
     - `certifying_user`: (object) contains the following details about the user that certified the submission:
         - `name`: (string) the user's name
         - `user_id`: (integer) the ID of the user in the database
@@ -1587,7 +1614,7 @@ Possible HTTP Status Codes:
     - `submission_id` missing or invalid
     - `submission_id` provided is for a FABS submission
     - User doesn't have permissions for this agency
-    - Submission has no certification history (has never been certified)
+    - Submission has no publication history (has never been published)
 
 #### POST "/v1/get_certified_file/"
 Get a signed url for a specified history item

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1752,64 +1752,93 @@ def list_submissions(page, limit, published, sort='modified', order='desc', is_f
     })
 
 
-def list_certifications(submission):
-    """ List all certifications for a single submission including the file history that goes with them.
+def list_history(submission):
+    """ List all publications and certifications for a single submission including the file history that goes with them.
 
         Args:
-            submission: submission to get certifications for
+            submission: submission to get publictions and certifications for
 
         Returns:
-            A JsonResponse containing a dictionary with the submission ID and a list of certifications or a JsonResponse
-            error containing details of what went wrong.
+            A JsonResponse containing a dictionary with the submission ID and a list of publications and certifications
+            or a JsonResponse error containing details of what went wrong.
     """
     # TODO: Split this into published and certified lists, probably can leave it as one endpoint
     if submission.d2_submission:
-        return JsonResponse.error(ValueError('FABS submissions do not have a certification history'),
+        return JsonResponse.error(ValueError('FABS submissions do not have a publication history'),
                                   StatusCode.CLIENT_ERROR)
 
     sess = GlobalDB.db().session
 
+    publish_history = sess.query(PublishHistory).filter_by(submission_id=submission.submission_id).\
+        order_by(PublishHistory.created_at.desc()).all()
     certify_history = sess.query(CertifyHistory).filter_by(submission_id=submission.submission_id).\
         order_by(CertifyHistory.created_at.desc()).all()
 
-    if len(certify_history) == 0:
-        return JsonResponse.error(ValueError('This submission has no certification history'), StatusCode.CLIENT_ERROR)
+    # We only have to check publish history because there can be no certify history without publish history
+    if len(publish_history) == 0:
+        return JsonResponse.error(ValueError('This submission has no publication history'), StatusCode.CLIENT_ERROR)
 
-    # get the details for each of the certifications
+    # get the details for each of the publications (and any associated certifications
+    publications = []
     certifications = []
-    for history in certify_history:
-        certifying_user = sess.query(User).filter_by(user_id=history.user_id).one()
+    for history in publish_history:
+        publishing_user = sess.query(User).filter_by(user_id=history.user_id).one()
 
         # get all published_files_history for this certification
-        file_history = sess.query(PublishedFilesHistory).filter_by(certify_history_id=history.certify_history_id).all()
+        file_history = sess.query(PublishedFilesHistory).filter_by(publish_history_id=history.publish_history_id).all()
+        is_certified = file_history[0].certify_history_id is not None
+        published_files = []
         certified_files = []
         for file in file_history:
             # if there's a filename, add it to the list
             if file.filename is not None:
-                certified_files.append({
+                history_file_content = {
                     'published_files_history_id': file.published_files_history_id,
                     'filename': file.filename.split('/')[-1],
                     'is_warning': False,
                     'comment': file.comment
-                })
+                }
+                published_files.append(history_file_content)
+
+                # If there's a certify history associated with this publish history, add it too
+                if is_certified:
+                    certified_files.append(history_file_content)
 
             # if there's a warning file, add it to the list
             if file.warning_filename is not None:
-                certified_files.append({
+                history_warning_file_content = {
                     'published_files_history_id': file.published_files_history_id,
                     'filename': file.warning_filename.split('/')[-1],
                     'is_warning': True,
                     'comment': None
-                })
+                }
+                published_files.append(history_warning_file_content)
+
+                # If there's a certify history associated with this publish history, add it too
+                if is_certified:
+                    certified_files.append(history_warning_file_content)
 
         # after adding all certified files to the history, add the entire history entry to the certifications list
-        certifications.append({
-            'certify_date': history.created_at.strftime('%Y-%m-%d %H:%M:%S'),
-            'certifying_user': {'name': certifying_user.name, 'user_id': history.user_id},
-            'certified_files': certified_files
+        publications.append({
+            'publish_date': history.created_at.strftime('%Y-%m-%d %H:%M:%S'),
+            'publishing_user': {'name': publishing_user.name, 'user_id': history.user_id},
+            'published_files': published_files
         })
 
+        # Also update based on certify history if that's the case
+        if is_certified:
+            certify_history = sess.query(CertifyHistory).\
+                filter_by(certify_history_id=file_history[0].certify_history_id).one()
+            certifying_user = sess.query(User).filter_by(user_id=certify_history.user_id).one()
+
+            certifications.append({
+                'certify_date': certify_history.created_at.strftime('%Y-%m-%d %H:%M:%S'),
+                'certifying_user': {'name': certifying_user.name, 'user_id': certify_history.user_id},
+                'certified_files': certified_files
+            })
+
     return JsonResponse.create(StatusCode.OK, {'submission_id': submission.submission_id,
+                                               'publications': publications,
                                                'certifications': certifications})
 
 

--- a/dataactbroker/routes/file_routes.py
+++ b/dataactbroker/routes/file_routes.py
@@ -5,7 +5,7 @@ from webargs.flaskparser import use_kwargs
 from dataactbroker.handlers.fileHandler import (
     FileHandler, get_error_metrics, get_status, list_submissions as list_submissions_handler, get_upload_file_url,
     get_detached_upload_file_url, get_submission_comments, submission_report_url, update_submission_comments,
-    list_certifications, file_history_url, get_comments_file)
+    list_history, file_history_url, get_comments_file)
 from dataactbroker.handlers.submission_handler import (
     delete_all_submission_data, get_submission_stats, list_windows, check_current_submission_page,
     publish_dabs_submission, certify_dabs_submission, publish_and_certify_dabs_submission, get_published_submission_ids,
@@ -100,12 +100,12 @@ def add_file_routes(app, is_local, server_path):
         filters = kwargs.get('filters')
         return list_submissions_handler(page, limit, certified, sort, order, fabs, filters)
 
-    @app.route("/v1/list_certifications/", methods=["POST"])
+    @app.route("/v1/list_history/", methods=['GET'])
     @convert_to_submission_id
     @requires_submission_perms('reader')
-    def submission_list_certifications(submission):
-        """ List all certifications for a specific submission """
-        return list_certifications(submission)
+    def submission_list_history(submission):
+        """ List all publish and certify history for a specific submission """
+        return list_history(submission)
 
     @app.route("/v1/get_certified_file/", methods=["POST"])
     @use_kwargs({

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -944,23 +944,23 @@ class FileTests(BaseTestAPI):
         self.assertEqual(response.json['message'], 'Submissions must be published before certification. Use the'
                                                    ' publish_dabs_submission endpoint to publish first.')
 
-    def test_list_certifications(self):
-        post_json = {'submission_id': self.test_published_submission_id}
-        response = self.app.post_json('/v1/list_certifications/', post_json, headers={'x-session-id': self.session_id})
+    def test_list_history(self):
+        params = {'submission_id': self.test_published_submission_id}
+        response = self.app.get('/v1/list_history/', params, headers={'x-session-id': self.session_id})
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(len(response.json['certifications']), 0)
 
-        post_json = {'submission_id': self.test_fabs_submission_id}
-        response = self.app.post_json('/v1/list_certifications/', post_json, headers={'x-session-id': self.session_id},
-                                      expect_errors=True)
+        params = {'submission_id': self.test_fabs_submission_id}
+        response = self.app.get('/v1/list_history/', params, headers={'x-session-id': self.session_id},
+                                expect_errors=True)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json['message'], 'FABS submissions do not have a certification history')
+        self.assertEqual(response.json['message'], 'FABS submissions do not have a publication history')
 
-        post_json = {'submission_id': self.test_unpublished_submission_id}
-        response = self.app.post_json('/v1/list_certifications/', post_json, headers={'x-session-id': self.session_id},
-                                      expect_errors=True)
+        params = {'submission_id': self.test_unpublished_submission_id}
+        response = self.app.get('/v1/list_history/', params, headers={'x-session-id': self.session_id},
+                                expect_errors=True)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json['message'], 'This submission has no certification history')
+        self.assertEqual(response.json['message'], 'This submission has no publication history')
 
     def test_get_certified_file(self):
         sess = GlobalDB.db().session

--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -927,6 +927,7 @@ def test_list_history(database):
 
     has_file_list = response_dict['certifications'][0]
     empty_file_list = response_dict['certifications'][1]
+    pub_list = response_dict['publications'][0]
 
     # asserts for certification with files associated
     assert len(has_file_list['certified_files']) == 4
@@ -939,6 +940,12 @@ def test_list_history(database):
 
     # asserts for certification without files associated
     assert len(empty_file_list['certified_files']) == 0
+
+    # asserts for publications
+    assert len(pub_list['published_files']) == 4
+    assert pub_list['published_files'][0]['is_warning'] is False
+    assert pub_list['published_files'][0]['filename'] == 'file_a.csv'
+    assert pub_list['published_files'][0]['comment'] == 'A has a comment'
 
 
 def test_file_history_url(database, monkeypatch):

--- a/tests/unit/dataactbroker/test_file_handler.py
+++ b/tests/unit/dataactbroker/test_file_handler.py
@@ -30,13 +30,13 @@ UploadFile.save = lambda x, y: True
 
 
 def list_submissions_result(is_fabs=False):
-    json_response = fileHandler.list_submissions(1, 10, "mixed", is_fabs=is_fabs)
+    json_response = fileHandler.list_submissions(1, 10, 'mixed', is_fabs=is_fabs)
     assert json_response.status_code == 200
     return json.loads(json_response.get_data().decode('UTF-8'))
 
 
 def list_submissions_sort(category, order):
-    json_response = fileHandler.list_submissions(1, 10, "mixed", category, order)
+    json_response = fileHandler.list_submissions(1, 10, 'mixed', category, order)
     assert json_response.status_code == 200
     return json.loads(json_response.get_data().decode('UTF-8'))
 
@@ -53,7 +53,7 @@ def mock_create_submission(sess, monkeypatch, request_params):
     return new_sub
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_create_submission_already_pub_mon(database, monkeypatch):
     """ Ensure submission is appropriately populated upon creation with monthly submissions already published """
     sess = database.session
@@ -137,7 +137,7 @@ def test_create_submission_already_pub_mon(database, monkeypatch):
     assert new_qtr_diff_sub.test_submission is False
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_create_submission_already_pub_qtr(database, monkeypatch):
     """ Ensure submission is appropriately populated upon creation with monthly submissions already published """
     sess = database.session
@@ -218,7 +218,7 @@ def test_create_submission_already_pub_qtr(database, monkeypatch):
     assert new_qtr_diff_sub.test_submission is False
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_list_submissions_sort_success(database, monkeypatch):
     user1 = UserFactory(user_id=1, name='Oliver Queen', website_admin=True)
     user2 = UserFactory(user_id=2, name='Barry Allen')
@@ -298,7 +298,7 @@ def test_list_submissions_sort_success(database, monkeypatch):
     delete_models(database, [user1, user2, sub1, sub2, sub3, sub4, sub5])
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_list_submissions_success(database, monkeypatch):
     user = UserFactory(user_id=1)
     sub = SubmissionFactory(user_id=1, submission_id=1, number_of_warnings=1, publish_status_id=1)
@@ -307,7 +307,7 @@ def test_list_submissions_success(database, monkeypatch):
     monkeypatch.setattr(filters_helper, 'g', Mock(user=user))
     result = list_submissions_result()
     assert result['total'] == 1
-    assert result['submissions'][0]['status'] == "validation_successful_warnings"
+    assert result['submissions'][0]['status'] == 'validation_successful_warnings'
     delete_models(database, [user, sub])
 
     user = UserFactory(user_id=1)
@@ -318,7 +318,7 @@ def test_list_submissions_success(database, monkeypatch):
 
     result = list_submissions_result()
     assert result['total'] == 1
-    assert result['submissions'][0]['status'] == "validation_successful"
+    assert result['submissions'][0]['status'] == 'validation_successful'
     delete_models(database, [user, sub, job])
 
     user = UserFactory(user_id=1)
@@ -329,7 +329,7 @@ def test_list_submissions_success(database, monkeypatch):
 
     result = list_submissions_result()
     assert result['total'] == 1
-    assert result['submissions'][0]['status'] == "running"
+    assert result['submissions'][0]['status'] == 'running'
     delete_models(database, [user, sub, job])
 
     user = UserFactory(user_id=1)
@@ -340,7 +340,7 @@ def test_list_submissions_success(database, monkeypatch):
 
     result = list_submissions_result()
     assert result['total'] == 1
-    assert result['submissions'][0]['status'] == "waiting"
+    assert result['submissions'][0]['status'] == 'waiting'
     delete_models(database, [user, sub, job])
 
     user = UserFactory(user_id=1)
@@ -351,7 +351,7 @@ def test_list_submissions_success(database, monkeypatch):
 
     result = list_submissions_result()
     assert result['total'] == 1
-    assert result['submissions'][0]['status'] == "ready"
+    assert result['submissions'][0]['status'] == 'ready'
     delete_models(database, [user, sub, job])
 
     user = UserFactory(user_id=1)
@@ -363,12 +363,12 @@ def test_list_submissions_success(database, monkeypatch):
 
     result = list_submissions_result(is_fabs=True)
     assert result['total'] == 1
-    assert result['submissions'][0]['status'] == "ready"
-    assert result['submissions'][0]['time_period'] == ""
+    assert result['submissions'][0]['status'] == 'ready'
+    assert result['submissions'][0]['time_period'] == ''
     delete_models(database, [user, sub, job])
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_list_submissions_failure(database, monkeypatch):
     user = UserFactory(user_id=1)
     sub = SubmissionFactory(user_id=1, submission_id=1, number_of_errors=1, publish_status_id=1)
@@ -377,7 +377,7 @@ def test_list_submissions_failure(database, monkeypatch):
     monkeypatch.setattr(filters_helper, 'g', Mock(user=user))
     result = list_submissions_result()
     assert result['total'] == 1
-    assert result['submissions'][0]['status'] == "validation_errors"
+    assert result['submissions'][0]['status'] == 'validation_errors'
     delete_models(database, [user, sub])
 
     user = UserFactory(user_id=1)
@@ -388,7 +388,7 @@ def test_list_submissions_failure(database, monkeypatch):
 
     result = list_submissions_result()
     assert result['total'] == 1
-    assert result['submissions'][0]['status'] == "failed"
+    assert result['submissions'][0]['status'] == 'failed'
     delete_models(database, [user, sub, job])
 
     user = UserFactory(user_id=1)
@@ -399,11 +399,11 @@ def test_list_submissions_failure(database, monkeypatch):
 
     result = list_submissions_result()
     assert result['total'] == 1
-    assert result['submissions'][0]['status'] == "file_errors"
+    assert result['submissions'][0]['status'] == 'file_errors'
     delete_models(database, [user, sub, job])
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_list_submissions_detached(database, monkeypatch):
     user = UserFactory(user_id=1)
     sub = SubmissionFactory(user_id=1, submission_id=1, publish_status_id=1)
@@ -422,10 +422,11 @@ def test_list_submissions_detached(database, monkeypatch):
 
 
 @pytest.mark.usefixtures('user_constants')
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_list_submissions_permissions(database, monkeypatch):
-    """Verify that the user must be in the same CGAC group, the submission's
-    owner, or website admin to see the submission"""
+    """ Verify that the user must be in the same CGAC group, the submission's owner, or website admin to see the
+        submission
+    """
     cgac1, cgac2 = CGACFactory(), CGACFactory()
     user1, user2 = UserFactory.with_cgacs(cgac1), UserFactory()
     database.session.add_all([cgac1, cgac2, user1, user2])
@@ -456,7 +457,7 @@ def test_list_submissions_permissions(database, monkeypatch):
     assert list_submissions_result()['total'] == 1
 
 
-@pytest.mark.usefixtures("job_constants", "broker_files_tmp_dir")
+@pytest.mark.usefixtures('job_constants', 'broker_files_tmp_dir')
 def test_comments(database):
     """ Verify that we can add, retrieve, and update submission comments. Not quite a unit test as it covers a few
         functions in sequence.
@@ -506,7 +507,7 @@ def test_comments(database):
     }
 
 
-@pytest.mark.usefixtures("job_constants", "broker_files_tmp_dir")
+@pytest.mark.usefixtures('job_constants', 'broker_files_tmp_dir')
 def test_get_comments_file(database):
     """ Test getting a URL for the comments file """
 
@@ -550,7 +551,7 @@ good_dates = [
 ]
 
 
-@pytest.mark.parametrize("start_date, end_date, quarter_flag, submission", good_dates)
+@pytest.mark.parametrize('start_date, end_date, quarter_flag, submission', good_dates)
 def test_submission_good_dates(start_date, end_date, quarter_flag, submission):
     fh = fileHandler.FileHandler(Mock())
     date_format = '%m/%Y'
@@ -586,7 +587,7 @@ bad_dates = [
 ]
 
 
-@pytest.mark.parametrize("start_date, end_date, quarter_flag, submission", bad_dates)
+@pytest.mark.parametrize('start_date, end_date, quarter_flag, submission', bad_dates)
 def test_submission_bad_dates(start_date, end_date, quarter_flag, submission):
     """Verify that submission date checks fail on bad input"""
     # all dates must be in mm/yyyy format
@@ -598,7 +599,7 @@ def test_submission_bad_dates(start_date, end_date, quarter_flag, submission):
         fh.check_submission_dates(start_date, end_date, quarter_flag, submission)
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_submission_to_dict_for_status(database):
     cgac = CGACFactory(cgac_code='abcdef', agency_name='Age')
     sub = SubmissionFactory(cgac_code='abcdef', number_of_errors=1234, publish_status_id=1)
@@ -637,42 +638,42 @@ def test_submission_report_url_s3(monkeypatch):
 def test_build_file_map_string(monkeypatch):
     monkeypatch.setattr(fileHandler, 'CONFIG_BROKER', {'local': False})
     upload_files = []
-    file_type_list = ["fabs", "appropriations", "award_financial", "program_activity"]
-    file_dict = {"fabs": "fabs_file.csv",
-                 "appropriations": "appropriations.csv",
-                 "award_financial": "award_financial.csv",
-                 "program_activity": "program_activity.csv"}
-    monkeypatch.setattr(S3Handler, 'get_timestamped_filename', Mock(side_effect=lambda x: "123_" + x))
+    file_type_list = ['fabs', 'appropriations', 'award_financial', 'program_activity']
+    file_dict = {'fabs': 'fabs_file.csv',
+                 'appropriations': 'appropriations.csv',
+                 'award_financial': 'award_financial.csv',
+                 'program_activity': 'program_activity.csv'}
+    monkeypatch.setattr(S3Handler, 'get_timestamped_filename', Mock(side_effect=lambda x: '123_' + x))
     submission = SubmissionFactory(submission_id=3)
     fh = fileHandler.FileHandler({})
     fh.build_file_map(file_dict, file_type_list, upload_files, submission)
     for file in upload_files:
-        assert file.upload_name == "3/123_"+file.file_name
+        assert file.upload_name == '3/123_'+file.file_name
 
 
 def test_build_file_map_file(monkeypatch):
     monkeypatch.setattr(fileHandler, 'CONFIG_BROKER', {'local': False})
     upload_files = []
-    file_type_list = ["fabs", "appropriations", "award_financial", "program_activity"]
-    fabs_file = io.BytesIO(b"something")
+    file_type_list = ['fabs', 'appropriations', 'award_financial', 'program_activity']
+    fabs_file = io.BytesIO(b'something')
     fabs_file.filename = 'fabs.csv'
-    approp_file = io.BytesIO(b"something")
+    approp_file = io.BytesIO(b'something')
     approp_file.filename = 'approp.csv'
-    pa_file = io.BytesIO(b"something")
+    pa_file = io.BytesIO(b'something')
     pa_file.filename = 'pa.csv'
-    award_file = io.BytesIO(b"something")
+    award_file = io.BytesIO(b'something')
     award_file.filename = 'award.csv'
-    file_dict = {"fabs": fabs_file, "award_financial": award_file, "program_activity": pa_file,
-                 "appropriations": approp_file}
-    monkeypatch.setattr(S3Handler, 'get_timestamped_filename', Mock(side_effect=lambda x: "123_" + x))
+    file_dict = {'fabs': fabs_file, 'award_financial': award_file, 'program_activity': pa_file,
+                 'appropriations': approp_file}
+    monkeypatch.setattr(S3Handler, 'get_timestamped_filename', Mock(side_effect=lambda x: '123_' + x))
     submission = SubmissionFactory(submission_id=3)
     fh = fileHandler.FileHandler({})
     fh.build_file_map(file_dict, file_type_list, upload_files, submission)
     for file in upload_files:
-        assert file.upload_name == "3/123_"+file.file_name
+        assert file.upload_name == '3/123_'+file.file_name
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_get_upload_file_url_local(database, monkeypatch, tmpdir):
     """ Test getting the url of the uploaded file locally. """
     file_path = str(tmpdir) + os.path.sep
@@ -711,7 +712,7 @@ def test_get_upload_file_url_invalid_for_type(database):
     assert response['message'] == 'Invalid file type for this submission'
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_get_upload_file_url_no_file(database):
     """ Test that a proper error is thrown when an upload job doesn't have a file associated with it
         get_upload_file_url.
@@ -728,7 +729,7 @@ def test_get_upload_file_url_no_file(database):
     assert response['message'] == 'No file uploaded or generated for this type'
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_get_upload_file_url_s3(database, monkeypatch):
     """ Test getting the url of the uploaded file non-locally. """
     monkeypatch.setattr(fileHandler, 'CONFIG_BROKER', {'local': False, 'submission_bucket_mapping': 'test/path'})
@@ -752,7 +753,7 @@ def test_get_upload_file_url_s3(database, monkeypatch):
     )
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_move_published_files(database, monkeypatch):
     # set up cgac and submission
     cgac = CGACFactory(cgac_code='zyxwv', agency_name='Test')
@@ -770,29 +771,29 @@ def test_move_published_files(database, monkeypatch):
 
     finished_job = JOB_STATUS_DICT['finished']
     upload_job = JOB_TYPE_DICT['file_upload']
-    appropriations_job = JobFactory(submission=sub, filename="/path/to/appropriations/file_a.csv",
+    appropriations_job = JobFactory(submission=sub, filename='/path/to/appropriations/file_a.csv',
                                     file_type_id=FILE_TYPE_DICT['appropriations'], job_type_id=upload_job,
                                     job_status_id=finished_job)
-    prog_act_job = JobFactory(submission=sub, filename="/path/to/prog/act/file_b.csv",
+    prog_act_job = JobFactory(submission=sub, filename='/path/to/prog/act/file_b.csv',
                               file_type_id=FILE_TYPE_DICT['program_activity'], job_type_id=upload_job,
                               job_status_id=finished_job)
-    award_fin_job = JobFactory(submission=sub, filename="/path/to/award/fin/file_c.csv",
+    award_fin_job = JobFactory(submission=sub, filename='/path/to/award/fin/file_c.csv',
                                file_type_id=FILE_TYPE_DICT['award_financial'], job_type_id=upload_job,
                                job_status_id=finished_job)
-    award_proc_job = JobFactory(submission=sub, filename="/path/to/award/proc/file_d1.csv",
+    award_proc_job = JobFactory(submission=sub, filename='/path/to/award/proc/file_d1.csv',
                                 file_type_id=FILE_TYPE_DICT['award_procurement'], job_type_id=upload_job,
                                 job_status_id=finished_job)
-    award_job = JobFactory(submission=sub, filename="/path/to/award/file_d2.csv",
+    award_job = JobFactory(submission=sub, filename='/path/to/award/file_d2.csv',
                            file_type_id=FILE_TYPE_DICT['award'], job_type_id=upload_job,
                            job_status_id=finished_job)
-    exec_comp_job = JobFactory(submission=sub, filename="/path/to/exec/comp/file_e.csv",
+    exec_comp_job = JobFactory(submission=sub, filename='/path/to/exec/comp/file_e.csv',
                                file_type_id=FILE_TYPE_DICT['executive_compensation'], job_type_id=upload_job,
                                job_status_id=finished_job)
-    sub_award_job = JobFactory(submission=sub, filename="/path/to/sub/award/file_f.csv",
+    sub_award_job = JobFactory(submission=sub, filename='/path/to/sub/award/file_f.csv',
                                file_type_id=FILE_TYPE_DICT['sub_award'], job_type_id=upload_job,
                                job_status_id=finished_job)
 
-    award_fin_narr = CommentFactory(submission=sub, comment="Test comment",
+    award_fin_narr = CommentFactory(submission=sub, comment='Test comment',
                                     file_type_id=FILE_TYPE_DICT['award_financial'])
     database.session.add_all([pub_hist_local, pub_hist_remote, cert_hist_local, cert_hist_remote, appropriations_job,
                               prog_act_job, award_fin_job, award_proc_job, award_job, exec_comp_job, sub_award_job,
@@ -817,11 +818,11 @@ def test_move_published_files(database, monkeypatch):
 
     c_cert_hist = sess.query(PublishedFilesHistory).\
         filter_by(publish_history_id=local_id, file_type_id=FILE_TYPE_DICT['award_financial']).one()
-    assert c_cert_hist.filename == "/path/to/award/fin/file_c.csv"
-    expected_filename = "/path/to/error/reports/submission_{}_File_C_award_financial_warning_report.csv".\
+    assert c_cert_hist.filename == '/path/to/award/fin/file_c.csv'
+    expected_filename = '/path/to/error/reports/submission_{}_File_C_award_financial_warning_report.csv'.\
         format(sub.submission_id)
     assert c_cert_hist.warning_filename == expected_filename
-    assert c_cert_hist.comment == "Test comment"
+    assert c_cert_hist.comment == 'Test comment'
 
     # cross-file warnings
     warning_cert_hist = sess.query(PublishedFilesHistory).filter_by(publish_history_id=local_id, file_type=None).all()
@@ -829,7 +830,7 @@ def test_move_published_files(database, monkeypatch):
     assert warning_cert_hist[0].comment is None
 
     warning_cert_hist_files = [hist.warning_filename for hist in warning_cert_hist]
-    assert "/path/to/error/reports/submission_{}_crossfile_warning_File_A_to_B_appropriations_program_activity.csv".\
+    assert '/path/to/error/reports/submission_{}_crossfile_warning_File_A_to_B_appropriations_program_activity.csv'.\
         format(sub.submission_id) in warning_cert_hist_files
 
     # test remote publication
@@ -838,13 +839,13 @@ def test_move_published_files(database, monkeypatch):
 
     c_cert_hist = sess.query(PublishedFilesHistory). \
         filter_by(publish_history_id=remote_id, file_type_id=FILE_TYPE_DICT['award_financial']).one()
-    assert c_cert_hist.filename == "zyxwv/2017/2/{}/file_c.csv".format(remote_id)
-    assert c_cert_hist.warning_filename == "zyxwv/2017/2/{}/submission_{}_File_C_award_financial_warning_report.csv". \
+    assert c_cert_hist.filename == 'zyxwv/2017/2/{}/file_c.csv'.format(remote_id)
+    assert c_cert_hist.warning_filename == 'zyxwv/2017/2/{}/submission_{}_File_C_award_financial_warning_report.csv'. \
         format(remote_id, sub.submission_id)
 
 
-@pytest.mark.usefixtures("job_constants")
-def test_list_certifications(database):
+@pytest.mark.usefixtures('job_constants')
+def test_list_history(database):
     # set up submission
     sub = SubmissionFactory()
     database.session.add(sub)
@@ -863,41 +864,42 @@ def test_list_certifications(database):
     sub_id = sub.submission_id
     file_hist_1 = PublishedFilesHistoryFactory(certify_history_id=cert_history_id,
                                                publish_history_id=pub_hist.publish_history_id, submission_id=sub_id,
-                                               filename="/path/to/file_a.csv",
-                                               warning_filename="/path/to/warning_file_a.csv",
-                                               comment="A has a comment",
+                                               filename='/path/to/file_a.csv',
+                                               warning_filename='/path/to/warning_file_a.csv',
+                                               comment='A has a comment',
                                                file_type_id=FILE_TYPE_DICT['appropriations'])
     file_hist_2 = PublishedFilesHistoryFactory(certify_history_id=cert_history_id,
                                                publish_history_id=pub_history_id, submission_id=sub_id,
-                                               filename="/path/to/file_d2.csv",
+                                               filename='/path/to/file_d2.csv',
                                                warning_filename=None,
                                                file_type_id=FILE_TYPE_DICT['award'])
     file_hist_3 = PublishedFilesHistoryFactory(certify_history_id=cert_history_id,
                                                publish_history_id=pub_history_id, submission_id=sub_id,
                                                filename=None,
-                                               warning_filename="/path/to/warning_file_cross_test.csv",
+                                               warning_filename='/path/to/warning_file_cross_test.csv',
                                                file_type_id=None)
     database.session.add_all([file_hist_1, file_hist_2, file_hist_3])
     database.session.commit()
 
-    json_response = fileHandler.list_certifications(sub)
+    json_response = fileHandler.list_history(sub)
     response_dict = json.loads(json_response.get_data().decode('utf-8'))
-    assert len(response_dict["certifications"]) == 2
+    assert len(response_dict['certifications']) == 2
+    assert len(response_dict['publications']) == 1
 
-    has_file_list = response_dict["certifications"][0]
-    empty_file_list = response_dict["certifications"][1]
+    has_file_list = response_dict['certifications'][0]
+    empty_file_list = response_dict['certifications'][1]
 
     # asserts for certification with files associated
-    assert len(has_file_list["certified_files"]) == 4
-    assert has_file_list["certified_files"][0]["is_warning"] is False
-    assert has_file_list["certified_files"][0]["filename"] == "file_a.csv"
-    assert has_file_list["certified_files"][0]["comment"] == "A has a comment"
+    assert len(has_file_list['certified_files']) == 4
+    assert has_file_list['certified_files'][0]['is_warning'] is False
+    assert has_file_list['certified_files'][0]['filename'] == 'file_a.csv'
+    assert has_file_list['certified_files'][0]['comment'] == 'A has a comment'
 
-    assert has_file_list["certified_files"][1]["is_warning"]
-    assert has_file_list["certified_files"][1]["comment"] is None
+    assert has_file_list['certified_files'][1]['is_warning']
+    assert has_file_list['certified_files'][1]['comment'] is None
 
     # asserts for certification without files associated
-    assert len(empty_file_list["certified_files"]) == 0
+    assert len(empty_file_list['certified_files']) == 0
 
 
 def test_file_history_url(database, monkeypatch):
@@ -913,8 +915,8 @@ def test_file_history_url(database, monkeypatch):
 
     file_hist = PublishedFilesHistoryFactory(certify_history_id=cert_hist.certify_history_id,
                                              publish_history_id=pub_hist.publish_history_id,
-                                             submission_id=sub.submission_id, filename="/path/to/file_d2.csv",
-                                             warning_filename="/path/to/warning_file_cross.csv",
+                                             submission_id=sub.submission_id, filename='/path/to/file_d2.csv',
+                                             warning_filename='/path/to/warning_file_cross.csv',
                                              comment=None, file_type_id=None)
     database.session.add(file_hist)
     database.session.commit()
@@ -925,17 +927,17 @@ def test_file_history_url(database, monkeypatch):
 
     # checking for local response to non-warning file
     json_response = fileHandler.file_history_url(sub, file_hist.published_files_history_id, False, True)
-    url = json.loads(json_response.get_data().decode('utf-8'))["url"]
-    assert url == "/path/to/file_d2.csv"
+    url = json.loads(json_response.get_data().decode('utf-8'))['url']
+    assert url == '/path/to/file_d2.csv'
 
     # local response to warning file
     json_response = fileHandler.file_history_url(sub, file_hist.published_files_history_id, True, True)
-    url = json.loads(json_response.get_data().decode('utf-8'))["url"]
-    assert url == "/path/to/warning_file_cross.csv"
+    url = json.loads(json_response.get_data().decode('utf-8'))['url']
+    assert url == '/path/to/warning_file_cross.csv'
 
     # generic test to make sure it's reaching the s3 handler properly
     json_response = fileHandler.file_history_url(sub, file_hist.published_files_history_id, False, False)
-    url = json.loads(json_response.get_data().decode('utf-8'))["url"]
+    url = json.loads(json_response.get_data().decode('utf-8'))['url']
     assert url == 'some/url/here.csv'
 
 
@@ -966,7 +968,7 @@ def test_get_status_invalid_type(database):
     assert json_content['message'] == 'approp is not a valid file type'
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_get_status_fabs(database):
     """ Test get status function for a fabs submission """
     sess = database.session
@@ -988,7 +990,7 @@ def test_get_status_fabs(database):
     assert json_content['fabs'] == {'status': 'finished', 'has_errors': False, 'has_warnings': True, 'message': ''}
 
 
-@pytest.mark.usefixtures("job_constants")
+@pytest.mark.usefixtures('job_constants')
 def test_get_status_dabs(database):
     """ Test get status function for a dabs submission, including all possible statuses and case insensitivity """
     sess = database.session


### PR DESCRIPTION
**High level description:**
Returning both publish and certify history when requesting history.

**Technical details:**
- Added `publications` to the history list
- Renamed the endpoint to better reflect what is being requested (new name: `list_history` instead of `list_certifications`)
- Fixed quote types in the test while I was there

**Link to JIRA Ticket:**
[DEV-5314](https://federal-spending-transparency.atlassian.net/browse/DEV-5314)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [ ] Merged concurrently with [Frontend#1381](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1381)
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation Updated