### PR TITLE
DTI Warmfix: SQS Endpoint URL Configuration

### DIFF
--- a/dataactcore/aws/sqsHandler.py
+++ b/dataactcore/aws/sqsHandler.py
@@ -107,10 +107,7 @@ def sqs_queue(region_name=CONFIG_BROKER['aws_region'], queue_name=CONFIG_BROKER[
         return SQSMockQueue()
     else:
         # stuff that's in get_queue
-        endpoint_url_format = 'https://sqs.{}.amazonaws.com'
-        if CONFIG_BROKER['use_legacy_queue_endpoint']:
-            endpoint_url_format = 'https://{}.queue.amazonaws.com'
-        endpoint_url = endpoint_url_format.format(region_name)
-        sqs = boto3.resource('sqs', endpoint_url=endpoint_url)
+        # Using endpoint_url as botocore defaults to the legacy endpoint url 'https://{env}.queue.amazonaws.com'
+        sqs = boto3.resource('sqs', endpoint_url='https://sqs.{}.amazonaws.com'.format(region_name))
         queue = sqs.get_queue_by_name(QueueName=queue_name)
         return queue

--- a/dataactcore/aws/sqsHandler.py
+++ b/dataactcore/aws/sqsHandler.py
@@ -107,6 +107,10 @@ def sqs_queue(region_name=CONFIG_BROKER['aws_region'], queue_name=CONFIG_BROKER[
         return SQSMockQueue()
     else:
         # stuff that's in get_queue
-        sqs = boto3.resource('sqs', region_name)
+        endpoint_url_format = 'https://sqs.{}.amazonaws.com'
+        if CONFIG_BROKER['use_legacy_queue_endpoint']:
+            endpoint_url_format = 'https://{}.queue.amazonaws.com'
+        endpoint_url = endpoint_url_format.format(region_name)
+        sqs = boto3.resource('sqs', endpoint_url=endpoint_url)
         queue = sqs.get_queue_by_name(QueueName=queue_name)
         return queue

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -23,8 +23,6 @@ broker:
     full_url: http://localhost:3000
 
     sqs_queue_name: sqs-queue-name
-    # whether to use the legacy SQS url (default in boto3) or not
-    use_legacy_queue_endpoint: false
 
 
     # Set the key (string) used to serialize tokens for email validations.

--- a/dataactcore/config_example.yml
+++ b/dataactcore/config_example.yml
@@ -23,6 +23,8 @@ broker:
     full_url: http://localhost:3000
 
     sqs_queue_name: sqs-queue-name
+    # whether to use the legacy SQS url (default in boto3) or not
+    use_legacy_queue_endpoint: false
 
 
     # Set the key (string) used to serialize tokens for email validations.


### PR DESCRIPTION
**High level description:**
Botocore uses the legacy SQS endpoint url which is not acceptable on the DTI environment. This config value sets whether to use the new one or legacy.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[BRUS2DTI-379](https://federal-spending-transparency.atlassian.net/browse/BRUS2DTI-379)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Tested locally connected to DAOI sandbox with a test script testing both config values and successfully added messages to a test bucket
```
from dataactcore.aws.sqsHandler import sqs_queue
queue = sqs_queue()
message_attr = {"test_type": {"DataType": "String", "StringValue": "test"}}
queue.send_message(MessageBody="TEST BODY", MessageAttributes=message_attr)
```
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated