### PR TITLE
DEV-5800: list submissions test filter

### DIFF
--- a/dataactbroker/README.md
+++ b/dataactbroker/README.md
@@ -1318,12 +1318,12 @@ This endpoint lists submissions for all agencies for which the current user is a
 ##### Body (JSON)
 ```
 {
-    "page": 2
+    "page": 2,
     "limit": 5,
-    "certified": "true",
+    "published": "true",
     "sort": "modified",
     "order": "desc",
-    "fabs": False,
+    "fabs": false,
     "filters": {
         "submission_ids": [123, 456],
         "last_modified_range": {
@@ -1332,7 +1332,8 @@ This endpoint lists submissions for all agencies for which the current user is a
         },
         "agency_codes": ["123", "4567"],
         "file_names": ["file_a", "test"],
-        "user_ids: [1, 2]
+        "user_ids": [1, 2],
+        "submission_type": "test"
     }
 }
 ```
@@ -1366,6 +1367,9 @@ This endpoint lists submissions for all agencies for which the current user is a
     - `agency_codes`: ([string]) CGAC and FREC codes
     - `file_names`: ([string]) total or partial matches to file names (including timestamps), will match any file name including generated ones
     - `user_ids`: ([string, integer]) limits the list of submissions to only ones created by users within the array.
+    - `submission_type`: (string) if present, limits to only showing test or only showing certifiable submissions in the list. Can be used with any other filters or parameters but only unpublished DABS submissions can be tests. Allowable values:
+      - `test`
+      - `certifiable`
 
 ##### Response (JSON)
 

--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -1628,6 +1628,13 @@ def add_list_submission_filters(query, filters, submission_updated_view):
             query = query.filter(Submission.user_id.in_(user_list))
         elif user_list:
             raise ResponseException('user_ids filter must be null or an array', StatusCode.CLIENT_ERROR)
+    # Test submission filter
+    if 'submission_type' in filters:
+        submission_type = filters['submission_type']
+        if str(submission_type).upper() in ['TEST', 'CERTIFIABLE']:
+            query = query.filter(Submission.test_submission.is_(submission_type.upper() == 'TEST'))
+        else:
+            raise ResponseException('submission_type filter must be "test" or "certifiable"', StatusCode.CLIENT_ERROR)
     return query
 
 


### PR DESCRIPTION
**High level description:**
Adds a filter to the `list_submissions` endpoint to allow showing only test or only certifiable submissions

**Technical details:**
New filter value `submission_type`

**Link to JIRA Ticket:**
[DEV-5800](https://federal-spending-transparency.atlassian.net/browse/DEV-5800)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation Updated