### PR TITLE
Warmfix: Including region_name in addition to endpoint_url

### DIFF
--- a/dataactcore/aws/sqsHandler.py
+++ b/dataactcore/aws/sqsHandler.py
@@ -108,6 +108,7 @@ def sqs_queue(region_name=CONFIG_BROKER['aws_region'], queue_name=CONFIG_BROKER[
     else:
         # stuff that's in get_queue
         # Using endpoint_url as botocore defaults to the legacy endpoint url 'https://{env}.queue.amazonaws.com'
-        sqs = boto3.resource('sqs', endpoint_url='https://sqs.{}.amazonaws.com'.format(region_name))
+        sqs = boto3.resource('sqs', endpoint_url='https://sqs.{}.amazonaws.com'.format(region_name),
+                             region_name=region_name)
         queue = sqs.get_queue_by_name(QueueName=queue_name)
         return queue


### PR DESCRIPTION
**High level description:**
Even though it didn't raise this locally, it turns out the call still needs `region_name` despite the endpoint url including it.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[BRUS2DTI-379](https://federal-spending-transparency.atlassian.net/browse/BRUS2DTI-379)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Tested on DAOI sandbox - https://broker-sandbox.usaspending.gov/#/submission/31365/validateData/
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated