### PR TITLE
[HOTFIX] Uploading the Error/Warning files to S3 Better

### DIFF
--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -227,18 +227,12 @@ class ValidationManager:
 
             # stream file to S3 when not local
             if not self.is_local:
-                s3_resource = boto3.resource('s3', region_name=region_name)
-                # stream error file
-                with open(self.error_file_path, 'rb') as csv_file:
-                    s3_resource.Object(bucket_name, self.get_file_name(self.error_file_name)).put(Body=csv_file)
-                csv_file.close()
+                s3 = boto3.client('s3', region_name='us-gov-west-1')
+
+                s3.upload_file(self.error_file_path, bucket_name, self.get_file_name(self.error_file_name))
                 os.remove(self.error_file_path)
 
-                # stream warning file
-                with open(self.warning_file_path, 'rb') as warning_csv_file:
-                    s3_resource.Object(bucket_name,
-                                       self.get_file_name(self.warning_file_name)).put(Body=warning_csv_file)
-                warning_csv_file.close()
+                s3.upload_file(self.warning_file_path, bucket_name, self.get_file_name(self.warning_file_name))
                 os.remove(self.warning_file_path)
 
             # Calculate total number of rows in file that passed validations

--- a/dataactvalidator/validation_handlers/validationManager.py
+++ b/dataactvalidator/validation_handlers/validationManager.py
@@ -227,7 +227,7 @@ class ValidationManager:
 
             # stream file to S3 when not local
             if not self.is_local:
-                s3 = boto3.client('s3', region_name='us-gov-west-1')
+                s3 = boto3.client('s3', region_name=region_name)
 
                 s3.upload_file(self.error_file_path, bucket_name, self.get_file_name(self.error_file_name))
                 os.remove(self.error_file_path)


### PR DESCRIPTION
**High level description:**
The current way we upload error/warnings files to S3 doesn't use multipart. `upload_file` does.

**Technical details:**
N/A

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Tested locally connected to AWS
- [x] Tested on sandbox
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated