### PR TITLE
DEV-6926: DUNS/Exec Comp Forced Reloads

### DIFF
--- a/dataactcore/scripts/load_duns.py
+++ b/dataactcore/scripts/load_duns.py
@@ -16,7 +16,7 @@ from dataactvalidator.health_check import create_app
 logger = logging.getLogger(__name__)
 
 
-def process_duns_dir(sess, historic, local, benchmarks=None, metrics=None, force_reload=None):
+def process_duns_dir(sess, historic, local, benchmarks=None, metrics=None, reload_date=None):
     """ Process the script arguments to figure out which files to process in which order
 
         Args:
@@ -25,7 +25,7 @@ def process_duns_dir(sess, historic, local, benchmarks=None, metrics=None, force
             local: path to local directory to process, if None, it will go though the remote SAM service
             benchmarks: whether to log times
             metrics: dictionary representing metrics data for the load
-            force_reload: specific date to force reload from
+            reload_date: specific date to force reload from
     """
     if not metrics:
         metrics = {}
@@ -63,9 +63,9 @@ def process_duns_dir(sess, historic, local, benchmarks=None, metrics=None, force
             earliest_daily_file = sorted_monthly_file_names[0].replace("MONTHLY", "DAILY")
         elif not historic:
             # if update, make sure it's been done once before
-            if force_reload:
+            if reload_date:
                 # a bit redundant but also date validation
-                load_date = datetime.datetime.strptime(force_reload, '%Y-%m-%d')
+                load_date = datetime.datetime.strptime(reload_date, '%Y-%m-%d')
             else:
                 load_date = sess.query(DUNS.last_sam_mod_date). \
                     order_by(DUNS.last_sam_mod_date.desc()). \
@@ -140,7 +140,7 @@ def get_parser():
     environ = parser.add_mutually_exclusive_group(required=True)
     environ.add_argument("-l", "--local", type=str, default=None, help='Local directory to work from')
     environ.add_argument("-r", "--remote", action="store_true", help='Work from a remote directory (SAM)')
-    parser.add_argument("-f", "--force_reload", type=str, default=None, help='Force update from a specific date'
+    parser.add_argument("-f", "--reload_date", type=str, default=None, help='Force update from a specific date'
                                                                              ' (YYYY-MM-DD)')
     parser.add_argument("-b", "--benchmarks", action="store_true", help='log times of operations for testing')
     return parser
@@ -158,7 +158,7 @@ if __name__ == '__main__':
     local = args.local
     remote = args.remote
     benchmarks = args.benchmarks
-    force_reload = args.force_reload
+    reload_date = args.reload_date
 
     metrics = {
         'script_name': 'load_duns.py',
@@ -179,7 +179,7 @@ if __name__ == '__main__':
 
     with create_app().app_context():
         sess = GlobalDB.db().session
-        process_duns_dir(sess, historic, local, benchmarks=benchmarks, metrics=metrics, force_reload=force_reload)
+        process_duns_dir(sess, historic, local, benchmarks=benchmarks, metrics=metrics, reload_date=reload_date)
         sess.close()
 
     metrics['records_added'] = len(set(metrics['added_duns']))

--- a/dataactcore/scripts/load_duns.py
+++ b/dataactcore/scripts/load_duns.py
@@ -141,7 +141,7 @@ def get_parser():
     environ.add_argument("-l", "--local", type=str, default=None, help='Local directory to work from')
     environ.add_argument("-r", "--remote", action="store_true", help='Work from a remote directory (SAM)')
     parser.add_argument("-f", "--reload_date", type=str, default=None, help='Force update from a specific date'
-                                                                             ' (YYYY-MM-DD)')
+                                                                            ' (YYYY-MM-DD)')
     parser.add_argument("-b", "--benchmarks", action="store_true", help='log times of operations for testing')
     return parser
 

--- a/dataactcore/scripts/load_duns.py
+++ b/dataactcore/scripts/load_duns.py
@@ -16,7 +16,7 @@ from dataactvalidator.health_check import create_app
 logger = logging.getLogger(__name__)
 
 
-def process_duns_dir(sess, historic, local, benchmarks=None, metrics=None):
+def process_duns_dir(sess, historic, local, benchmarks=None, metrics=None, force_reload=None):
     """ Process the script arguments to figure out which files to process in which order
 
         Args:
@@ -25,6 +25,7 @@ def process_duns_dir(sess, historic, local, benchmarks=None, metrics=None):
             local: path to local directory to process, if None, it will go though the remote SAM service
             benchmarks: whether to log times
             metrics: dictionary representing metrics data for the load
+            force_reload: specific date to force reload from
     """
     if not metrics:
         metrics = {}
@@ -56,21 +57,26 @@ def process_duns_dir(sess, historic, local, benchmarks=None, metrics=None):
 
     # load in daily files after depending on params
     if sorted_daily_file_names:
-        # if update, make sure it's been done once before
-        last_update = sess.query(DUNS.last_sam_mod_date). \
-            order_by(DUNS.last_sam_mod_date.desc()). \
-            filter(DUNS.last_sam_mod_date.isnot(None)). \
-            first()
-        if not historic and not last_update:
-            raise Exception('No last sam mod date found in DUNS table. Please run historic loader first.')
-
         # determine which daily files to load
         earliest_daily_file = None
         if historic and sorted_monthly_file_names:
             earliest_daily_file = sorted_monthly_file_names[0].replace("MONTHLY", "DAILY")
         elif not historic:
-            last_update = last_update[0].strftime("%Y%m%d")
-            earliest_daily_file = re.sub("_DAILY_[0-9]{8}\.ZIP", "_DAILY_" + last_update + ".ZIP",
+            # if update, make sure it's been done once before
+            if force_reload:
+                # a bit redundant but also date validation
+                load_date = datetime.datetime.strptime(force_reload, '%Y-%m-%d')
+            else:
+                load_date = sess.query(DUNS.last_sam_mod_date). \
+                    order_by(DUNS.last_sam_mod_date.desc()). \
+                    filter(DUNS.last_sam_mod_date.isnot(None)). \
+                    first()
+                load_date = load_date[0]
+                if not load_date:
+                    raise Exception('No last sam mod date found in DUNS table. Please run historic loader first.')
+            load_date = load_date.strftime("%Y%m%d")
+
+            earliest_daily_file = re.sub("_DAILY_[0-9]{8}\.ZIP", "_DAILY_" + load_date + ".ZIP",
                                          sorted_daily_file_names[0])
         daily_files_after = sorted_daily_file_names
         if earliest_daily_file:
@@ -134,6 +140,8 @@ def get_parser():
     environ = parser.add_mutually_exclusive_group(required=True)
     environ.add_argument("-l", "--local", type=str, default=None, help='Local directory to work from')
     environ.add_argument("-r", "--remote", action="store_true", help='Work from a remote directory (SAM)')
+    parser.add_argument("-f", "--force_reload", type=str, default=None, help='Force update from a specific date'
+                                                                             ' (YYYY-MM-DD)')
     parser.add_argument("-b", "--benchmarks", action="store_true", help='log times of operations for testing')
     return parser
 
@@ -150,6 +158,7 @@ if __name__ == '__main__':
     local = args.local
     remote = args.remote
     benchmarks = args.benchmarks
+    force_reload = args.force_reload
 
     metrics = {
         'script_name': 'load_duns.py',
@@ -170,7 +179,7 @@ if __name__ == '__main__':
 
     with create_app().app_context():
         sess = GlobalDB.db().session
-        process_duns_dir(sess, historic, local, benchmarks=benchmarks, metrics=metrics)
+        process_duns_dir(sess, historic, local, benchmarks=benchmarks, metrics=metrics, force_reload=force_reload)
         sess.close()
 
     metrics['records_added'] = len(set(metrics['added_duns']))

--- a/dataactcore/scripts/load_exec_comp.py
+++ b/dataactcore/scripts/load_exec_comp.py
@@ -136,7 +136,7 @@ def get_parser():
     environ.add_argument('-l', '--local', type=str, default=None, help='Local directory to work from')
     environ.add_argument('-k', '--ssh_key', type=str, default=None, help='Private key used to access the API remotely')
     parser.add_argument("-f", "--reload_date", type=str, default=None, help='Force update from a specific date'
-                                                                             ' (YYYY-MM-DD)')
+                                                                            ' (YYYY-MM-DD)')
     return parser
 
 


### PR DESCRIPTION
**High level description:**
Adding `--force_reload` arguments to the DUNS and Exec Comp loaders which forces a reload of data from a specified date.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-6926](https://federal-spending-transparency.atlassian.net/browse/DEV-6926)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Successfully run on dev and production to reload data from 2021-02-06
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated