### PR TITLE
DEV-6547: B20 pre 2021 exception

### DIFF
--- a/dataactvalidator/config/sqlrules/b20_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b20_object_class_program_activity.sql
@@ -4,6 +4,7 @@
 
 WITH award_financial_b20_{0} AS
     (SELECT row_number,
+        submission_id,
         allocation_transfer_agency,
         agency_identifier,
         beginning_period_of_availa,
@@ -35,6 +36,8 @@ SELECT
     af.program_activity_name AS "uniqueid_ProgramActivityName",
     af.object_class AS "uniqueid_ObjectClass"
 FROM award_financial_b20_{0} AS af
+JOIN submission AS sub
+    ON sub.submission_id = af.submission_id
 WHERE NOT EXISTS (
         SELECT 1
         FROM ocpa_b20_{0} AS op
@@ -51,4 +54,7 @@ WHERE NOT EXISTS (
                     AND op.object_class IN ('0', '00', '000', '0000')
                 )
             )
-    );
+    )
+    AND NOT (UPPER(af.program_activity_code) = 'OPTN'
+        AND UPPER(af.program_activity_name) = 'FIELD IS OPTIONAL PRIOR TO FY21'
+        AND sub.reporting_fiscal_year < 2021);


### PR DESCRIPTION
**High level description:**
Adding ignoring specific pairings of PAC and PAN before the year 2021

**Technical details:**
PAC of `OPTN` and PAN of `FIELD IS OPTIONAL PRIOR TO FY21` (case insensitive) are ignored for B20 prior to FY2021

**Link to JIRA Ticket:**
[DEV-6547](https://federal-spending-transparency.atlassian.net/browse/DEV-6547)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated