### PR TITLE
reverting ddtace client upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cffi==1.8.3
 click==6.6
 colorama==0.3.3
 coverage==4.0.3
-ddtrace==0.37.1
+ddtrace==0.32.2
 decorator==4.0.4
 docutils==0.12
 factory-boy==2.7.0


### PR DESCRIPTION
**High level description:**
This PR will revert the recent ddtrace client upgrade as its not compatible with our version of python (3.5)

**Technical details:**
the package is not compatible with python 3.5 Travis automated build did not catch this because it does not install the requirements.

**Link to JIRA Ticket:**
[DEV-1234](https://federal-spending-transparency.atlassian.net/browse/DEV-1234)