### PR TITLE
DEV-5514: Publish certify past deadline

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1172,7 +1172,6 @@ Possible HTTP Status Codes:
   - Submission is not published
   - Submission is already certified
   - Submission is a quarterly submission
-  - It is past the certification window for the submission
 - 401: Login required
 - 403: Permission denied, user does not have permission to view this submission
 

--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -953,18 +953,6 @@ def certify_dabs_submission(submission):
                                              ' Use the publish_and_certify_dabs_submission endpoint to recertify.'),
                                   StatusCode.CLIENT_ERROR)
 
-    # Get the year/period of the submission and filter by them
-    sess = GlobalDB.db().session
-    sub_period = submission.reporting_fiscal_period
-    sub_year = submission.reporting_fiscal_year
-    sub_schedule = sess.query(SubmissionWindowSchedule).filter_by(year=sub_year, period=sub_period).one_or_none()
-
-    # If this is a monthly submission and the certification deadline has passed they have to publish/certify together
-    if sub_schedule and sub_schedule.certification_deadline < datetime.utcnow():
-        return JsonResponse.error(ValueError('Monthly submissions past their certification deadline must be published'
-                                             ' and certified at the same time. Use the'
-                                             ' publish_and_certify_dabs_submission endpoint.'), StatusCode.CLIENT_ERROR)
-
     try:
         process_dabs_certify(submission)
     except ValueError as e:

--- a/tests/unit/dataactbroker/test_submission_handler.py
+++ b/tests/unit/dataactbroker/test_submission_handler.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 
 from dataactbroker.handlers import fileHandler
 from dataactbroker.handlers.submission_handler import (
-    publish_checks, process_dabs_publish, process_dabs_certify, publish_dabs_submission, certify_dabs_submission,
+    publish_checks, process_dabs_publish, process_dabs_certify, publish_dabs_submission,
     publish_and_certify_dabs_submission, get_submission_metadata, get_revalidation_threshold, get_submission_data,
     move_published_data, get_latest_publication_period, revert_to_certified)
 

--- a/tests/unit/dataactbroker/test_submission_handler.py
+++ b/tests/unit/dataactbroker/test_submission_handler.py
@@ -917,31 +917,6 @@ def test_publish_dabs_submission_past_due(database):
 
 
 @pytest.mark.usefixtures('job_constants')
-def test_certify_dabs_submission_past_due(database):
-    """ Tests that a DABS submission cannot be certified without republishing if it is past its certification date. """
-    now = datetime.datetime.utcnow()
-    sess = database.session
-
-    user = UserFactory()
-    cgac = CGACFactory(cgac_code='001', agency_name='CGAC Agency')
-    submission = SubmissionFactory(cgac_code=cgac.cgac_code, reporting_fiscal_period=3, reporting_fiscal_year=2017,
-                                   reporting_start_date='2016-10-01', is_quarter_format=False, publishable=True,
-                                   publish_status_id=PUBLISH_STATUS_DICT['published'], d2_submission=False,
-                                   number_of_errors=0, number_of_warnings=200, certifying_user_id=None)
-    sched = SubmissionWindowScheduleFactory(period=3, year=2017, period_start=now - datetime.timedelta(5),
-                                            certification_deadline=now - datetime.timedelta(1))
-    sess.add_all([user, cgac, submission, sched])
-    sess.commit()
-
-    results = certify_dabs_submission(submission)
-
-    assert results.status_code == 400
-    assert results.json['message'] == 'Monthly submissions past their certification deadline must be published and' \
-                                      ' certified at the same time. Use the publish_and_certify_dabs_submission' \
-                                      ' endpoint.'
-
-
-@pytest.mark.usefixtures('job_constants')
 def test_process_dabs_certify_success(database):
     """ Tests that a DABS submission can be successfully certified and the certify info added to the published files
         history.


### PR DESCRIPTION
**High level description:**
Remove preventing only certify after certification deadline

**Technical details:**
It will only ever allow it to get through the call if it's been published already and we don't need a re-publish in this case.

**Link to JIRA Ticket:**
[DEV-5514](https://federal-spending-transparency.atlassian.net/browse/DEV-5514)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Merged concurrently with [Frontend#1386](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1386)
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation Updated