### PR TITLE
DEV-6347: backfill display tas

### DIFF
--- a/dataactcore/scripts/backfill_displaytas.py
+++ b/dataactcore/scripts/backfill_displaytas.py
@@ -8,7 +8,7 @@ from dataactvalidator.health_check import create_app
 logger = logging.getLogger(__name__)
 
 BACKFILL_DISPLAYTAS_SF133_SQL = """
-    UPDATE sf_133
+    UPDATE {}
     SET display_tas =
         CONCAT_WS(
             '-',
@@ -29,10 +29,16 @@ if __name__ == '__main__':
     with create_app().app_context():
         sess = GlobalDB.db().session
 
-        logger.info('Backfilling empty display_tas values in the sf_133 table.')
-        executed = sess.execute(BACKFILL_DISPLAYTAS_SF133_SQL)
+        logger.info('Starting display_tas backfill script.')
+
+        table_list = ['sf_133', 'appropriation', 'object_class_program_activity', 'award_financial',
+                      'certified_appropriation', 'certified_object_class_program_activity', 'certified_award_financial']
+        for table in table_list:
+            logger.info('Backfilling empty display_tas values in the {} table.'.format(table))
+            executed = sess.execute(BACKFILL_DISPLAYTAS_SF133_SQL.format(table))
+            logger.info('Backfill completed, {} rows affected\n'.format(executed.rowcount))
         sess.commit()
 
-        logger.info('Backfill completed, {} rows affected\n'.format(executed.rowcount))
+        logger.info('Completed display_tas backfill script')
 
         sess.close()

--- a/dataactcore/scripts/backfill_displaytas_sf133.py
+++ b/dataactcore/scripts/backfill_displaytas_sf133.py
@@ -10,16 +10,15 @@ logger = logging.getLogger(__name__)
 BACKFILL_DISPLAYTAS_SF133_SQL = """
     UPDATE sf_133
     SET display_tas =
-        CONCAT(
-            COALESCE(allocation_transfer_agency || '-', ''),
-            COALESCE(agency_identifier || '-', ''),
-            CASE WHEN availability_type_code IS NOT NULL THEN availability_type_code
-                WHEN beginning_period_of_availa IS NOT NULL AND ending_period_of_availabil IS NOT NULL
-                    THEN beginning_period_of_availa || '/' || ending_period_of_availabil
-                ELSE ''
+        CONCAT_WS(
+            '-',
+            allocation_transfer_agency,
+            agency_identifier,
+            CASE WHEN availability_type_code IS NOT NULL AND availability_type_code <> '' THEN availability_type_code
+                ELSE CONCAT_WS('/', beginning_period_of_availa, ending_period_of_availabil)
                 END,
-            COALESCE('-' || main_account_code, ''),
-            COALESCE('-' || sub_account_code, '')
+            main_account_code,
+            sub_account_code
         )
     WHERE display_tas IS NULL;
 """


### PR DESCRIPTION
**High level description:**
Updating an existing `display_tas` backfill script to backfill not only SF133 but also the staging tables for A, B, and C files and the related certified tables.

**Technical details:**
Also updating the backfill script to more accurately generate the `display_tas`. Basing the updated code on this USAS code to generate the TAS they display https://github.com/fedspendingtransparency/usaspending-api/blob/dev/usaspending_api/references/management/sql/restock_tas.sql

**Link to JIRA Ticket:**
[DEV-6347](https://federal-spending-transparency.atlassian.net/browse/DEV-6347)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated