### PR TITLE
DEV-6194: Starting with Long Rows Bug

### DIFF
--- a/tests/integration/data/appropReadError.csv
+++ b/tests/integration/data/appropReadError.csv
@@ -1,9 +1,9 @@
 allocationtransferagencyidentifier,agencyidentifier,beginningperiodofavailability,endingperiodofavailability,availabilitytypecode,mainaccountcode,subaccountcode,budgetauthorityunobligatedbalancebroughtforward_fyb,budgetauthorityappropriatedamount_cpe,budgetauthorityadjustmentstotal_cpe,adjustmentstounobligatedbalancebroughtforward_cpe,borrowingauthorityamounttotal_cpe,contractauthorityamounttotal_cpe,spendingauthorityfromoffsettingcollectionsamounttotal_cpe,otherbudgetaryresourcesamount_cpe,totalbudgetaryresources_cpe,grossoutlayamountbytas_cpe,obligationsincurredtotalbytas_cpe,deobligationsrecoveriesrefundsbytas_cpe,unobligatedbalance_cpe,statusofbudgetaryresourcestotal_cpe,flex_field_a,flex_field_b
-19,72,,,X,306,0,3.03,1.01,3500.5,2.02,1.51,2.02,0.51,4.04,10.1,3500.5,8.08,3500.5,2.02,10.1,FLEX_A,FLEX_B
-,19,2016,2016,,113,0,3.03,1.01,3500,2.02,1.51,2.02,0.51,4.04,10.1,,FLEX_A,FLEX_B
+19,72,,,X,306,0,3.03,1.01,3500.5,2.02,1.51,2.02,0.51,4.04,10.1,3500.5,8.08,3500.5,2.02,10.1,FLEX_A,FLEX_B,FLEX_C
+,19,2016,2016,,113,0,3.03,1.01,3500,2.02,1.51,2.02,0.51,4.04,10.1,3500,8.08,3500,2.02,10.1,FLEX_A,FLEX_B,FLEX_C
 ,28,,,X,406,0,3.03,1.01,3500,2.02,1.51,2.02,0.51,4.04,10.1,3500,8.08,3500,2.02,10.1,FLEX_A,FLEX_B
-,28,2010,2011,,406,0,3.03,1.01,3500,2.02,1.51,2.02,0.51,4.04,10.1,3500,8.08,3500,2.02,10.1,FLEX_A,FLEX_B
-69,13,,,X,2050,5,3.03,1.01,3500,2.02,1.51,2.02,0.51,4.04,10.1,3500,8.08,3500,2.02,FLEX_A,FLEX_B
+,28,2010,2011,,406,0,3.03,1.01,3500,2.02,1.51,2.02,0.51,4.04,10.1,3500,8.08,3500,2.02,10.1
+69,13,,,X,2050,5,3.03,1.01,3500,2.02,1.51,2.02,0.51,4.04,10.1,3500,8.08,3500,2.02,10.1,FLEX_A,FLEX_B
 28,28,,,X,8007,0,3.03,1.01,3500,2.02,1.51,2.02,0.51,4.04,10.1,3500,8.08,3500,2.02,10.1,FLEX_A,FLEX_B,FLEX_C
 ,49,,,X,100,0,3.03,1.01,3500,2.02,1.51,2.02,0.51,4.04,10.1,3500,8.08,3500,2.02,10.1,FLEX_A,FLEX_B
 ,49,2010,2011,,100,0,3.03,1.01,3500,2.02,1.51,2.02,0.51,4.04,10.1,3500,8.08,3500,2.02,10.1,FLEX_A,FLEX_B

--- a/tests/integration/error_warning_file_tests.py
+++ b/tests/integration/error_warning_file_tests.py
@@ -65,7 +65,7 @@ class ErrorWarningTests(BaseTestValidator):
             submission: the submission foundation to be used for all the tests
             val_job: the validation job to be used for all the tests
     """
-    CHUNK_SIZES = [2]
+    CHUNK_SIZES = [4]
     PARALLEL_OPTIONS = [True, False]
     BATCH_SQL_OPTIONS = [True, False]
     CONFIGS = list(itertools.product(CHUNK_SIZES, PARALLEL_OPTIONS, BATCH_SQL_OPTIONS))
@@ -429,17 +429,28 @@ class ErrorWarningTests(BaseTestValidator):
         # Read Error
         report_headers, report_content = self.generate_file_report(READ_ERROR, 'appropriations', warning=False)
         appro_count = self.session.query(Appropriation).filter_by(submission_id=self.submission_id).count()
-        assert appro_count == 7
+        assert appro_count == 6
         flex_count = self.session.query(FlexField).filter_by(submission_id=self.submission_id).count()
-        assert flex_count == 14
+        assert flex_count == 12
         assert self.validator.job.number_of_rows == 11
-        assert self.validator.job.number_of_rows_valid == 7
+        assert self.validator.job.number_of_rows_valid == 6
         format_errors = self.session.query(ErrorMetadata).filter_by(job_id=self.val_job.job_id,
                                                                     severity_id=RULE_SEVERITY_DICT['fatal']).one()
         format_error_count = format_errors.occurrences
-        assert format_error_count == 3
+        assert format_error_count == 4
         assert report_headers == self.validator.report_headers
         expected_values = [
+            {
+                'Unique ID': '',
+                'Field Name': 'Formatting Error',
+                'Rule Message': 'Could not parse this record correctly.',
+                'Value Provided': '',
+                'Expected Value': '',
+                'Difference': '',
+                'Flex Field': '',
+                'Row Number': '2',
+                'Rule Label': ''
+            },
             {
                 'Unique ID': '',
                 'Field Name': 'Formatting Error',
@@ -459,7 +470,7 @@ class ErrorWarningTests(BaseTestValidator):
                 'Expected Value': '',
                 'Difference': '',
                 'Flex Field': '',
-                'Row Number': '6',
+                'Row Number': '5',
                 'Rule Label': ''
             },
             {

--- a/tests/unit/dataactbroker/test_validation_helper.py
+++ b/tests/unit/dataactbroker/test_validation_helper.py
@@ -516,5 +516,5 @@ def test_process_formatting_errors():
 
 def test_simple_file_scan():
     # Note: only testing locally
-    assert validation_helper.simple_file_scan(CsvReader(), None, None, READ_ERROR) == (11, [3, 6], [7], [], [])
+    assert validation_helper.simple_file_scan(CsvReader(), None, None, READ_ERROR) == (11, [5], [2, 3, 7], [], [])
     assert validation_helper.simple_file_scan(CsvReader(), None, None, BLANK_C) == (5, [], [], [3], [4])


### PR DESCRIPTION
**High level description:**
It was discovered that when uploading a file that started off with rows with too many fields, it failed the job. This resolves that by skipping said long rows in the beginning.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-6194](https://federal-spending-transparency.atlassian.net/browse/DEV-6194)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Merged after #1973
- [x] Unit & integration tests updated with relevant test cases
- [x] Manually tested
- Frontend impact assessment completed
- Documentation Updated