### PR TITLE
Hotfix: WSDL SOAP SUDS HTTP Proxies

### DIFF
--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -12,6 +12,7 @@ from suds.xsd import doctor
 from dataactcore.config import CONFIG_BROKER
 from dataactcore.models.fsrs import FSRSProcurement, FSRSSubcontract, FSRSGrant, FSRSSubgrant
 from dataactcore.models.domainModels import States
+from dataactbroker.helpers.generic_helper import WellBehavedHttpTransport
 
 logger = logging.getLogger(__name__)
 PROCUREMENT = 'procurement_service'
@@ -147,15 +148,7 @@ def new_client(service_type):
             password=config['password'],
             timeout=300)
 
-    proxy_options = {}
-    http_proxy = os.environ.get('HTTP_PROXY')
-    if http_proxy:
-        proxy_options['http'] = http_proxy
-    https_proxy = os.environ.get('HTTPS_PROXY')
-    if https_proxy:
-        proxy_options['https'] = https_proxy
-    if proxy_options:
-        options['proxy'] = proxy_options
+    options['transport'] = WellBehavedHttpTransport()
 
     return Client(**options)
 

--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -12,7 +12,7 @@ from suds.xsd import doctor
 from dataactcore.config import CONFIG_BROKER
 from dataactcore.models.fsrs import FSRSProcurement, FSRSSubcontract, FSRSGrant, FSRSSubgrant
 from dataactcore.models.domainModels import States
-from dataactbroker.helpers.generic_helper import WellBehavedHttpTransport
+from dataactbroker.helpers.generic_helper import WellBehavedHttpsTransport
 
 logger = logging.getLogger(__name__)
 PROCUREMENT = 'procurement_service'
@@ -148,7 +148,7 @@ def new_client(service_type):
             password=config['password'],
             timeout=300)
 
-    options['transport'] = WellBehavedHttpTransport()
+    options['transport'] = WellBehavedHttpsTransport()
 
     return Client(**options)
 

--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -143,12 +143,10 @@ def new_client(service_type):
     options['plugins'] = [ControlFilter(), ZeroDateFilter()]
 
     if config.get('username') and config.get('password'):
-        options['transport'] = HttpAuthenticated(
+        options['transport'] = WellBehavedHttpsTransport(
             username=config['username'],
             password=config['password'],
             timeout=300)
-
-    options['transport'] = WellBehavedHttpsTransport()
 
     return Client(**options)
 

--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -1,5 +1,6 @@
 import logging
 import unicodedata
+import os
 from urllib.parse import urlparse
 
 from suds import sudsobject
@@ -145,6 +146,16 @@ def new_client(service_type):
             username=config['username'],
             password=config['password'],
             timeout=300)
+
+    proxy_options = {}
+    http_proxy = os.environ.get('HTTP_PROXY')
+    if http_proxy:
+        proxy_options['http'] = http_proxy
+    https_proxy = os.environ.get('HTTPS_PROXY')
+    if https_proxy:
+        proxy_options['https'] = https_proxy
+    if proxy_options:
+        options['proxy'] = proxy_options
 
     return Client(**options)
 

--- a/dataactbroker/fsrs.py
+++ b/dataactbroker/fsrs.py
@@ -1,12 +1,10 @@
 import logging
 import unicodedata
-import os
 from urllib.parse import urlparse
 
 from suds import sudsobject
 from suds.client import Client
 from suds.plugin import MessagePlugin
-from suds.transport.https import HttpAuthenticated
 from suds.xsd import doctor
 
 from dataactcore.config import CONFIG_BROKER

--- a/dataactbroker/helpers/generic_helper.py
+++ b/dataactbroker/helpers/generic_helper.py
@@ -5,7 +5,7 @@ import datetime as dt
 import os
 
 from suds.client import Client
-from suds.transport.http import HttpTransport as SudsHttpTransport
+from suds.transport.https import HttpsTransport as SudsHttpsTransport
 
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.sql.sqltypes import String, DateTime, NullType, Date
@@ -55,8 +55,8 @@ class LiteralDialect(PGDialect):
         NullType: StringLiteral,
     }
 
-class WellBehavedHttpTransport(SudsHttpTransport):
-    """ HttpTransport which properly obeys the ``*_proxy`` environment variables."""
+class WellBehavedHttpsTransport(SudsHttpsTransport):
+    """ HttpsTransport which properly obeys the ``*_proxy`` environment variables."""
 
     def u2handlers(self):
         """ Return a list of specific handlers to add.
@@ -139,7 +139,7 @@ def format_internal_tas(row):
 
 def get_client():
     """ Get the Client to access SAM. """
-    options = {'transport': WellBehavedHttpTransport()}
+    options = {'transport': WellBehavedHttpsTransport()}
 
     try:
         client = Client(CONFIG_BROKER['sam']['wsdl'], **options)

--- a/dataactbroker/helpers/generic_helper.py
+++ b/dataactbroker/helpers/generic_helper.py
@@ -140,7 +140,8 @@ def format_internal_tas(row):
 
 def get_client():
     """ Get the Client to access SAM. """
-    options = {'transport': WellBehavedHttpsTransport()}
+    options = {'transport': WellBehavedHttpsTransport(username=CONFIG_BROKER['sam']['username'],
+                                                      password=CONFIG_BROKER['sam']['password'])}
 
     try:
         client = Client(CONFIG_BROKER['sam']['wsdl'], **options)

--- a/dataactbroker/helpers/generic_helper.py
+++ b/dataactbroker/helpers/generic_helper.py
@@ -77,8 +77,8 @@ class WellBehavedHttpsTransport(SudsHttpsTransport):
         Configuration on Mac OS, ...) to determine which proxies to use for
         the current protocol, and when not to use a proxy (no_proxy).
 
-        Thus, passing an empty list will use the default ProxyHandler which
-        behaves correctly.
+        Thus, passing an empty list (asides from the BasicAuthHandler)
+        will use the default ProxyHandler which behaves correctly.
         """
         return [HTTPBasicAuthHandler(self.pm)]
 

--- a/dataactbroker/helpers/generic_helper.py
+++ b/dataactbroker/helpers/generic_helper.py
@@ -2,6 +2,7 @@ import re
 import calendar
 from dateutil.parser import parse
 import datetime as dt
+import os
 
 from suds.client import Client
 
@@ -112,8 +113,19 @@ def format_internal_tas(row):
 
 def get_client():
     """ Get the Client to access SAM. """
+    options = {}
+    proxy_options = {}
+    http_proxy = os.environ.get('HTTP_PROXY')
+    if http_proxy:
+        proxy_options['http'] = http_proxy
+    https_proxy = os.environ.get('HTTPS_PROXY')
+    if https_proxy:
+        proxy_options['https'] = https_proxy
+    if proxy_options:
+        options['proxy'] = proxy_options
+
     try:
-        client = Client(CONFIG_BROKER['sam']['wsdl'])
+        client = Client(CONFIG_BROKER['sam']['wsdl'], **options)
     except ConnectionResetError:
         raise ResponseException("Unable to contact SAM service, which may be experiencing downtime or intermittent "
                                 "performance issues. Please try again later.", StatusCode.NOT_FOUND)

--- a/dataactbroker/helpers/generic_helper.py
+++ b/dataactbroker/helpers/generic_helper.py
@@ -3,7 +3,7 @@ import calendar
 from dateutil.parser import parse
 import datetime as dt
 import os
-import urllib2
+from urllib.request import HTTPBasicAuthHandler
 
 from suds.client import Client
 from suds.transport.https import HttpAuthenticated as SudsHttpsTransport
@@ -81,7 +81,7 @@ class WellBehavedHttpsTransport(SudsHttpsTransport):
         Thus, passing an empty list will use the default ProxyHandler which
         behaves correctly.
         """
-        return [urllib2.HTTPBasicAuthHandler(self.pm)]
+        return [HTTPBasicAuthHandler(self.pm)]
 
 
 def year_period_to_dates(year, period):

--- a/dataactbroker/helpers/generic_helper.py
+++ b/dataactbroker/helpers/generic_helper.py
@@ -3,9 +3,12 @@ import calendar
 from dateutil.parser import parse
 import datetime as dt
 import os
+import urllib2
 
 from suds.client import Client
 from suds.transport.https import HttpAuthenticated as SudsHttpsTransport
+from suds.transport.http import HttpTransport
+
 
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.sql.sqltypes import String, DateTime, NullType, Date
@@ -78,7 +81,7 @@ class WellBehavedHttpsTransport(SudsHttpsTransport):
         Thus, passing an empty list will use the default ProxyHandler which
         behaves correctly.
         """
-        return []
+        return [urllib2.HTTPBasicAuthHandler(self.pm)]
 
 
 def year_period_to_dates(year, period):

--- a/dataactbroker/helpers/generic_helper.py
+++ b/dataactbroker/helpers/generic_helper.py
@@ -56,6 +56,7 @@ class LiteralDialect(PGDialect):
         NullType: StringLiteral,
     }
 
+
 class WellBehavedHttpsTransport(SudsHttpsTransport):
     """ HttpsTransport which properly obeys the ``*_proxy`` environment variables."""
 

--- a/dataactbroker/helpers/generic_helper.py
+++ b/dataactbroker/helpers/generic_helper.py
@@ -2,12 +2,10 @@ import re
 import calendar
 from dateutil.parser import parse
 import datetime as dt
-import os
-from urllib.request import HTTPBasicAuthHandler
 
 from suds.client import Client
 from suds.transport.https import HttpAuthenticated as SudsHttpsTransport
-from suds.transport.http import HttpTransport
+from urllib.request import HTTPBasicAuthHandler
 
 
 from sqlalchemy.dialects.postgresql.base import PGDialect

--- a/dataactbroker/helpers/generic_helper.py
+++ b/dataactbroker/helpers/generic_helper.py
@@ -5,7 +5,7 @@ import datetime as dt
 import os
 
 from suds.client import Client
-from suds.transport.https import HttpsTransport as SudsHttpsTransport
+from suds.transport.https import HttpAuthenticated as SudsHttpsTransport
 
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.sql.sqltypes import String, DateTime, NullType, Date

--- a/dataactbroker/scripts/load_fsrs.py
+++ b/dataactbroker/scripts/load_fsrs.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
         }
 
         # Setups state mapping for deriving state name
-        config_state_mappings(sess, init=True)
+        # config_state_mappings(sess, init=True)
 
         if not config_valid():
             logger.error("No config for broker/fsrs/[service]/wsdl")

--- a/dataactbroker/scripts/load_fsrs.py
+++ b/dataactbroker/scripts/load_fsrs.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
         }
 
         # Setups state mapping for deriving state name
-        # config_state_mappings(sess, init=True)
+        config_state_mappings(sess, init=True)
 
         if not config_valid():
             logger.error("No config for broker/fsrs/[service]/wsdl")
@@ -74,14 +74,14 @@ if __name__ == '__main__':
             # Regular FSRS data load, starts where last load left off
             updated_proc_internal_ids = []
             updated_grant_internal_ids = []
-            # original_min_procurement_id = SERVICE_MODEL[PROCUREMENT].next_id(sess)
-            # original_min_grant_id = SERVICE_MODEL[GRANT].next_id(sess)
-            # last_updated_at = sess.query(func.max(Subaward.updated_at)).one_or_none()[0]
+            original_min_procurement_id = SERVICE_MODEL[PROCUREMENT].next_id(sess)
+            original_min_grant_id = SERVICE_MODEL[GRANT].next_id(sess)
+            last_updated_at = sess.query(func.max(Subaward.updated_at)).one_or_none()[0]
             if len(sys.argv) <= 1:
                 # there may be more transaction data since we've last run, let's fix any links before importing new data
-                # if last_updated_at:
-                #     fix_broken_links(sess, PROCUREMENT, min_date=last_updated_at)
-                #     fix_broken_links(sess, GRANT, min_date=last_updated_at)
+                if last_updated_at:
+                    fix_broken_links(sess, PROCUREMENT, min_date=last_updated_at)
+                    fix_broken_links(sess, GRANT, min_date=last_updated_at)
 
                 awards = ['Starting']
                 logger.info('Loading latest FSRS reports')

--- a/dataactbroker/scripts/load_fsrs.py
+++ b/dataactbroker/scripts/load_fsrs.py
@@ -79,9 +79,9 @@ if __name__ == '__main__':
             last_updated_at = sess.query(func.max(Subaward.updated_at)).one_or_none()[0]
             if len(sys.argv) <= 1:
                 # there may be more transaction data since we've last run, let's fix any links before importing new data
-                if last_updated_at:
-                    fix_broken_links(sess, PROCUREMENT, min_date=last_updated_at)
-                    fix_broken_links(sess, GRANT, min_date=last_updated_at)
+                # if last_updated_at:
+                #     fix_broken_links(sess, PROCUREMENT, min_date=last_updated_at)
+                #     fix_broken_links(sess, GRANT, min_date=last_updated_at)
 
                 awards = ['Starting']
                 logger.info('Loading latest FSRS reports')

--- a/dataactbroker/scripts/load_fsrs.py
+++ b/dataactbroker/scripts/load_fsrs.py
@@ -74,9 +74,9 @@ if __name__ == '__main__':
             # Regular FSRS data load, starts where last load left off
             updated_proc_internal_ids = []
             updated_grant_internal_ids = []
-            original_min_procurement_id = SERVICE_MODEL[PROCUREMENT].next_id(sess)
-            original_min_grant_id = SERVICE_MODEL[GRANT].next_id(sess)
-            last_updated_at = sess.query(func.max(Subaward.updated_at)).one_or_none()[0]
+            # original_min_procurement_id = SERVICE_MODEL[PROCUREMENT].next_id(sess)
+            # original_min_grant_id = SERVICE_MODEL[GRANT].next_id(sess)
+            # last_updated_at = sess.query(func.max(Subaward.updated_at)).one_or_none()[0]
             if len(sys.argv) <= 1:
                 # there may be more transaction data since we've last run, let's fix any links before importing new data
                 # if last_updated_at:


### PR DESCRIPTION
**High level description:**
The current implementation and use of suds doesn't account for http proxies. This makes the FSRS and DUNS historical loads break on the DTI environment. This PR simply uses the HTTP proxy environment variables if there are any. 

**Technical details:**
N/A

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Successfully tested with the [DTI subaward load](http://10.117.0.20:8080/job/Broker-FSRS-Subaward-Load/906/console)
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated