### PR TITLE
DEV-5533: sf133 defc line sum validations

### DIFF
--- a/dataactvalidator/config/sqlrules/a14_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a14_appropriations.sql
@@ -10,8 +10,8 @@ WITH appropriation_a14_{0} AS
 SELECT
     approp.row_number,
     approp.gross_outlay_amount_by_tas_cpe,
-    sf.amount AS "expected_value_GTAS SF133 Line 3020",
-    approp.gross_outlay_amount_by_tas_cpe - sf.amount AS "difference",
+    SUM(sf.amount) AS "expected_value_GTAS SF133 Line 3020",
+    approp.gross_outlay_amount_by_tas_cpe - SUM(sf.amount) AS "difference",
     approp.display_tas AS "uniqueid_TAS"
 FROM appropriation_a14_{0} AS approp
     INNER JOIN sf_133 AS sf
@@ -21,4 +21,7 @@ FROM appropriation_a14_{0} AS approp
         AND sf.period = sub.reporting_fiscal_period
         AND sf.fiscal_year = sub.reporting_fiscal_year
 WHERE sf.line = 3020
-    AND approp.gross_outlay_amount_by_tas_cpe <> sf.amount;
+GROUP BY approp.row_number,
+    approp.gross_outlay_amount_by_tas_cpe,
+    approp.display_tas
+HAVING approp.gross_outlay_amount_by_tas_cpe <> SUM(sf.amount);

--- a/dataactvalidator/config/sqlrules/a15_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a15_appropriations.sql
@@ -10,8 +10,8 @@ WITH appropriation_a15_{0} AS
 SELECT
     approp.row_number,
     approp.unobligated_balance_cpe,
-    sf.amount AS "expected_value_GTAS SF133 Line 2490",
-    approp.unobligated_balance_cpe - sf.amount AS "difference",
+    SUM(sf.amount) AS "expected_value_GTAS SF133 Line 2490",
+    approp.unobligated_balance_cpe - SUM(sf.amount) AS "difference",
     approp.display_tas AS "uniqueid_TAS"
 FROM appropriation_a15_{0} AS approp
     INNER JOIN sf_133 AS sf
@@ -21,4 +21,7 @@ FROM appropriation_a15_{0} AS approp
         AND sf.period = sub.reporting_fiscal_period
         AND sf.fiscal_year = sub.reporting_fiscal_year
 WHERE sf.line = 2490
-    AND approp.unobligated_balance_cpe <> sf.amount;
+GROUP BY approp.row_number,
+    approp.unobligated_balance_cpe,
+    approp.display_tas
+HAVING approp.unobligated_balance_cpe <> SUM(sf.amount);

--- a/dataactvalidator/config/sqlrules/a22_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a22_appropriations.sql
@@ -2,8 +2,8 @@
 SELECT
     approp.row_number,
     approp.obligations_incurred_total_cpe,
-    sf.amount AS "expected_value_GTAS SF133 Line 2190",
-    approp.obligations_incurred_total_cpe - sf.amount AS "difference",
+    SUM(sf.amount) AS "expected_value_GTAS SF133 Line 2190",
+    approp.obligations_incurred_total_cpe - SUM(sf.amount) AS "difference",
     approp.display_tas AS "uniqueid_TAS"
 FROM appropriation AS approp
     INNER JOIN sf_133 AS sf
@@ -14,4 +14,7 @@ FROM appropriation AS approp
         AND sf.fiscal_year = sub.reporting_fiscal_year
 WHERE approp.submission_id = {0}
     AND sf.line = 2190
-    AND approp.obligations_incurred_total_cpe <> sf.amount;
+GROUP BY approp.row_number,
+    approp.obligations_incurred_total_cpe,
+    approp.display_tas
+HAVING approp.obligations_incurred_total_cpe <> SUM(sf.amount);

--- a/dataactvalidator/config/sqlrules/a23_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a23_appropriations.sql
@@ -2,8 +2,8 @@
 SELECT
     approp.row_number,
     approp.status_of_budgetary_resour_cpe,
-    sf.amount AS "expected_value_GTAS SF133 Line 2500",
-    approp.status_of_budgetary_resour_cpe - sf.amount AS "difference",
+    SUM(sf.amount) AS "expected_value_GTAS SF133 Line 2500",
+    approp.status_of_budgetary_resour_cpe - SUM(sf.amount) AS "difference",
     approp.display_tas AS "uniqueid_TAS"
 FROM appropriation AS approp
     INNER JOIN sf_133 AS sf
@@ -14,4 +14,7 @@ FROM appropriation AS approp
         AND sf.fiscal_year = sub.reporting_fiscal_year
 WHERE approp.submission_id = {0}
     AND sf.line = 2500
-    AND approp.status_of_budgetary_resour_cpe <> sf.amount;
+GROUP BY approp.row_number,
+    approp.status_of_budgetary_resour_cpe,
+    approp.display_tas
+HAVING approp.status_of_budgetary_resour_cpe <> SUM(sf.amount);

--- a/dataactvalidator/config/sqlrules/a34_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a34_appropriations.sql
@@ -11,8 +11,8 @@ WITH appropriation_a34_{0} AS
 SELECT
     approp.row_number,
     approp.budget_authority_unobligat_fyb,
-    sf.amount AS "expected_value_GTAS SF133 Line 2490",
-    COALESCE(approp.budget_authority_unobligat_fyb, 0) - sf.amount AS "difference",
+    SUM(sf.amount) AS "expected_value_GTAS SF133 Line 2490",
+    COALESCE(approp.budget_authority_unobligat_fyb, 0) - SUM(sf.amount) AS "difference",
     approp.display_tas AS "uniqueid_TAS"
 FROM appropriation_a34_{0} AS approp
     JOIN sf_133 AS sf
@@ -22,4 +22,7 @@ FROM appropriation_a34_{0} AS approp
         AND sf.period = 12
         AND sf.fiscal_year = (sub.reporting_fiscal_year - 1)
 WHERE sf.line = 2490
-    AND COALESCE(approp.budget_authority_unobligat_fyb, 0) <> sf.amount;
+GROUP BY approp.row_number,
+    approp.budget_authority_unobligat_fyb,
+    approp.display_tas
+HAVING COALESCE(approp.budget_authority_unobligat_fyb, 0) <> SUM(sf.amount);

--- a/dataactvalidator/config/sqlrules/a6_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a6_appropriations.sql
@@ -10,8 +10,8 @@ WITH appropriation_a6_{0} AS
 SELECT
     approp.row_number,
     approp.total_budgetary_resources_cpe,
-    sf.amount AS "expected_value_GTAS SF133 Line 1910",
-    approp.total_budgetary_resources_cpe - sf.amount AS "difference",
+    SUM(sf.amount) AS "expected_value_GTAS SF133 Line 1910",
+    approp.total_budgetary_resources_cpe - SUM(sf.amount) AS "difference",
     approp.display_tas AS "uniqueid_TAS"
 FROM appropriation_a6_{0} AS approp
     INNER JOIN sf_133 AS sf
@@ -21,4 +21,7 @@ FROM appropriation_a6_{0} AS approp
         AND sf.period = sub.reporting_fiscal_period
         AND sf.fiscal_year = sub.reporting_fiscal_year
 WHERE sf.line = 1910
-    AND approp.total_budgetary_resources_cpe <> sf.amount;
+GROUP BY approp.row_number,
+    approp.total_budgetary_resources_cpe,
+    approp.display_tas
+HAVING approp.total_budgetary_resources_cpe <> SUM(sf.amount);

--- a/dataactvalidator/config/sqlrules/a7_appropriations.sql
+++ b/dataactvalidator/config/sqlrules/a7_appropriations.sql
@@ -10,8 +10,8 @@ WITH appropriation_a7_{0} AS
 SELECT
     approp.row_number,
     approp.budget_authority_unobligat_fyb,
-    sf.amount AS "expected_value_GTAS SF133 Line 1000",
-    COALESCE(approp.budget_authority_unobligat_fyb, 0) - sf.amount AS "difference",
+    SUM(sf.amount) AS "expected_value_GTAS SF133 Line 1000",
+    COALESCE(approp.budget_authority_unobligat_fyb, 0) - SUM(sf.amount) AS "difference",
     approp.display_tas AS "uniqueid_TAS"
 FROM appropriation_a7_{0} AS approp
     INNER JOIN sf_133 AS sf
@@ -21,4 +21,7 @@ FROM appropriation_a7_{0} AS approp
         AND sf.period = sub.reporting_fiscal_period
         AND sf.fiscal_year = sub.reporting_fiscal_year
 WHERE sf.line = 1000
-    AND COALESCE(approp.budget_authority_unobligat_fyb, 0) <> sf.amount;
+GROUP BY approp.row_number,
+    approp.budget_authority_unobligat_fyb,
+    approp.display_tas
+HAVING COALESCE(approp.budget_authority_unobligat_fyb, 0) <> SUM(sf.amount);

--- a/tests/unit/dataactvalidator/test_a14_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a14_appropriations.py
@@ -18,13 +18,24 @@ def test_success(database):
     """ Tests that SF 133 amount sum for line 3020 matches Appropriation gross_outlay_amount_by_tas_cpe
         for the specified fiscal year and period
     """
-    tas = "".join([_TAS, "_success"])
+    tas = 'tas_one_line'
 
     sf = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                main_account_code="000", sub_account_code="000")
-    ap = Appropriation(job_id=1, row_number=1, tas=tas, gross_outlay_amount_by_tas_cpe=1)
+    ap = Appropriation(job_id=1, row_number=1, tas=tas, display_tas=tas, gross_outlay_amount_by_tas_cpe=1)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
+
+    # Test with split SF133 lines
+    tas = 'tas_two_lines'
+
+    sf_1 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='n')
+    sf_2 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='o')
+    ap = Appropriation(job_id=1, row_number=1, tas=tas, gross_outlay_amount_by_tas_cpe=5)
+
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap]) == 0
 
 
 def test_failure(database):
@@ -33,8 +44,8 @@ def test_failure(database):
     """
     tas = "".join([_TAS, "_failure"])
 
-    sf = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
+    sf = SF133(line=3020, tas=tas, display_tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                main_account_code="000", sub_account_code="000")
-    ap = Appropriation(job_id=1, row_number=1, tas=tas, gross_outlay_amount_by_tas_cpe=0)
+    ap = Appropriation(job_id=1, row_number=1, tas=tas, display_tas=tas, gross_outlay_amount_by_tas_cpe=0)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a14_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a14_appropriations.py
@@ -4,7 +4,6 @@ from tests.unit.dataactvalidator.utils import number_of_errors, query_columns
 
 
 _FILE = 'a14_appropriations'
-_TAS = 'a14_appropriations_tas'
 
 
 def test_column_headers(database):
@@ -20,8 +19,8 @@ def test_success(database):
     """
     tas = 'tas_one_line'
 
-    sf = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, display_tas=tas, gross_outlay_amount_by_tas_cpe=1)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
@@ -42,10 +41,10 @@ def test_failure(database):
     """ Tests that SF 133 amount sum for line 3020 does not match Appropriation gross_outlay_amount_by_tas_cpe
         for the specified fiscal year and period
     """
-    tas = "".join([_TAS, "_failure"])
+    tas = 'fail_tas'
 
-    sf = SF133(line=3020, tas=tas, display_tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=3020, tas=tas, display_tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, display_tas=tas, gross_outlay_amount_by_tas_cpe=0)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a15_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a15_appropriations.py
@@ -4,7 +4,6 @@ from tests.unit.dataactvalidator.utils import number_of_errors, query_columns
 
 
 _FILE = 'a15_appropriations'
-_TAS = 'a15_appropriations_tas'
 
 
 def test_column_headers(database):
@@ -18,23 +17,34 @@ def test_success(database):
     """ Tests that SF 133 amount sum for line 2490 matches Appropriation unobligated_balance_cpe
         for the specified fiscal year and period
     """
-    tas = "".join([_TAS, "_success"])
+    tas = 'tas_one_line'
 
-    sf = SF133(line=2490, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=2490, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, unobligated_balance_cpe=1)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
+
+    # Test with split SF133 lines
+    tas = 'tas_two_lines'
+
+    sf_1 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='n')
+    sf_2 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='o')
+    ap = Appropriation(job_id=1, row_number=1, tas=tas, unobligated_balance_cpe=5)
+
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap]) == 0
 
 
 def test_failure(database):
     """ Tests that SF 133 amount sum for line 2490 does not match Appropriation unobligated_balance_cpe
         for the specified fiscal year and period
     """
-    tas = "".join([_TAS, "_failure"])
+    tas = 'fail_tas'
 
-    sf = SF133(line=2490, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=2490, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, unobligated_balance_cpe=0)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a15_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a15_appropriations.py
@@ -28,9 +28,9 @@ def test_success(database):
     # Test with split SF133 lines
     tas = 'tas_two_lines'
 
-    sf_1 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+    sf_1 = SF133(line=2490, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
                  main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='n')
-    sf_2 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
+    sf_2 = SF133(line=2490, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
                  main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='o')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, unobligated_balance_cpe=5)
 

--- a/tests/unit/dataactvalidator/test_a22_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a22_appropriations.py
@@ -4,7 +4,6 @@ from tests.unit.dataactvalidator.utils import number_of_errors, query_columns
 
 
 _FILE = 'a22_appropriations'
-_TAS = 'a22_appropriations_tas'
 
 
 def test_column_headers(database):
@@ -18,23 +17,34 @@ def test_success(database):
     """ Tests that SF 133 amount sum for line 2190 matches Appropriation obligations_incurred_total_cpe
         for the specified fiscal year and period
     """
-    tas = "".join([_TAS, "_success"])
+    tas = 'tas_one_line'
 
-    sf = SF133(line=2190, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=2190, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, obligations_incurred_total_cpe=1)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
+
+    # Test with split SF133 lines
+    tas = 'tas_two_lines'
+
+    sf_1 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='n')
+    sf_2 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='o')
+    ap = Appropriation(job_id=1, row_number=1, tas=tas, obligations_incurred_total_cpe=5)
+
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap]) == 0
 
 
 def test_failure(database):
     """ Tests that SF 133 amount sum for line 2190 does not match Appropriation obligations_incurred_total_cpe
         for the specified fiscal year and period
     """
-    tas = "".join([_TAS, "_failure"])
+    tas = 'fail_tas'
 
-    sf = SF133(line=2190, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=2190, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, obligations_incurred_total_cpe=0)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a22_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a22_appropriations.py
@@ -28,9 +28,9 @@ def test_success(database):
     # Test with split SF133 lines
     tas = 'tas_two_lines'
 
-    sf_1 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+    sf_1 = SF133(line=2190, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
                  main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='n')
-    sf_2 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
+    sf_2 = SF133(line=2190, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
                  main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='o')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, obligations_incurred_total_cpe=5)
 

--- a/tests/unit/dataactvalidator/test_a23_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a23_appropriations.py
@@ -28,9 +28,9 @@ def test_success(database):
     # Test with split SF133 lines
     tas = 'tas_two_lines'
 
-    sf_1 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+    sf_1 = SF133(line=2500, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
                  main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='n')
-    sf_2 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
+    sf_2 = SF133(line=2500, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
                  main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='o')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, status_of_budgetary_resour_cpe=5)
 

--- a/tests/unit/dataactvalidator/test_a23_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a23_appropriations.py
@@ -4,7 +4,6 @@ from tests.unit.dataactvalidator.utils import number_of_errors, query_columns
 
 
 _FILE = 'a23_appropriations'
-_TAS = 'a23_appropriations_tas'
 
 
 def test_column_headers(database):
@@ -18,23 +17,34 @@ def test_success(database):
     """ Tests that SF 133 amount sum for line 2500 matches Appropriation status_of_budgetary_resour_cpe
         for the specified fiscal year and period
     """
-    tas = "".join([_TAS, "_success"])
+    tas = 'tas_one_line'
 
-    sf = SF133(line=2500, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=2500, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, status_of_budgetary_resour_cpe=1)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
+
+    # Test with split SF133 lines
+    tas = 'tas_two_lines'
+
+    sf_1 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='n')
+    sf_2 = SF133(line=3020, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='o')
+    ap = Appropriation(job_id=1, row_number=1, tas=tas, status_of_budgetary_resour_cpe=5)
+
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap]) == 0
 
 
 def test_failure(database):
     """ Tests that SF 133 amount sum for line 2500 does not match Appropriation status_of_budgetary_resour_cpe
         for the specified fiscal year and period
     """
-    tas = "".join([_TAS, "_failure"])
+    tas = 'fail_tas'
 
-    sf = SF133(line=2500, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=2500, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, status_of_budgetary_resour_cpe=0)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a34_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a34_appropriations.py
@@ -35,6 +35,16 @@ def test_success_fy2016(database):
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
 
 
+def test_success_multi_line(database):
+    """ Tests that the validation is still successful if there are multiple SF-133 lines because of DEFC splits. """
+
+    sf_1 = SF133Factory(line=2490, tas=_TAS, period=12, fiscal_year=2015, amount=1)
+    sf_2 = SF133Factory(line=2490, tas=_TAS, period=12, fiscal_year=2015, amount=4)
+    ap = AppropriationFactory(tas=_TAS, budget_authority_unobligat_fyb=5)
+
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap]) == 0
+
+
 def test_failure(database):
     """ Tests that SF-133 amount for line 2490 for the end of the last fiscal year does not equal Appropriation
         budget_authority_unobligat_fyb

--- a/tests/unit/dataactvalidator/test_a6_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a6_appropriations.py
@@ -4,7 +4,6 @@ from tests.unit.dataactvalidator.utils import number_of_errors, query_columns
 
 
 _FILE = 'a6_appropriations'
-_TAS = 'a6_appropriations_tas'
 
 
 def test_column_headers(database):
@@ -19,23 +18,34 @@ def test_success(database):
         for the specified fiscal year and period
     """
 
-    tas = "".join([_TAS, "_success"])
+    tas = 'tas_one_line'
 
-    sf = SF133(line=1910, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=1910, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, total_budgetary_resources_cpe=1)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 0
+
+    # Test with split SF133 lines
+    tas = 'tas_two_lines'
+
+    sf_1 = SF133(line=1910, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='n')
+    sf_2 = SF133(line=1910, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='o')
+    ap = Appropriation(job_id=1, row_number=1, tas=tas, total_budgetary_resources_cpe=5)
+
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap]) == 0
 
 
 def test_failure(database):
     """ Tests that SF 133 amount for line 1910 does not match Appropriation total_budgetary_resources_cpe
         for the specified fiscal year and period
     """
-    tas = "".join([_TAS, "_failure"])
+    tas = 'fail_tas'
 
-    sf = SF133(line=1910, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=1910, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap = Appropriation(job_id=1, row_number=1, tas=tas, total_budgetary_resources_cpe=0)
 
     assert number_of_errors(_FILE, database, models=[sf, ap]) == 1

--- a/tests/unit/dataactvalidator/test_a7_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a7_appropriations.py
@@ -18,8 +18,8 @@ def test_success(database):
     """ Tests that SF 133 amount for line 1000 matches Appropriation budget_authority_unobligat_fyb for the specified
         fiscal year and period
     """
-    tas_1 = "".join([_TAS, "_success"])
-    tas_2 = "".join([_TAS, "_success_2"])
+    tas_1 = 'tas_one_line_1'
+    tas_2 = 'tas_one_line_2'
 
     sf_1 = SF133(line=1000, tas=tas_1, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                  main_account_code="000", sub_account_code="000")
@@ -30,12 +30,23 @@ def test_success(database):
 
     assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap_1, ap_2]) == 0
 
+    # Test with split SF133 lines
+    tas = 'tas_two_lines'
+
+    sf_1 = SF133(line=1000, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='n')
+    sf_2 = SF133(line=1000, tas=tas, period=1, fiscal_year=2016, amount=4, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000', disaster_emergency_fund_code='o')
+    ap = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_unobligat_fyb=5)
+
+    assert number_of_errors(_FILE, database, models=[sf_1, sf_2, ap]) == 0
+
 
 def test_failure(database):
     """ Tests that SF 133 amount for line 1000 does not match Appropriation budget_authority_unobligat_fyb for the
         specified fiscal year and period
     """
-    tas = "".join([_TAS, "_failure"])
+    tas = 'fail_tas'
 
     sf = SF133(line=1000, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
                main_account_code="000", sub_account_code="000")

--- a/tests/unit/dataactvalidator/test_a7_appropriations.py
+++ b/tests/unit/dataactvalidator/test_a7_appropriations.py
@@ -21,10 +21,10 @@ def test_success(database):
     tas_1 = 'tas_one_line_1'
     tas_2 = 'tas_one_line_2'
 
-    sf_1 = SF133(line=1000, tas=tas_1, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-                 main_account_code="000", sub_account_code="000")
-    sf_2 = SF133(line=1000, tas=tas_2, period=1, fiscal_year=2016, amount=0, agency_identifier="sys",
-                 main_account_code="000", sub_account_code="000")
+    sf_1 = SF133(line=1000, tas=tas_1, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000')
+    sf_2 = SF133(line=1000, tas=tas_2, period=1, fiscal_year=2016, amount=0, agency_identifier='sys',
+                 main_account_code='000', sub_account_code='000')
     ap_1 = Appropriation(job_id=1, row_number=1, tas=tas_1, budget_authority_unobligat_fyb=1)
     ap_2 = Appropriation(job_id=2, row_number=1, tas=tas_2, budget_authority_unobligat_fyb=None)
 
@@ -48,8 +48,8 @@ def test_failure(database):
     """
     tas = 'fail_tas'
 
-    sf = SF133(line=1000, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier="sys",
-               main_account_code="000", sub_account_code="000")
+    sf = SF133(line=1000, tas=tas, period=1, fiscal_year=2016, amount=1, agency_identifier='sys',
+               main_account_code='000', sub_account_code='000')
     ap_1 = Appropriation(job_id=1, row_number=1, tas=tas, budget_authority_unobligat_fyb=0)
     ap_2 = Appropriation(job_id=2, row_number=1, tas=tas, budget_authority_unobligat_fyb=None)
 


### PR DESCRIPTION
**High level description:**
Fixing Rules A6, A7, A14, A15, A22, A23, and A34 to account for multiple entries of the same SF133 line due to DEFC

**Technical details:**
Summing SF133 lines in cases where we aren't separating by DEFC and are only looking at one line

**Link to JIRA Ticket:**
[DEV-5533](https://federal-spending-transparency.atlassian.net/browse/DEV-5533)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated