### PR TITLE
DEV-5955: metadata box last modified

### DIFF
--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -12,7 +12,7 @@ from dataactcore.config import CONFIG_BROKER
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.interfaces.function_bag import (sum_number_of_errors_for_job_list, get_last_validated_date,
                                                  get_fabs_meta, get_error_type, get_error_metrics_by_job_id,
-                                                 get_certification_deadline)
+                                                 get_certification_deadline, get_last_modified)
 
 from dataactcore.models.lookups import (JOB_STATUS_DICT, PUBLISH_STATUS_DICT, JOB_TYPE_DICT, RULE_SEVERITY_DICT,
                                         FILE_TYPE_DICT)
@@ -147,6 +147,7 @@ def get_submission_metadata(submission):
     certification_deadline = get_certification_deadline(submission)
     reporting_start = submission.reporting_start_date.strftime('%m/%d/%Y') if submission.reporting_start_date else None
     reporting_end = submission.reporting_end_date.strftime('%m/%d/%Y') if submission.reporting_end_date else None
+    last_modified = get_last_modified(submission.submission_id)
 
     return {
         'cgac_code': submission.cgac_code,
@@ -157,7 +158,7 @@ def get_submission_metadata(submission):
         'number_of_rows': number_of_rows,
         'total_size': total_size,
         'created_on': submission.created_at.strftime('%Y-%m-%dT%H:%M:%S'),
-        'last_updated': submission.updated_at.strftime('%Y-%m-%dT%H:%M:%S'),
+        'last_updated': last_modified.strftime('%Y-%m-%dT%H:%M:%S') if last_modified else '',
         'last_validated': last_validated,
         'reporting_period': reporting_date(submission),
         'reporting_start_date': reporting_start,

--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -688,5 +688,5 @@ def get_last_modified(submission_id):
     submission_updated_view = SubmissionUpdatedView()
     sess = GlobalDB.db().session
     last_modified = sess.query(submission_updated_view.updated_at).\
-        filter(submission_updated_view.submission_id == submission_id).first().updated_at
-    return last_modified
+        filter(submission_updated_view.submission_id == submission_id).first()
+    return last_modified.updated_at if last_modified else None

--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -15,6 +15,7 @@ from dataactcore.models.jobModels import (Job, Submission, JobDependency, Publis
 from dataactcore.models.stagingModels import DetachedAwardFinancialAssistance
 from dataactcore.models.userModel import User, EmailTemplateType, EmailTemplate
 from dataactcore.models.validationModels import RuleSeverity
+from dataactcore.models.views import SubmissionUpdatedView
 from dataactcore.models.lookups import (FILE_TYPE_DICT, FILE_STATUS_DICT, JOB_TYPE_DICT,
                                         JOB_STATUS_DICT, FILE_TYPE_DICT_ID, PUBLISH_STATUS_DICT)
 from dataactcore.interfaces.db import GlobalDB
@@ -660,12 +661,12 @@ def get_fabs_meta(submission_id):
 def get_action_dates(submission_id):
     """ Pull the earliest/latest action dates from the DetachedAwardFinancialAssistance table
 
-    Arguments:
-        submission_id: submission ID pull action dates from
+        Args:
+            submission_id: submission ID pull action dates from
 
-    Returns:
-        the earliest action date (str) or None if not found
-        the latest action date (str) or None if not found
+        Returns:
+            the earliest action date (str) or None if not found
+            the latest action date (str) or None if not found
     """
 
     sess = GlobalDB.db().session
@@ -673,3 +674,19 @@ def get_action_dates(submission_id):
                       func.max(DetachedAwardFinancialAssistance.action_date).label("max_action_date"))\
         .filter(DetachedAwardFinancialAssistance.submission_id == submission_id,
                 DetachedAwardFinancialAssistance.is_valid.is_(True)).one()
+
+
+def get_last_modified(submission_id):
+    """ Get the last modified date for a submission
+
+        Args:
+            submission_id: submission ID to get the last modified for
+
+        Returns:
+            the last modified date of the provided submission or None if the submission doesn't exist
+    """
+    submission_updated_view = SubmissionUpdatedView()
+    sess = GlobalDB.db().session
+    last_modified = sess.query(submission_updated_view.updated_at).\
+        filter(submission_updated_view.submission_id == submission_id).first().updated_at
+    return last_modified

--- a/tests/unit/dataactcore/test_function_bag.py
+++ b/tests/unit/dataactcore/test_function_bag.py
@@ -139,13 +139,20 @@ def test_get_time_period(database):
     assert get_time_period(month_sub) == '09 / 2020'
 
 
+@pytest.mark.usefixtures("job_constants")
 def test_get_last_modified(database):
     """ Tests get_last_modified """
     now = datetime.datetime.now()
     sess = database.session
-    sub = SubmissionFactory(submission_id=1, reporting_fiscal_year=2020, reporting_fiscal_period=6, d2_submission=False,
-                            is_quarter_format=True, updated_at=now)
-    sess.add(sub)
+    sub_1 = SubmissionFactory(submission_id=1, reporting_fiscal_year=2020, reporting_fiscal_period=6,
+                              d2_submission=False, is_quarter_format=True, updated_at=now)
+    sub_2 = SubmissionFactory(submission_id=2, reporting_fiscal_year=2020, reporting_fiscal_period=6,
+                              d2_submission=False, is_quarter_format=True, updated_at=now)
+    job = JobFactory(submission_id=sub_2.submission_id, job_status_id=JOB_STATUS_DICT['waiting'],
+                     job_type_id=JOB_TYPE_DICT['csv_record_validation'], file_type_id=FILE_TYPE_DICT['award'],
+                     updated_at=now + datetime.timedelta(days=1))
+    sess.add_all([sub_1, sub_2, job])
 
-    assert get_last_modified(1) == now
+    assert get_last_modified(sub_1.submission_id) == now
+    assert get_last_modified(sub_2.submission_id) == now + datetime.timedelta(days=1)
     assert get_last_modified(0) is None

--- a/tests/unit/dataactcore/test_function_bag.py
+++ b/tests/unit/dataactcore/test_function_bag.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 from dataactcore.aws.sqsHandler import SQSMockQueue
 from dataactcore.models.jobModels import JobDependency
 from dataactcore.models.lookups import JOB_STATUS_DICT, JOB_TYPE_DICT, FILE_TYPE_DICT
-from dataactcore.interfaces.function_bag import check_job_dependencies, get_certification_deadline, get_time_period
+from dataactcore.interfaces.function_bag import (check_job_dependencies, get_certification_deadline, get_time_period,
+                                                 get_last_modified)
 
 from tests.unit.dataactcore.factories.job import JobFactory, SubmissionFactory, SubmissionWindowScheduleFactory
 
@@ -136,3 +137,15 @@ def test_get_time_period(database):
     # Pass cases
     assert get_time_period(quart_sub) == 'FY 20 / Q2'
     assert get_time_period(month_sub) == '09 / 2020'
+
+
+def test_get_last_modified(database):
+    """ Tests get_last_modified """
+    now = datetime.datetime.now()
+    sess = database.session
+    sub = SubmissionFactory(submission_id=1, reporting_fiscal_year=2020, reporting_fiscal_period=6, d2_submission=False,
+                            is_quarter_format=True, updated_at=now)
+    sess.add(sub)
+
+    assert get_last_modified(1) == now
+    assert get_last_modified(0) is None


### PR DESCRIPTION
**High level description:**
Updating the metadata box above submissions to use the proper modified date instead of only checking the submission's updated_at

**Technical details:**
Uses the same table as the frontend submission table to get the last_modified date so if a job has changed that didn't cause the submission to change, the most recent modification of any kind will be the one displayed.

**Link to JIRA Ticket:**
[DEV-5955](https://federal-spending-transparency.atlassian.net/browse/DEV-5955)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- Documentation Updated