### PR TITLE
Hotfix: DUNS loader updates (http proxy, tempfiles)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7
 
 RUN apt-get -y update
 RUN apt-get install -y postgresql-client
-RUN apt-get install -y netcat
+RUN apt-get install -y netcat-openbsd
 
 RUN pip install unittest-xml-reporting
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.7
 
 RUN apt-get -y update
 RUN apt-get install -y postgresql-client
+RUN apt-get install -y netcat
 
 RUN pip install unittest-xml-reporting
 

--- a/dataactcore/scripts/derive_historical_transaction_exec_comp.py
+++ b/dataactcore/scripts/derive_historical_transaction_exec_comp.py
@@ -3,7 +3,6 @@ import argparse
 import re
 import tempfile
 
-from dataactcore.config import CONFIG_BROKER
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.logging import configure_logging
 from dataactcore.utils.duns import get_client, REMOTE_SAM_EXEC_COMP_DIR, parse_exec_comp_file, \

--- a/dataactcore/scripts/derive_historical_transaction_exec_comp.py
+++ b/dataactcore/scripts/derive_historical_transaction_exec_comp.py
@@ -1,6 +1,7 @@
 import logging
 import argparse
 import re
+import tempfile
 
 from dataactcore.config import CONFIG_BROKER
 from dataactcore.interfaces.db import GlobalDB
@@ -77,7 +78,7 @@ def main():
     sess = GlobalDB.db().session
 
     if args.ssh_key:
-        root_dir = CONFIG_BROKER['d_file_storage_path']
+        root_dir = tempfile.gettempdir()
         # dirlist on remote host
         client = get_client(ssh_key=args.ssh_key)
         sftp = client.open_sftp()

--- a/dataactcore/scripts/load_duns.py
+++ b/dataactcore/scripts/load_duns.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import json
+import tempfile
 
 from dataactcore.config import CONFIG_BROKER
 from dataactcore.interfaces.db import GlobalDB
@@ -34,7 +35,7 @@ def process_duns_dir(sess, historic, local, benchmarks=None, metrics=None):
     # dealing with a local or remote directory
     sftp = None
     if not local:
-        root_dir = CONFIG_BROKER["d_file_storage_path"]
+        root_dir = tempfile.gettempdir()
         client = get_client()
         sftp = client.open_sftp()
         # dirlist on remote host

--- a/dataactcore/scripts/load_duns.py
+++ b/dataactcore/scripts/load_duns.py
@@ -6,7 +6,6 @@ import re
 import json
 import tempfile
 
-from dataactcore.config import CONFIG_BROKER
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.logging import configure_logging
 from dataactcore.models.domainModels import DUNS

--- a/dataactcore/scripts/load_exec_comp.py
+++ b/dataactcore/scripts/load_exec_comp.py
@@ -4,6 +4,7 @@ import re
 import argparse
 import datetime
 import json
+import tempfile
 
 from dataactcore.models.domainModels import DUNS
 from dataactcore.interfaces.db import GlobalDB
@@ -35,7 +36,7 @@ def process_exec_comp_dir(sess, historic, local, ssh_key, benchmarks=None, metri
     if not (local or ssh_key) or (local and ssh_key):
         raise Exception('Please provide the local param or the ssh key.')
     if ssh_key:
-        root_dir = CONFIG_BROKER['d_file_storage_path']
+        root_dir = tempfile.gettempdir()
         client = get_client(ssh_key=ssh_key)
         sftp = client.open_sftp()
         # dirlist on remote host

--- a/dataactcore/scripts/load_exec_comp.py
+++ b/dataactcore/scripts/load_exec_comp.py
@@ -10,7 +10,6 @@ from dataactcore.models.domainModels import DUNS
 from dataactcore.interfaces.db import GlobalDB
 from dataactcore.logging import configure_logging
 from dataactvalidator.health_check import create_app
-from dataactcore.config import CONFIG_BROKER
 from dataactcore.utils.duns import get_client, REMOTE_SAM_EXEC_COMP_DIR, parse_exec_comp_file, update_exec_comp_duns
 
 logger = logging.getLogger(__name__)

--- a/dataactcore/utils/duns.py
+++ b/dataactcore/utils/duns.py
@@ -61,9 +61,8 @@ def get_client(ssh_key=None):
 
     https_proxy = os.environ.get('HTTPS_PROXY')
     if https_proxy:
-        para_proxy = paramiko.ProxyCommand('nc --proxy-type http --proxy {} {} {}'.format(https_proxy[7:-1],
-                                                                                          connect_args['hostname'],
-                                                                                          '22'))
+        para_proxy = paramiko.ProxyCommand('nc --proxy-type http -w 90 --proxy {} {} {}'.format(
+            https_proxy[7:-1], connect_args['hostname'], '22'))
         connect_args['sock'] = para_proxy
 
     client.connect(**connect_args)

--- a/dataactcore/utils/duns.py
+++ b/dataactcore/utils/duns.py
@@ -38,7 +38,7 @@ def get_client(ssh_key=None):
 
     connect_args = {}
     if ssh_key:
-        connect_args['host'] = sam_config.get('host_ssh')
+        connect_args['hostname'] = sam_config.get('host_ssh')
         connect_args['username'] = sam_config.get('username_ssh')
         connect_args['password'] = sam_config.get('password_ssh')
 
@@ -46,12 +46,12 @@ def get_client(ssh_key=None):
         connect_args['pkey'] = paramiko.RSAKey.from_private_key(ssh_key_file,
                                                                 password=sam_config.get('ssh_key_password'))
     else:
-        connect_args['host'] = sam_config.get('host')
+        connect_args['hostname'] = sam_config.get('host')
         connect_args['username'] = sam_config.get('username')
         connect_args['password'] = sam_config.get('password')
         connect_args['pkey'] = None
 
-    if ((None in (connect_args['host'], connect_args['username'], connect_args['password'])) or
+    if ((None in (connect_args['hostname'], connect_args['username'], connect_args['password'])) or
             (ssh_key and not connect_args['pkey'])):
         raise Exception("Missing config elements for connecting to SAM")
 

--- a/dataactcore/utils/duns.py
+++ b/dataactcore/utils/duns.py
@@ -61,7 +61,7 @@ def get_client(ssh_key=None):
 
     https_proxy = os.environ.get('HTTPS_PROXY')
     if https_proxy:
-        para_proxy = paramiko.ProxyCommand('nc --proxy-type http --proxy {} {} {}'.format(https_proxy[7:],
+        para_proxy = paramiko.ProxyCommand('nc --proxy-type http --proxy {} {} {}'.format(https_proxy[7:-1],
                                                                                           connect_args['hostname'],
                                                                                           '22'))
         connect_args['sock'] = para_proxy

--- a/dataactcore/utils/duns.py
+++ b/dataactcore/utils/duns.py
@@ -61,7 +61,7 @@ def get_client(ssh_key=None):
 
     https_proxy = os.environ.get('HTTPS_PROXY')
     if https_proxy:
-        para_proxy = paramiko.ProxyCommand('nc --proxy-type http -w 90 --proxy {} {} {}'.format(
+        para_proxy = paramiko.ProxyCommand('nc -w 90 -X connect -x {} {} {}'.format(
             https_proxy[7:-1], connect_args['hostname'], '22'))
         connect_args['sock'] = para_proxy
 

--- a/dataactcore/utils/duns.py
+++ b/dataactcore/utils/duns.py
@@ -51,8 +51,8 @@ def get_client(ssh_key=None):
         connect_args['password'] = sam_config.get('password')
         connect_args['pkey'] = None
 
-    if ((None in (connect_args['hostname'], connect_args['username'], connect_args['password'])) or
-            (ssh_key and not connect_args['pkey'])):
+    if ((None in (connect_args['hostname'], connect_args['username'], connect_args['password']))
+            or (ssh_key and not connect_args['pkey'])):
         raise Exception("Missing config elements for connecting to SAM")
 
     client = paramiko.SSHClient()

--- a/dataactcore/utils/duns.py
+++ b/dataactcore/utils/duns.py
@@ -61,7 +61,7 @@ def get_client(ssh_key=None):
 
     https_proxy = os.environ.get('HTTPS_PROXY')
     if https_proxy:
-        para_proxy = paramiko.ProxyCommand('nc --proxy-type https --proxy {} %h %p'.format(https_proxy))
+        para_proxy = paramiko.ProxyCommand('nc --proxy-type https --proxy {} %h %p'.format(https_proxy[7:]))
         connect_args['sock'] = para_proxy
 
     client.connect(**connect_args)

--- a/dataactcore/utils/duns.py
+++ b/dataactcore/utils/duns.py
@@ -61,7 +61,9 @@ def get_client(ssh_key=None):
 
     https_proxy = os.environ.get('HTTPS_PROXY')
     if https_proxy:
-        para_proxy = paramiko.ProxyCommand('nc --proxy-type https --proxy {} %h %p'.format(https_proxy[7:]))
+        para_proxy = paramiko.ProxyCommand('nc --proxy-type http --proxy {} {} {}'.format(https_proxy[7:],
+                                                                                          connect_args['hostname'],
+                                                                                          '22'))
         connect_args['sock'] = para_proxy
 
     client.connect(**connect_args)


### PR DESCRIPTION
**High level description:**
The following are necessary changes to the DUNS/Exec Comp loaders to run on the DTI environment.

**Technical details:**
* Running the DUNS load on DTI requires extra work to use the HTTP proxies.
* The loader will use the tempdir instead of `file_d_storage_path` to run within docker containers.

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Successful run on [DTI sandbox](http://10.117.0.20:8080/view/Broker-Jobs/job/Broker-DUNS-Load/937/console)
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated