### PR TITLE
DEV-4518: require cgac or frec new dabs submission

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -228,6 +228,16 @@ class FileHandler:
                 elif 'existing_submission_id' not in request_params:
                     raise ResponseException('{} is required'.format(request_field), StatusCode.CLIENT_ERROR, ValueError)
 
+            if not existing_submission:
+                cgac_code = submission_data['cgac_code'] or ''
+                frec_code = submission_data['frec_code'] or ''
+                if cgac_code != '' and frec_code != '':
+                    raise ResponseException('New DABS submissions must have either a CGAC or a FREC code but not both',
+                                            StatusCode.CLIENT_ERROR)
+                if cgac_code == '' and frec_code == '':
+                    raise ResponseException('New DABS submissions must have either a CGAC or a FREC code',
+                                            StatusCode.CLIENT_ERROR)
+
             # make sure submission dates are valid
             formatted_start_date, formatted_end_date = FileHandler.check_submission_dates(
                 submission_data.get('reporting_start_date'),

--- a/doc/api_docs/file/upload_dabs_files.md
+++ b/doc/api_docs/file/upload_dabs_files.md
@@ -70,5 +70,7 @@ Possible HTTP Status Codes:
     - Missing parameter
     - Submission does not exist
     - Invalid start/end date combination
+    - Both `cgac_code` and `frec_code` filled with a value in a new submission
+    - Both `cgac_code` and `frec_code` null in a new submission
 - 401: Login required
 - 403: Permission denied, user does not have permission to edit this submission

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -487,6 +487,35 @@ class FileTests(BaseTestAPI):
         self.assertEqual(response.json['message'], 'A monthly submission must be exactly one month with the exception'
                                                    ' of periods 1 and 2, which must be selected together.')
 
+    def test_both_cgac_and_frec(self):
+        """ Test to make sure there's an error if both cgac and frec are included and not null """
+        update_json = {
+            'cgac_code': '020',
+            'frec_code': '0500',
+            'is_quarter': True,
+            'reporting_period_start_date': '10/2016',
+            'reporting_period_end_date': '12/2016'}
+        response = self.app.post('/v1/upload_dabs_files/', update_json,
+                                 upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
+                                 headers={'x-session-id': self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'New DABS submissions must have either a CGAC or a FREC code but not'
+                                                   ' both')
+
+    def test_neither_cgac_nor_frec(self):
+        """ Test to make sure there's an error if both cgac and frec are included and are null """
+        update_json = {
+            'cgac_code': None,
+            'frec_code': None,
+            'is_quarter': True,
+            'reporting_period_start_date': '10/2016',
+            'reporting_period_end_date': '12/2016'}
+        response = self.app.post('/v1/upload_dabs_files/', update_json,
+                                 upload_files=[AWARD_FILE_T, APPROP_FILE_T, PA_FILE_T],
+                                 headers={'x-session-id': self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['message'], 'New DABS submissions must have either a CGAC or a FREC code')
+
     def test_revalidation_threshold_no_login(self):
         """ Test response with no login """
         self.logout()


### PR DESCRIPTION
**High level description:**
Ensures that when making a new DABS submission, API users can't send both cgac and frec codes or leave both of them as null.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-4518](https://federal-spending-transparency.atlassian.net/browse/DEV-4518)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- [x] Documentation Updated