### PR TITLE
Fix: Parallelized Non-SQL Validations 

### DIFF
--- a/dataactvalidator/validation_handlers/errorInterface.py
+++ b/dataactvalidator/validation_handlers/errorInterface.py
@@ -6,88 +6,80 @@ from dataactcore.interfaces.db import GlobalDB
 from dataactcore.models.lookups import ERROR_TYPE_DICT
 
 
-class ErrorInterface:
-    """Manages communication with error database."""
+def record_row_error(error_list, job_id, filename, field_name, error_type, row, original_label=None, file_type_id=None,
+                     target_file_id=None, severity_id=None):
+    """ Add this error to running sum of error types
 
-    def __init__(self):
-        """ Create empty row error dict """
-        self.rowErrors = {}
+    Args:
+        job_id: ID of job in job tracker
+        filename: name of error report in S3
+        field_name: name of field where error occurred
+        error_type: type of error, value will be mapped to ValidationError class,
+            for rule failures this will hold entire message
+        row: Row number error occurred on
+        original_label: Label of rule
+        file_type_id: Id of source file type
+        target_file_id: Id of target file type
+        severity_id: Id of error severity
+    """
+    key = "".join([str(job_id), field_name, str(error_type)])
+    if key in error_list:
+        error_list[key]["numErrors"] += 1
+    else:
+        error_dict = {"filename": filename, "fieldName": field_name, "jobId": job_id, "errorType": error_type,
+                      "numErrors": 1,
+                      "firstRow": row, "originalRuleLabel": original_label, "fileTypeId": file_type_id,
+                      "targetFileId": target_file_id, "severity": severity_id}
+        error_list[key] = error_dict
+    return error_list
 
-    def record_row_error(self, job_id, filename, field_name, error_type, row, original_label=None, file_type_id=None,
-                         target_file_id=None, severity_id=None):
-        """ Add this error to running sum of error types
 
-        Args:
-            job_id: ID of job in job tracker
-            filename: name of error report in S3
-            field_name: name of field where error occurred
-            error_type: type of error, value will be mapped to ValidationError class,
-                for rule failures this will hold entire message
-            row: Row number error occurred on
-            original_label: Label of rule
-            file_type_id: Id of source file type
-            target_file_id: Id of target file type
-            severity_id: Id of error severity
-        """
-        key = "".join([str(job_id), field_name, str(error_type)])
-        if key in self.rowErrors:
-            self.rowErrors[key]["numErrors"] += 1
-        else:
-            error_dict = {"filename": filename, "fieldName": field_name, "jobId": job_id, "errorType": error_type,
-                          "numErrors": 1,
-                          "firstRow": row, "originalRuleLabel": original_label, "fileTypeId": file_type_id,
-                          "targetFileId": target_file_id, "severity": severity_id}
-            self.rowErrors[key] = error_dict
+def write_all_row_errors(error_list, job_id):
+    """ Writes all recorded errors to database
 
-    def write_all_row_errors(self, job_id):
-        """ Writes all recorded errors to database
-
-        Args:
-            job_id: ID to write errors for
-        """
-        sess = GlobalDB.db().session
-        for key in self.rowErrors.keys():
-            error_dict = self.rowErrors[key]
-            # Set info for this error
-            this_job = error_dict["jobId"]
-            if int(job_id) != int(this_job):
-                # This row is for a different job, skip it
-                continue
-            field_name = error_dict["fieldName"]
-            try:
-                # If last part of key is an int, it's one of our prestored messages
-                error_type = int(error_dict["errorType"])
-            except ValueError:
-                # For rule failures, it will hold the error message
-                error_msg = error_dict["errorType"]
-                if "Field must be no longer than specified limit" in error_msg:
-                    rule_failed_id = ERROR_TYPE_DICT['length_error']
-                else:
-                    rule_failed_id = ERROR_TYPE_DICT['rule_failed']
-                error_row = ErrorMetadata(job_id=this_job, filename=error_dict["filename"], field_name=field_name,
-                                          error_type_id=rule_failed_id, rule_failed=error_msg,
-                                          occurrences=error_dict["numErrors"], first_row=error_dict["firstRow"],
-                                          original_rule_label=error_dict["originalRuleLabel"],
-                                          file_type_id=error_dict["fileTypeId"],
-                                          target_file_type_id=error_dict["targetFileId"],
-                                          severity_id=error_dict["severity"])
+    Args:
+        job_id: ID to write errors for
+    """
+    sess = GlobalDB.db().session
+    for key in error_list.keys():
+        error_dict = error_list[key]
+        # Set info for this error
+        this_job = error_dict["jobId"]
+        if int(job_id) != int(this_job):
+            # This row is for a different job, skip it
+            continue
+        field_name = error_dict["fieldName"]
+        try:
+            # If last part of key is an int, it's one of our prestored messages
+            error_type = int(error_dict["errorType"])
+        except ValueError:
+            # For rule failures, it will hold the error message
+            error_msg = error_dict["errorType"]
+            if "Field must be no longer than specified limit" in error_msg:
+                rule_failed_id = ERROR_TYPE_DICT['length_error']
             else:
-                # This happens if cast to int was successful
-                error_string = ValidationError.get_error_type_string(error_type)
-                error_id = ERROR_TYPE_DICT[error_string]
-                # Create error metadata
-                error_row = ErrorMetadata(job_id=this_job, filename=error_dict["filename"], field_name=field_name,
-                                          error_type_id=error_id, occurrences=error_dict["numErrors"],
-                                          first_row=error_dict["firstRow"],
-                                          rule_failed=ValidationError.get_error_message(error_type),
-                                          original_rule_label=error_dict["originalRuleLabel"],
-                                          file_type_id=error_dict["fileTypeId"],
-                                          target_file_type_id=error_dict["targetFileId"],
-                                          severity_id=error_dict["severity"])
+                rule_failed_id = ERROR_TYPE_DICT['rule_failed']
+            error_row = ErrorMetadata(job_id=this_job, filename=error_dict["filename"], field_name=field_name,
+                                      error_type_id=rule_failed_id, rule_failed=error_msg,
+                                      occurrences=error_dict["numErrors"], first_row=error_dict["firstRow"],
+                                      original_rule_label=error_dict["originalRuleLabel"],
+                                      file_type_id=error_dict["fileTypeId"],
+                                      target_file_type_id=error_dict["targetFileId"],
+                                      severity_id=error_dict["severity"])
+        else:
+            # This happens if cast to int was successful
+            error_string = ValidationError.get_error_type_string(error_type)
+            error_id = ERROR_TYPE_DICT[error_string]
+            # Create error metadata
+            error_row = ErrorMetadata(job_id=this_job, filename=error_dict["filename"], field_name=field_name,
+                                      error_type_id=error_id, occurrences=error_dict["numErrors"],
+                                      first_row=error_dict["firstRow"],
+                                      rule_failed=ValidationError.get_error_message(error_type),
+                                      original_rule_label=error_dict["originalRuleLabel"],
+                                      file_type_id=error_dict["fileTypeId"],
+                                      target_file_type_id=error_dict["targetFileId"],
+                                      severity_id=error_dict["severity"])
 
-            sess.add(error_row)
-
-        # Commit the session to write all rows
-        sess.commit()
-        # Clear the dictionary
-        self.rowErrors = {}
+        sess.add(error_row)
+    # Commit the session to write all rows
+    sess.commit()

--- a/dataactvalidator/validation_handlers/errorInterface.py
+++ b/dataactvalidator/validation_handlers/errorInterface.py
@@ -22,6 +22,9 @@ def record_row_error(error_list, job_id, filename, field_name, error_type, row, 
         file_type_id: Id of source file type
         target_file_id: Id of target file type
         severity_id: Id of error severity
+
+    Returns:
+        updated error_list with new/updated record rows
     """
     key = "".join([str(job_id), field_name, str(error_type)])
     if key in error_list:

--- a/dataactvalidator/validation_handlers/errorInterface.py
+++ b/dataactvalidator/validation_handlers/errorInterface.py
@@ -11,6 +11,7 @@ def record_row_error(error_list, job_id, filename, field_name, error_type, row, 
     """ Add this error to running sum of error types
 
     Args:
+        error_list: dict keeping track of error metadata to be updated
         job_id: ID of job in job tracker
         filename: name of error report in S3
         field_name: name of field where error occurred
@@ -38,6 +39,7 @@ def write_all_row_errors(error_list, job_id):
     """ Writes all recorded errors to database
 
     Args:
+        error_list: dict keeping track of error metadata to be updated
         job_id: ID to write errors for
     """
     sess = GlobalDB.db().session

--- a/dataactvalidator/validation_handlers/validator.py
+++ b/dataactvalidator/validation_handlers/validator.py
@@ -7,6 +7,7 @@ from dataactcore.models.lookups import FILE_TYPE_DICT, RULE_SEVERITY_DICT
 from dataactcore.models.validationModels import RuleSql
 from dataactcore.interfaces.db import GlobalDB
 from dataactbroker.scripts.update_historical_duns import batch as batcher
+from dataactvalidator.validation_handlers.errorInterface import record_row_error
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ def cross_validate_sql(rules, submission_id, short_to_long_dict, job_id, error_c
             job_id: the id of the cross-file job
             error_csv: the csv to write errors to
             warning_csv: the csv to write warnings to
-            error_list: instance of ErrorInterface to keep track of errors
+            error_list: dict to keep track of errors
             batch_results: instead of storing the results in memory, batch the results (for memory)
     """
     conn = GlobalDB.db().connection
@@ -130,8 +131,8 @@ def cross_validate_sql(rules, submission_id, short_to_long_dict, job_id, error_c
                     error_csv.writerow(failure[0:12])
                 if failure[14] == RULE_SEVERITY_DICT['warning']:
                     warning_csv.writerow(failure[0:12])
-                error_list.record_row_error(job_id, 'cross_file', failure[1], failure[5], failure[10], failure[11],
-                                            failure[12], failure[13], severity_id=failure[14])
+                record_row_error(error_list, job_id, 'cross_file', failure[1], failure[5], failure[10], failure[11],
+                                 failure[12], failure[13], severity_id=failure[14])
 
         sub_rule_sql = rule.rule_sql.format(submission_id)
         if batch_results:


### PR DESCRIPTION
**High level description:**
It was discovered that non-SQL validation errors weren't being stored in the database properly when running with parallelized loading. This resolves said bug. 

**Technical details:**
* Reduced wrapper class ErrorInterface to a dictionary with helper functions
* Core issue was multiprocessing's manager proxy list/dict objects not being updated correctly.

**Link to JIRA Ticket:**
[DEV-1234](https://federal-spending-transparency.atlassian.net/browse/DEV-1234)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Tested on sandbox with various DABS non-SQL validations
- Frontend impact assessment completed
- Documentation Updated