### PR TITLE
DEV-5654: Duplicate Certified Error Metadata

### DIFF
--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -815,6 +815,9 @@ def process_dabs_publish(submission, file_manager):
     # Determine if this is the first time this submission is being published
     first_publish = (submission.publish_status_id == PUBLISH_STATUS_DICT['unpublished'])
 
+    # set publish_status to "publishing"
+    submission.publish_status_id = PUBLISH_STATUS_DICT['publishing']
+
     # create the publish_history entry
     publish_history = PublishHistory(created_at=datetime.utcnow(), user_id=current_user_id,
                                      submission_id=submission.submission_id)
@@ -834,6 +837,7 @@ def process_dabs_publish(submission, file_manager):
     # set submission contents
     submission.certifying_user_id = current_user_id
     submission.publish_status_id = PUBLISH_STATUS_DICT['published']
+    sess.commit()
 
     if first_publish:
         # update any other submissions by the same agency in the same quarter/period to point to this submission


### PR DESCRIPTION
**High level description:**
There was a bug with duplicate certified data from a submission before CARES. Setting the submission publish status to "publishing" as it starts publishing should prevent this.

**Technical details:**
Added an extra sess.commit() for republishing submissions.

**Link to JIRA Ticket:**
[DEV-5654](https://federal-spending-transparency.atlassian.net/browse/DEV-5654)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated