### PR TITLE
[DEV-5582] make batch size configurable

### DIFF
--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -5,6 +5,9 @@
 
 broker:
 
+    # Specify the number or rows to process at a time during submission validation
+    validator_batch_size: 10000
+
     # Specify the url where the front end of the application will be accessed.
     # For a local installation this will most likely be localhost or the
     # location where the /public files are located. If a port is required,

--- a/dataactcore/local_config_example.yml
+++ b/dataactcore/local_config_example.yml
@@ -6,6 +6,7 @@
 broker:
 
     use_aws: false
+    validator_batch_size: 10000
     full_url: http://127.0.0.1:3000
     reply_to_email: valid.developer.email@domain.com
     broker_files: ./tmp/data_act_broker

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -48,7 +48,7 @@ from dataactvalidator.validation_handlers.validationError import ValidationError
 
 logger = logging.getLogger(__name__)
 
-CHUNK_SIZE = 10000
+CHUNK_SIZE = CONFIG_BROKER['validator_batch_size']
 
 
 class ValidationManager:


### PR DESCRIPTION
**High level description:**
Makes the batch size for validations configurable instead of hard-coded

**Technical details:**
validator_batch_size in config.yml will be used as the CHUNK_SIZE in the validationManager.py

**Link to JIRA Ticket:**
https://federal-spending-transparency.atlassian.net/browse/DEV-5582

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [N/A] Merged concurrently with frontend
- [N/A] Unit & integration tests updated with relevant test cases
- [N/A] Frontend impact assessment completed
- [x] Documentation Updated