### PR TITLE
HOTFIX (DEV-5824): Accessing older Error/Warning Reports

### DIFF
--- a/dataactcore/utils/report.py
+++ b/dataactcore/utils/report.py
@@ -1,24 +1,54 @@
 import itertools
 from operator import attrgetter
+from datetime import datetime
 
-from dataactcore.models.lookups import FILE_TYPE, FILE_TYPE_DICT_NAME_LETTER
+from dataactcore.interfaces.db import GlobalDB
+from dataactcore.models.jobModels import Job
+from dataactcore.models.lookups import FILE_TYPE, FILE_TYPE_DICT_NAME_LETTER, JOB_TYPE_DICT, FILE_TYPE_DICT
+
+DAIMS_THRESHOLD = datetime.strptime('07-13-2020 21:53', '%m-%d-%Y %H:%M')
 
 
 def report_file_name(submission_id, warning, file_type, cross_type=None):
-    """Format the csv file name for the requested file.
-    @todo: unify these file names"""
+    """ Format the csv file name for the requested file
+
+        Args:
+            submission_id: the submission's id
+            warning: whether it's a warning or error (True if warning)
+            file_type: the file type name associated with the report
+            cross_type: cross file type name associated with the report
+
+        Returns:
+            string of the report file name
+    """
+    sess = GlobalDB.db().session
+
     if cross_type:
-        report_type_str = 'warning_' if warning else ''
-        return "submission_{}_crossfile_{}File_{}_to_{}_{}_{}.csv".format(submission_id, report_type_str,
-                                                                          FILE_TYPE_DICT_NAME_LETTER[file_type],
-                                                                          FILE_TYPE_DICT_NAME_LETTER[cross_type],
-                                                                          file_type,
-                                                                          cross_type)
+        job = sess.query(Job).filter_by(submission_id=submission_id, job_type_id=JOB_TYPE_DICT['validation']).one()
     else:
-        report_type_str = 'warning_' if warning else 'error_'
-        return "submission_{}_File_{}_{}_{}report.csv".format(submission_id,
-                                                              FILE_TYPE_DICT_NAME_LETTER[file_type],
-                                                              file_type, report_type_str)
+        job = sess.query(Job).filter_by(submission_id=submission_id, job_type_id=JOB_TYPE_DICT['csv_record_validation'],
+                                        file_type_id=FILE_TYPE_DICT[file_type]).one()
+
+    if job.updated_at < DAIMS_THRESHOLD:
+        if cross_type:
+            report_type_str = 'warning_' if warning else ''
+            return "submission_{}_cross_{}{}_{}.csv".format(submission_id, report_type_str, file_type, cross_type)
+        else:
+            report_type_str = 'warning' if warning else 'error'
+            return "submission_{}_{}_{}_report.csv".format(submission_id, file_type, report_type_str)
+    else:
+        if cross_type:
+            report_type_str = 'warning_' if warning else ''
+            return "submission_{}_crossfile_{}File_{}_to_{}_{}_{}.csv".format(submission_id, report_type_str,
+                                                                              FILE_TYPE_DICT_NAME_LETTER[file_type],
+                                                                              FILE_TYPE_DICT_NAME_LETTER[cross_type],
+                                                                              file_type,
+                                                                              cross_type)
+        else:
+            report_type_str = 'warning_' if warning else 'error_'
+            return "submission_{}_File_{}_{}_{}report.csv".format(submission_id,
+                                                                  FILE_TYPE_DICT_NAME_LETTER[file_type],
+                                                                  file_type, report_type_str)
 
 
 def get_cross_file_pairs():

--- a/tests/integration/error_warning_file_tests.py
+++ b/tests/integration/error_warning_file_tests.py
@@ -6,10 +6,10 @@ from dataactcore.interfaces.db import GlobalDB
 from dataactcore.config import CONFIG_SERVICES
 from dataactcore.models.domainModels import concat_tas_dict
 from dataactcore.models.lookups import (FILE_TYPE_DICT, JOB_TYPE_DICT, JOB_STATUS_DICT)
-from dataactcore.models.jobModels import Submission
+from dataactcore.models.jobModels import Submission, Job
 from dataactcore.models.userModel import User
 from dataactcore.models.errorModels import ErrorMetadata
-from dataactcore.models.stagingModels import Appropriation, ObjectClassProgramActivity
+from dataactcore.models.stagingModels import Appropriation, ObjectClassProgramActivity, FlexField
 from dataactvalidator.health_check import create_app
 from dataactvalidator.validation_handlers.validationManager import ValidationManager
 from dataactbroker.handlers.fileHandler import report_file_name
@@ -181,18 +181,16 @@ class ErrorWarningTests(BaseTestValidator):
         return os.path.join(CONFIG_SERVICES['error_report_path'], filename)
 
     def setup_csv_record_validation(self, file, file_type):
-        self.val_job.filename = file
-        self.val_job.file_type_id = FILE_TYPE_DICT[file_type]
-        self.val_job.job_status_id = JOB_STATUS_DICT['ready']
-        self.val_job.job_type_id = JOB_TYPE_DICT['csv_record_validation']
-        self.session.commit()
+        self.session.query(Job).delete(synchronize_session='fetch')
+        self.val_job = insert_job(self.session, FILE_TYPE_DICT[file_type], JOB_STATUS_DICT['ready'],
+                                  JOB_TYPE_DICT['csv_record_validation'], self.submission_id,
+                                  filename=file)
 
     def setup_validation(self):
-        self.val_job.filename = None
-        self.val_job.file_type_id = None
-        self.val_job.job_status_id = JOB_STATUS_DICT['ready']
-        self.val_job.job_type_id = JOB_TYPE_DICT['validation']
-        self.session.commit()
+        self.session.query(Job).delete(synchronize_session='fetch')
+        self.val_job = insert_job(self.session, None, JOB_STATUS_DICT['ready'],
+                                  JOB_TYPE_DICT['validation'], self.submission_id,
+                                  filename=None)
 
     def get_report_content(self, report_path):
         report_content = []
@@ -247,6 +245,7 @@ class ErrorWarningTests(BaseTestValidator):
         self.session.query(Appropriation).delete(synchronize_session='fetch')
         self.session.query(ObjectClassProgramActivity).delete(synchronize_session='fetch')
         self.session.query(ErrorMetadata).delete(synchronize_session='fetch')
+        self.session.query(FlexField).delete(synchronize_session='fetch')
         self.session.commit()
 
     def test_single_file_warnings(self):
@@ -515,7 +514,7 @@ class ErrorWarningTests(BaseTestValidator):
                 'Source Value Provided': 'grossoutlayamountbytas_cpe: 10000',
                 'Target Value Provided': 'gross_outlay_amount_by_pro_cpe_sum: 6000',
                 'Difference': '4000',
-                'Source Flex Field': '',
+                'Source Flex Field': 'flex_field_a: FLEX_A, flex_field_b: FLEX_B',
                 'Source Row Number': '5',
                 'Rule Label': 'A18'
             },
@@ -531,7 +530,7 @@ class ErrorWarningTests(BaseTestValidator):
                 'Source Value Provided': 'obligationsincurredtotalbytas_cpe: 12000',
                 'Target Value Provided': 'obligations_incurred_by_pr_cpe_sum: 6000',
                 'Difference': '18000',
-                'Source Flex Field': '',
+                'Source Flex Field': 'flex_field_a: FLEX_A, flex_field_b: FLEX_B',
                 'Source Row Number': '5',
                 'Rule Label': 'A19'
             },
@@ -550,7 +549,7 @@ class ErrorWarningTests(BaseTestValidator):
                                          ' ussgl487200_downward_adjus_cpe_sum: 400,'
                                          ' ussgl497200_downward_adjus_cpe_sum: 2000',
                 'Difference': '9600',
-                'Source Flex Field': '',
+                'Source Flex Field': 'flex_field_a: FLEX_A, flex_field_b: FLEX_B',
                 'Source Row Number': '5',
                 'Rule Label': 'A35'
             }
@@ -586,7 +585,7 @@ class ErrorWarningTests(BaseTestValidator):
                                          ' availabilitytypecode: X, mainaccountcode: 0306, subaccountcode: 000',
                 'Target Value Provided': '',
                 'Difference': '',
-                'Source Flex Field': '',
+                'Source Flex Field': 'flex_field_a: FLEX_A, flex_field_b: FLEX_B',
                 'Source Row Number': '2',
                 'Rule Label': 'A30.1'
             }

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -877,6 +877,8 @@ class FileTests(BaseTestAPI):
                    JOB_TYPE_DICT['csv_record_validation'], self.test_monthly_submission_id, num_valid_rows=1)
         insert_job(self.session, FILE_TYPE_DICT['program_activity'], JOB_STATUS_DICT['finished'],
                    JOB_TYPE_DICT['csv_record_validation'], self.test_monthly_submission_id, num_valid_rows=1)
+        insert_job(self.session, None, JOB_STATUS_DICT['finished'],
+                   JOB_TYPE_DICT['validation'], self.test_monthly_submission_id, num_valid_rows=1)
         post_json = {'submission_id': self.test_monthly_submission_id}
         response = self.app.post_json('/v1/publish_and_certify_dabs_submission/', post_json,
                                       headers={'x-session-id': self.session_id}, expect_errors=False)
@@ -887,6 +889,8 @@ class FileTests(BaseTestAPI):
                    JOB_TYPE_DICT['csv_record_validation'], self.dup_test_monthly_submission_id, num_valid_rows=1)
         insert_job(self.session, FILE_TYPE_DICT['program_activity'], JOB_STATUS_DICT['finished'],
                    JOB_TYPE_DICT['csv_record_validation'], self.dup_test_monthly_submission_id, num_valid_rows=1)
+        insert_job(self.session, None, JOB_STATUS_DICT['finished'],
+                   JOB_TYPE_DICT['validation'], self.dup_test_monthly_submission_id, num_valid_rows=1)
         post_json = {'submission_id': self.dup_test_monthly_submission_id}
         response = self.app.post_json('/v1/publish_and_certify_dabs_submission/', post_json,
                                       headers={'x-session-id': self.session_id}, expect_errors=True)

--- a/tests/unit/dataactbroker/test_submission_handler.py
+++ b/tests/unit/dataactbroker/test_submission_handler.py
@@ -864,7 +864,9 @@ def test_publish_and_certify_dabs_submission_window_multiple_thresholds(database
 
         job = JobFactory(submission_id=submission.submission_id, last_validated=now,
                          job_type_id=JOB_TYPE_DICT['csv_record_validation'])
-        sess.add(job)
+        c_job = JobFactory(submission_id=submission.submission_id, last_validated=now,
+                           job_type_id=JOB_TYPE_DICT['validation'])
+        sess.add_all([job, c_job])
         sess.commit()
 
         g.user = user


### PR DESCRIPTION
**High level description:**
Since we changed the name of the error/warning reports, the older reports have been inaccessible. This resolves that by associating certain filename formats to different time periods (before/after DAIMS 2.0 was deployed to production)

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-5824](https://federal-spending-transparency.atlassian.net/browse/DEV-5824)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated