### PR TITLE
DEV-6753: prevent fy22 quarterly publish

### DIFF
--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -1009,6 +1009,9 @@ def publish_and_certify_dabs_submission(submission, file_manager):
             A JsonResponse containing the message "success" if successful, JsonResponse error containing the details of
             the error if something went wrong
     """
+    if submission.is_quarter_format and submission.reporting_fiscal_year >= 2022:
+        return JsonResponse.error(ValueError('Quarterly submissions from FY22 onward cannot be published.'),
+                                  StatusCode.CLIENT_ERROR)
     try:
         process_dabs_publish(submission, file_manager)
     except ValueError as e:

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -100,16 +100,20 @@ class FileTests(BaseTestAPI):
                                                                    start_date='04/2015', end_date='06/2015',
                                                                    is_quarter=True, number_of_errors=0)
 
+            cls.test_post_fy22_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code='SYS',
+                                                                 start_date='04/2022', end_date='06/2022',
+                                                                 is_quarter=True, number_of_errors=0)
+
             cls.test_revalidate_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code='SYS',
                                                                   start_date='10/2015', end_date='12/2015',
                                                                   is_quarter=True, number_of_errors=0)
 
             cls.test_monthly_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code='SYS',
-                                                               start_date='04/2015', end_date='06/2015',
+                                                               start_date='04/2022', end_date='06/2022',
                                                                is_quarter=False, number_of_errors=0)
 
             cls.dup_test_monthly_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code='SYS',
-                                                                   start_date='04/2015', end_date='06/2015',
+                                                                   start_date='04/2022', end_date='06/2022',
                                                                    is_quarter=False, number_of_errors=0)
 
             cls.test_monthly_pub_submission_id = insert_submission(sess, cls.submission_user_id, cgac_code='SYS',
@@ -829,6 +833,11 @@ class FileTests(BaseTestAPI):
                                       headers={'x-session-id': self.session_id}, expect_errors=True)
         self.assertEqual(response.json['message'], 'Submission cannot be published due to critical errors')
 
+        post_json = {'submission_id': self.test_post_fy22_submission_id}
+        response = self.app.post_json('/v1/publish_and_certify_dabs_submission/', post_json,
+                                      headers={'x-session-id': self.session_id}, expect_errors=True)
+        self.assertEqual(response.json['message'], 'Quarterly submissions from FY22 onward cannot be published.')
+
         post_json = {'submission_id': self.test_test_submission_id}
         response = self.app.post_json('/v1/publish_and_certify_dabs_submission/', post_json,
                                       headers={'x-session-id': self.session_id}, expect_errors=True)
@@ -842,10 +851,14 @@ class FileTests(BaseTestAPI):
         insert_job(self.session, FILE_TYPE_DICT['appropriations'], JOB_STATUS_DICT['finished'],
                    JOB_TYPE_DICT['csv_record_validation'], self.test_unpublished_submission_id, num_valid_rows=0)
         test_sub = self.session.query(Submission).filter_by(submission_id=self.test_unpublished_submission_id).one()
+        test_sub_2 = self.session.query(Submission).filter_by(submission_id=self.test_monthly_submission_id).one()
         submission_window = SubmissionWindowSchedule(year=test_sub.reporting_fiscal_year,
                                                      period=test_sub.reporting_fiscal_period,
                                                      period_start=datetime.now() - timedelta(days=1))
-        self.session.add(submission_window)
+        submission_window_2 = SubmissionWindowSchedule(year=test_sub_2.reporting_fiscal_year,
+                                                       period=test_sub_2.reporting_fiscal_period,
+                                                       period_start=datetime.now() - timedelta(days=1))
+        self.session.add_all([submission_window, submission_window_2])
         self.session.commit()
         post_json = {'submission_id': self.test_unpublished_submission_id}
         response = self.app.post_json('/v1/publish_and_certify_dabs_submission/', post_json,


### PR DESCRIPTION
**High level description:**
Preventing FY22+ quarterly submission publishing

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-6753](https://federal-spending-transparency.atlassian.net/browse/DEV-6753)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated