### PR TITLE
Hotfix: SAM "use_proxy" Config

### DIFF
--- a/dataactcore/utils/duns.py
+++ b/dataactcore/utils/duns.py
@@ -60,7 +60,7 @@ def get_client(ssh_key=None):
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     https_proxy = os.environ.get('HTTPS_PROXY')
-    if https_proxy:
+    if https_proxy and sam_config.get('use_proxy'):
         para_proxy = paramiko.ProxyCommand('nc -w 90 -X connect -x {} {} {}'.format(
             https_proxy[7:-1], connect_args['hostname'], '22'))
         connect_args['sock'] = para_proxy


### PR DESCRIPTION
Turns out using the HTTP_PROXY updates the IP address for outbound SSH connections which need to be whitelisted by SAM. This simply is a band-aid fix that temporarily makes DAOI ignore the proxy for DUNS and respect the proxy for DTI. When the IPs get whitelisted and/or when we migrate to DTI, this line can be reverted along with updating the DTI configs.

- [x] Tested the following:
    - successful run with the config added and set to `true` on DTI sandbox (http://10.117.0.20:8080/job/Broker-DUNS-Load/948/console)
    - failure without the config added on DTI qat (http://10.117.0.20:8080/job/Broker-DUNS-Load/949/console)
    - successful run with the config added and set to `true` on DTI qat (http://10.117.0.20:8080/job/Broker-DUNS-Load/950/console)