### PR TITLE
DEV-5933: FABS publishing blank id updates

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -834,7 +834,7 @@ class FileHandler:
                 SET is_active = FALSE,
                     updated_at = nrk.modified_at
                 FROM new_record_keys AS nrk
-                WHERE pafa.submission_id <> {submission_id}
+                WHERE COALESCE(pafa.submission_id, 0) <> {submission_id}
                     AND UPPER(pafa.afa_generated_unique) = nrk.afa_generated_unique
                     AND is_active IS TRUE;
             """


### PR DESCRIPTION
**High level description:**
Accounting for historical records or records from before we stored submission IDs when deactivating records

**Technical details:**
Not ignoring anything with a blank submission ID when deactivating old records

**Link to JIRA Ticket:**
[DEV-5933](https://federal-spending-transparency.atlassian.net/browse/DEV-5933)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated