### PR TITLE
DEV-5954: C23 ignored with NULL TOA

### DIFF
--- a/dataactvalidator/config/sqlrules/c23_award_financial_1.sql
+++ b/dataactvalidator/config/sqlrules/c23_award_financial_1.sql
@@ -13,9 +13,10 @@ WITH award_financial_c23_1_{0} AS
 -- gather the grouped sum from the previous WITH (we need both so we can do the NOT EXISTS later)
 award_financial_grouped_c23_1_{0} AS
     (SELECT UPPER(piid) AS piid,
-        COALESCE(SUM(transaction_obligated_amou), 0) AS sum_ob_amount
+        SUM(transaction_obligated_amou) AS sum_ob_amount
     FROM award_financial_c23_1_{0}
     WHERE COALESCE(parent_award_id, '') = ''
+        AND transaction_obligated_amou IS NOT NULL
     GROUP BY UPPER(piid)),
 -- gather the grouped sum for award procurement data
 award_procurement_c23_1_{0} AS

--- a/dataactvalidator/config/sqlrules/c23_award_financial_2.sql
+++ b/dataactvalidator/config/sqlrules/c23_award_financial_2.sql
@@ -14,8 +14,9 @@ WITH award_financial_c23_2_{0} AS
 award_financial_grouped_c23_2_{0} AS
     (SELECT UPPER(piid) AS piid,
     UPPER(parent_award_id) AS parent_award_id,
-        COALESCE(SUM(transaction_obligated_amou), 0) AS sum_ob_amount
+        SUM(transaction_obligated_amou) AS sum_ob_amount
     FROM award_financial_c23_2_{0}
+    WHERE transaction_obligated_amou IS NOT NULL
     GROUP BY UPPER(parent_award_id),
         UPPER(piid)),
 -- gather the grouped sum for award procurement data

--- a/dataactvalidator/config/sqlrules/c23_award_financial_3.sql
+++ b/dataactvalidator/config/sqlrules/c23_award_financial_3.sql
@@ -12,8 +12,9 @@ WITH award_financial_c23_3_{0} AS
 -- gather the grouped sum from the previous WITH (we need both so we can do the NOT EXISTS later)
 award_financial_grouped_c23_3_{0} AS
     (SELECT UPPER(fain) AS fain,
-        COALESCE(SUM(transaction_obligated_amou), 0) AS sum_ob_amount
+        SUM(transaction_obligated_amou) AS sum_ob_amount
     FROM award_financial_c23_3_{0}
+    WHERE transaction_obligated_amou IS NOT NULL
     GROUP BY UPPER(fain)),
 -- gather the grouped sum for award financial assistance data
 award_financial_assistance_c23_3_{0} AS

--- a/dataactvalidator/config/sqlrules/c23_award_financial_4.sql
+++ b/dataactvalidator/config/sqlrules/c23_award_financial_4.sql
@@ -12,8 +12,9 @@ WITH award_financial_c23_4_{0} AS
 -- gather the grouped sum from the previous WITH (we need both so we can do the NOT EXISTS later)
 award_financial_grouped_c23_4_{0} AS
     (SELECT UPPER(uri) AS uri,
-        COALESCE(SUM(transaction_obligated_amou), 0) AS sum_ob_amount
+        SUM(transaction_obligated_amou) AS sum_ob_amount
     FROM award_financial_c23_4_{0}
+    WHERE transaction_obligated_amou IS NOT NULL
     GROUP BY UPPER(uri)),
 -- gather the grouped sum for award financial assistance data
 award_financial_assistance_c23_4_{0} AS

--- a/tests/unit/dataactvalidator/test_c23_award_financial_1.py
+++ b/tests/unit/dataactvalidator/test_c23_award_financial_1.py
@@ -98,7 +98,7 @@ def test_failure(database):
 
     # Not ignored with TOA of 0
     af_4 = AwardFinancialFactory(transaction_obligated_amou=0, piid=piid_4.lower(), parent_award_id=None,
-                                    allocation_transfer_agency='123', agency_identifier='123')
+                                 allocation_transfer_agency='123', agency_identifier='123')
 
     # Award Procurement portion of checks
     # Sum of all these would be sum of piid_1 af if one wasn't ignored

--- a/tests/unit/dataactvalidator/test_c23_award_financial_3.py
+++ b/tests/unit/dataactvalidator/test_c23_award_financial_3.py
@@ -24,6 +24,7 @@ def test_success(database):
     fain_1 = ''.join(choice(ascii_uppercase + ascii_lowercase + digits) for _ in range(12))
     fain_2 = ''.join(choice(ascii_uppercase + ascii_lowercase + digits) for _ in range(12))
     fain_3 = ''.join(choice(ascii_uppercase + ascii_lowercase + digits) for _ in range(12))
+    fain_4 = ''.join(choice(ascii_uppercase + ascii_lowercase + digits) for _ in range(12))
 
     # Just some basic sums to make sure it works
     af_1_row_1 = AwardFinancialFactory(transaction_obligated_amou=1100, fain=fain_1, allocation_transfer_agency=None)
@@ -36,6 +37,9 @@ def test_success(database):
     # Ignored row with non-matching ATA/AID
     af_3 = AwardFinancialFactory(transaction_obligated_amou=8888, fain=fain_3, allocation_transfer_agency='good',
                                  agency_identifier='bad')
+    # No TOA in File C, ignored
+    af_4 = AwardFinancialFactory(transaction_obligated_amou=None, piid=fain_4.lower(),
+                                 allocation_transfer_agency='good', agency_identifier='good')
 
     # Fain sums for AFA
     afa_1_row_1 = AwardFinancialAssistanceFactory(fain=fain_1, federal_action_obligation=-1100,
@@ -57,9 +61,12 @@ def test_success(database):
     # Fain 3 test for ignoring a non-matching ATA/AID
     afa_3 = AwardFinancialAssistanceFactory(fain=fain_3, federal_action_obligation=-9999, record_type='3')
 
-    errors = number_of_errors(_FILE, database, models=[af_1_row_1, af_1_row_2, af_2_row_1, af_2_row_2, af_3,
+    # This one matches but will be ignored
+    afa_4 = AwardFinancialAssistanceFactory(fain=fain_4, federal_action_obligation=-9999)
+
+    errors = number_of_errors(_FILE, database, models=[af_1_row_1, af_1_row_2, af_2_row_1, af_2_row_2, af_3, af_4,
                                                        afa_1_row_1, afa_1_row_2, afa_1_row_3, afa_1_row_4, afa_1_row_5,
-                                                       afa_2, afa_3])
+                                                       afa_2, afa_3, afa_4])
     assert errors == 0
 
 
@@ -72,6 +79,7 @@ def test_failure(database):
     fain_1 = ''.join(choice(ascii_uppercase + ascii_lowercase + digits) for _ in range(12))
     fain_2 = ''.join(choice(ascii_uppercase + ascii_lowercase + digits) for _ in range(12))
     fain_3 = ''.join(choice(ascii_uppercase + ascii_lowercase + digits) for _ in range(12))
+    fain_4 = ''.join(choice(ascii_uppercase + ascii_lowercase + digits) for _ in range(12))
 
     # Simple addition that doesn't add up right
     af_1_row_1 = AwardFinancialFactory(transaction_obligated_amou=1100, fain=fain_1, allocation_transfer_agency=None)
@@ -81,6 +89,9 @@ def test_failure(database):
     af_2 = AwardFinancialFactory(transaction_obligated_amou=9999, fain=fain_2, allocation_transfer_agency=None)
     # Don't ignore when ATA and AID match
     af_3 = AwardFinancialFactory(transaction_obligated_amou=1111, fain=fain_3, allocation_transfer_agency='good',
+                                 agency_identifier='good')
+    # Not ignored with TOA of 0
+    af_4 = AwardFinancialFactory(transaction_obligated_amou=0, fain=fain_4, allocation_transfer_agency='good',
                                  agency_identifier='good')
 
     # Sum of this fain doesn't add up to af fain sum
@@ -97,7 +108,10 @@ def test_failure(database):
     # This shouldn't be ignored
     afa_3 = AwardFinancialAssistanceFactory(fain=fain_3, federal_action_obligation=0, original_loan_subsidy_cost=None,
                                             record_type='2')
+    # Shouldn't be ignored with a TOA of 0
+    afa_4 = AwardFinancialAssistanceFactory(fain=fain_4, federal_action_obligation=1, original_loan_subsidy_cost=None,
+                                            record_type='2')
 
-    errors = number_of_errors(_FILE, database, models=[af_1_row_1, af_1_row_2, af_2, af_3, afa_1_row_1, afa_1_row_2,
-                                                       afa_2_row_1, afa_2_row_2, afa_3])
-    assert errors == 3
+    errors = number_of_errors(_FILE, database, models=[af_1_row_1, af_1_row_2, af_2, af_3, af_4, afa_1_row_1,
+                                                       afa_1_row_2, afa_2_row_1, afa_2_row_2, afa_3, afa_4])
+    assert errors == 4


### PR DESCRIPTION
**High level description:**
Updating C23 to only trigger when TOA is not null

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-5954](https://federal-spending-transparency.atlassian.net/browse/DEV-5954)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Tested locally
- Frontend impact assessment completed
- Documentation Updated