### PR TITLE
[OPS-1660] ddtrace update and subprocess and sub-step tracing of Validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
 
 script:
   - flake8
-  - pytest tests/unit/dataactcore/utils/test_tracing.py
+  - pytest tests/unit/* -k test_tracing.py
   #- pytest tests/unit/* --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml
   #- pytest tests/integration/* --cov=. --cov-append --cov-report term --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,9 @@ before_script:
 
 script:
   - flake8
-  - pytest tests/unit/* --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml
-  - pytest tests/integration/* --cov=. --cov-append --cov-report term --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml
+  - pytest tests/unit/dataactcore/utils/test_tracing.py
+  #- pytest tests/unit/* --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml
+  #- pytest tests/integration/* --cov=. --cov-append --cov-report term --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml
 
 after_script:
   - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,8 @@ before_script:
 
 script:
   - flake8
-  - pytest tests/unit/* -k test_tracing.py
-  #- pytest tests/unit/* --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml
-  #- pytest tests/integration/* --cov=. --cov-append --cov-report term --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml
+  - pytest tests/unit/* --cov=. --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml
+  - pytest tests/integration/* --cov=. --cov-append --cov-report term --cov-report xml:tests/coverage.xml --junitxml=tests/test-results.xml
 
 after_script:
   - docker-compose down

--- a/dataactbroker/app.py
+++ b/dataactbroker/app.py
@@ -33,7 +33,7 @@ from dataactcore.utils.statusCode import StatusCode
 logger = logging.getLogger(__name__)
 
 # Replace below param with enabled=True during env-deploys to turn on
-ddtrace.tracer.configure(enabled=True)  # TODO: set back to False
+ddtrace.tracer.configure(enabled=False)
 if ddtrace.tracer.enabled:
     ddtrace.config.flask["service_name"] = "api"
     ddtrace.config.flask["analytics_enabled"] = True  # capture APM "Traces" & "Analyzed Spans" in App Analytics

--- a/dataactcore/utils/tracing.py
+++ b/dataactcore/utils/tracing.py
@@ -1,0 +1,115 @@
+"""
+Module for Application Performance Monitoring and distributed tracing tools and helpers.
+
+Specifically leveraging the Datadog tracing client.
+"""
+import logging
+
+from ddtrace import tracer
+from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
+from ddtrace.ext import SpanTypes
+from ddtrace.ext.priority import USER_REJECT
+from ddtrace.internal.writer import AgentWriter
+from ddtrace.span import Span
+from typing import Optional
+
+_logger = logging.getLogger(__name__)
+
+
+class DatadogEagerlyDropTraceFilter:
+    """
+    A trace filter that eagerly drops a trace, by filtering it out before sending it on to the Datadog Server API.
+    It uses the `self.EAGERLY_DROP_TRACE_KEY` as a sentinel value. If present within any span's tags, the whole
+    trace that the span is part of will be filtered out before being sent to the server.
+    """
+
+    EAGERLY_DROP_TRACE_KEY = "EAGERLY_DROP_TRACE"
+
+    @staticmethod
+    def activate():
+        if not hasattr(tracer, "_filters"):
+            _logger.warning("Datadog tracer client no longer has attribute '_filters' on which to append a span filter")
+        else:
+            if tracer._filters:
+                tracer._filters.append(DatadogEagerlyDropTraceFilter())
+            else:
+                tracer._filters = [DatadogEagerlyDropTraceFilter()]
+
+    @classmethod
+    def drop(cls, span: Span):
+        tracer.get_call_context().sampling_priority = USER_REJECT
+        span.set_tag(cls.EAGERLY_DROP_TRACE_KEY, True)
+
+    def process_trace(self, trace):
+        """Drop trace if any span tag has tag with key 'EAGERLY_DROP_TRACE'"""
+        return None if any(span.get_tag(self.EAGERLY_DROP_TRACE_KEY) for span in trace) else trace
+
+
+class SubprocessTrace:
+    """A context manager class to handle of entry and exit things that need to be done to get spans published that are
+    part of a Datadog trace which continues into a subprocess.
+
+    This wraps some of the context management activity done in ``Span`` class, which is also a context manager.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        service: str = None,
+        resource: str = None,
+        span_type: SpanTypes = None,
+        can_drop_sample: bool = True,
+        **tags,
+    ) -> None:
+        self.name = name
+        self.service = service
+        self.resource = resource
+        self.span_type = span_type
+        self.can_drop_sample = can_drop_sample
+        self.tags = tags
+        self.span: Optional[Span] = None
+
+    def __enter__(self) -> Span:
+        self.span = tracer.trace(name=self.name, service=self.service, resource=self.resource, span_type=self.span_type)
+        self.span.set_tags(self.tags)
+        if not self.can_drop_sample:
+            # Set True to add trace to App Analytics:
+            # - https://docs.datadoghq.com/tracing/app_analytics/?tab=python#custom-instrumentation
+            self.span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, 1.0)
+        return self.span
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """This context exit handler ensures that traces get sent to server regardless of how fast this subprocess runs.
+
+        Workaround for: https://github.com/DataDog/dd-trace-py/issues/1184
+        """
+        try:
+            # This will call span.finish() which must be done before the queue is flushed in order to enqueue the
+            # span data that is to be flushed (sent to the server)
+            self.span.__exit__(exc_type, exc_val, exc_tb)
+        finally:
+            writer_type = type(tracer.writer)
+            if writer_type is AgentWriter:
+                tracer.writer.flush_queue()
+            else:
+                _logger.warning(
+                    f"Unexpected Datadog tracer.writer type of {writer_type} found. Not flushing trace spans."
+                )
+
+
+class DatadogLoggingTraceFilter:
+    """Debugging utility filter that can log trace spans"""
+
+    _logger = logging.getLogger(__name__)
+
+    def process_trace(self, trace):
+        logged = False
+        trace_id = "???"
+        for span in trace:
+            trace_id = span.trace_id or "???"
+            if not span.get_tag(DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY):
+                logged = True
+                self._logger.info(f"----[SPAN#{trace_id}]" + "-" * 40 + f"\n{span.pprint()}")
+        if logged:
+            self._logger.info(f"====[END TRACE#{trace_id}]" + "=" * 35)
+        return trace

--- a/dataactcore/utils/tracing.py
+++ b/dataactcore/utils/tracing.py
@@ -74,12 +74,14 @@ class SubprocessTrace:
         self.span: Optional[Span] = None
 
     def __enter__(self) -> Span:
+        _logger.warning("TRACER: starting enter handler")  # TODO:remove
         self.span = tracer.trace(name=self.name, service=self.service, resource=self.resource, span_type=self.span_type)
         self.span.set_tags(self.tags)
         if not self.can_drop_sample:
             # Set True to add trace to App Analytics:
             # - https://docs.datadoghq.com/tracing/app_analytics/?tab=python#custom-instrumentation
             self.span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, 1.0)
+        _logger.warning("TRACER: finished enter handler")  # TODO:remove
         return self.span
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -87,6 +89,7 @@ class SubprocessTrace:
 
         Workaround for: https://github.com/DataDog/dd-trace-py/issues/1184
         """
+        _logger.warning("TRACER: starting exit handler")  # TODO:remove
         try:
             # This will call span.finish() which must be done before the queue is flushed in order to enqueue the
             # span data that is to be flushed (sent to the server)
@@ -99,6 +102,7 @@ class SubprocessTrace:
                 _logger.warning(
                     f"Unexpected Datadog tracer.writer type of {writer_type} found. Not flushing trace spans."
                 )
+            _logger.warning("TRACER: finished exit handler")  # TODO:remove
 
 
 class DatadogLoggingTraceFilter:

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -69,7 +69,7 @@ def run_app():
         keep_polling = True
         while keep_polling:
             # Start a Datadog Trace for this poll iter to capture activity in APM
-            with tracer.trace(
+            with ddtrace.tracer.trace(
                     name=f"job.{JOB_TYPE}", service=JOB_TYPE.lower(), resource=queue.url, span_type=SpanTypes.WORKER
             ) as span:
                 # Set True to add trace to App Analytics:
@@ -212,7 +212,6 @@ def validator_process_file_generation(file_gen_id, is_retry=False):
                 raise e
 
 
-@tracer.wrap(name="job.{}.validation".format(JOB_TYPE), service=JOB_TYPE.lower(), span_type=SpanTypes.WORKER)
 def validator_process_job(job_id, agency_code, is_retry=False):
     """ Retrieves a Job based on its ID, and kicks off a validation. Handles errors by ensuring the Job (if exists) is
         no longer running.

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -29,7 +29,7 @@ from dataactvalidator.validator_logging import log_job_message
 logger = logging.getLogger(__name__)
 
 # Replace below param with enabled=True during env-deploys to turn on
-ddtrace.tracer.configure(enabled=True)  # TODO: set back to False
+ddtrace.tracer.configure(enabled=False)
 if ddtrace.tracer.enabled:
     ddtrace.config.flask["service_name"] = "validator"
     ddtrace.config.flask["analytics_enabled"] = True  # capture APM "Traces" & "Analyzed Spans" in App Analytics

--- a/dataactvalidator/app.py
+++ b/dataactvalidator/app.py
@@ -1,14 +1,13 @@
 import logging
 import csv
+import ddtrace
 import inspect
 import time
 import traceback
 
-from flask import Flask, g, current_app
-
-from ddtrace import config as ddconfig, tracer, patch_all
+from ddtrace.constants import ANALYTICS_SAMPLE_RATE_KEY
 from ddtrace.ext import SpanTypes
-from ddtrace.ext.priority import USER_REJECT
+from flask import Flask, g, current_app
 
 from dataactcore.aws.sqsHandler import sqs_queue
 from dataactcore.config import CONFIG_BROKER, CONFIG_SERVICES
@@ -19,6 +18,7 @@ from dataactcore.models.jobModels import Job, FileGeneration
 from dataactcore.models.lookups import JOB_STATUS_DICT
 from dataactcore.utils.responseException import ResponseException
 from dataactcore.utils.statusCode import StatusCode
+from dataactcore.utils.tracing import DatadogEagerlyDropTraceFilter, SubprocessTrace
 from dataactvalidator.sqs_work_dispatcher import SQSWorkDispatcher
 
 from dataactvalidator.validation_handlers.file_generation_manager import FileGenerationManager
@@ -28,13 +28,18 @@ from dataactvalidator.validator_logging import log_job_message
 
 logger = logging.getLogger(__name__)
 
-# Datadog APM Tracer configuration for Flask integration
-tracer.enabled = False  # value toggled True/False via Ansible during deployment. DO NOT DELETE
-if tracer.enabled:
-    ddconfig.flask["service_name"] = "validator"
-    ddconfig.flask["analytics_enabled"] = True  # sample rate defaults to 100%
-    ddconfig.flask["distributed_tracing_enabled"] = False
-    patch_all()
+# Replace below param with enabled=True during env-deploys to turn on
+ddtrace.tracer.configure(enabled=True)  # TODO: set back to False
+if ddtrace.tracer.enabled:
+    ddtrace.config.flask["service_name"] = "validator"
+    ddtrace.config.flask["analytics_enabled"] = True  # capture APM "Traces" & "Analyzed Spans" in App Analytics
+    ddtrace.config.flask["analytics_sample_rate"] = 1.0  # Including 100% of traces in sample
+    # Distributed tracing only needed if picking up disjoint traces by HTTP Header value
+    ddtrace.config.django["distributed_tracing_enabled"] = False
+    # patch_all() captures traces from integrated components' libraries by patching them. See:
+    # - http://pypi.datadoghq.com/trace/docs/advanced_usage.html#patch-all
+    # - Integrated Libs: http://pypi.datadoghq.com/trace/docs/index.html#supported-libraries
+    ddtrace.patch_all()
 
 READY_STATUSES = [JOB_STATUS_DICT['waiting'], JOB_STATUS_DICT['ready']]
 RUNNING_STATUSES = READY_STATUSES + [JOB_STATUS_DICT['running']]
@@ -63,14 +68,13 @@ def run_app():
         logger.info("Starting SQS polling")
         keep_polling = True
         while keep_polling:
-
             # Start a Datadog Trace for this poll iter to capture activity in APM
             with tracer.trace(
-                name="job.{}".format(JOB_TYPE),
-                service=JOB_TYPE.lower(),
-                resource=queue.url,
-                span_type=SpanTypes.WORKER
+                    name=f"job.{JOB_TYPE}", service=JOB_TYPE.lower(), resource=queue.url, span_type=SpanTypes.WORKER
             ) as span:
+                # Set True to add trace to App Analytics:
+                # - https://docs.datadoghq.com/tracing/app_analytics/?tab=python#custom-instrumentation
+                span.set_tag(ANALYTICS_SAMPLE_RATE_KEY, 1.0)
 
                 # With cleanup handling engaged, allowing retries
                 dispatcher = SQSWorkDispatcher(queue, worker_can_start_child_processes=True)
@@ -101,9 +105,8 @@ def run_app():
                 found_message = dispatcher.dispatch_by_message_attribute(choose_job_by_message_attributes)
 
                 if not found_message:
-                    # Drop the Datadog trace, since no trace-worthy activity happened on this poll
-                    tracer.context_provider.active().sampling_priority = USER_REJECT
-                    span.set_tag(DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY, True)
+                    # Flag the the Datadog trace for dropping, since no trace-worthy activity happened on this poll
+                    DatadogEagerlyDropTraceFilter.drop(span)
 
                     # When you receive an empty response from the queue, wait before trying again
                     time.sleep(1)
@@ -112,7 +115,6 @@ def run_app():
                 keep_polling = not dispatcher.is_exiting
 
 
-@tracer.wrap(name="job.{}.file_generation".format(JOB_TYPE), service=JOB_TYPE.lower(), span_type=SpanTypes.WORKER)
 def validator_process_file_generation(file_gen_id, is_retry=False):
     """ Retrieves a FileGeneration object based on its ID, and kicks off a file generation. Handles errors by ensuring
         the FileGeneration (if exists) is no longer cached.
@@ -125,83 +127,92 @@ def validator_process_file_generation(file_gen_id, is_retry=False):
         Raises:
             Any Exceptions raised by the FileGenerationManager
     """
-    # Add args name and values as span tags on this trace
-    tracer.current_span().set_tags(locals())
-    if is_retry:
-        if cleanup_generation(file_gen_id):
-            log_job_message(
-                logger=logger,
-                message="Attempting a retry of {} after successful retry-cleanup.".format(inspect.stack()[0][3]),
-                job_type=JOB_TYPE,
-                job_id=file_gen_id,
-                is_debug=True
-            )
-        else:
-            log_job_message(
-                logger=logger,
-                message="Retry of {} found to be not necessary after cleanup. "
-                        "Returning from job with success.".format(inspect.stack()[0][3]),
-                job_type=JOB_TYPE,
-                job_id=file_gen_id,
-                is_debug=True
-            )
-            return
+    with SubprocessTrace(
+        name=f"job.{JOB_TYPE}.file_generation",
+        service=JOB_TYPE.lower(),
+        resource=f"file_generation_id={file_gen_id}",
+        span_type=SpanTypes.WORKER,
+    ) as span:
+        # Add args name and values as span tags on this trace
+        span.set_tags(locals())
+        if is_retry:
+            if cleanup_generation(file_gen_id):
+                log_job_message(
+                    logger=logger,
+                    message="Attempting a retry of {} after successful retry-cleanup.".format(inspect.stack()[0][3]),
+                    job_type=JOB_TYPE,
+                    job_id=file_gen_id,
+                    is_debug=True
+                )
+            else:
+                log_job_message(
+                    logger=logger,
+                    message="Retry of {} found to be not necessary after cleanup. "
+                            "Returning from job with success.".format(inspect.stack()[0][3]),
+                    job_type=JOB_TYPE,
+                    job_id=file_gen_id,
+                    is_debug=True
+                )
+                return
 
-    sess = GlobalDB.db().session
-    file_generation = None
+        sess = GlobalDB.db().session
+        file_generation = None
 
-    try:
-        file_generation = sess.query(FileGeneration).filter_by(file_generation_id=file_gen_id).one_or_none()
-        if file_generation is None:
-            raise ResponseException('FileGeneration ID {} not found in database'.format(file_gen_id),
-                                    StatusCode.CLIENT_ERROR, None)
-
-        file_generation_manager = FileGenerationManager(sess, g.is_local, file_generation=file_generation)
-        file_generation_manager.generate_file()
-
-    except Exception as e:
-        # Log uncaught exceptions and fail all Jobs referencing this FileGeneration
-        error_data = {
-            'message': 'An unhandled exception occurred in the Validator during file generation',
-            'message_type': 'ValidatorInfo',
-            'file_generation_id': file_gen_id,
-            'traceback': traceback.format_exc()
-        }
-        if file_generation:
-            error_data.update({
-                'agency_code': file_generation.agency_code, 'agency_type': file_generation.agency_type,
-                'start_date': file_generation.start_date, 'end_date': file_generation.end_date,
-                'file_type': file_generation.file_type, 'file_path': file_generation.file_path,
-            })
-        logger.error(error_data)
-
-        # Try to mark the Jobs as failed, but continue raising the original Exception if not possible
         try:
+            file_generation = sess.query(FileGeneration).filter_by(file_generation_id=file_gen_id).one_or_none()
             if file_generation:
-                # Uncache the FileGeneration
-                sess.refresh(file_generation)
-                file_generation.is_cached_file = False
+                file_gen_data = {
+                    'agency_code': file_generation.agency_code, 'agency_type': file_generation.agency_type,
+                    'start_date': file_generation.start_date, 'end_date': file_generation.end_date,
+                    'file_type': file_generation.file_type, 'file_path': file_generation.file_path,
+                }
+                span.set_tags(file_gen_data)
+            elif file_generation is None:
+                raise ResponseException('FileGeneration ID {} not found in database'.format(file_gen_id),
+                                        StatusCode.CLIENT_ERROR, None)
 
-                # Mark all Jobs waiting on this FileGeneration as failed
-                generation_jobs = sess.query(Job).filter_by(file_generation_id=file_gen_id).all()
-                for job in generation_jobs:
-                    if job.job_status in [JOB_STATUS_DICT['waiting'], JOB_STATUS_DICT['ready'],
-                                          JOB_STATUS_DICT['running']]:
-                        mark_job_status(job.job_id, 'failed')
-                        sess.refresh(job)
-                        job.file_generation_id = None
-                        job.error_message = str(e)
-                sess.commit()
-        except Exception:
-            pass
+            file_generation_manager = FileGenerationManager(sess, g.is_local, file_generation=file_generation)
+            file_generation_manager.generate_file()
 
-        # ResponseExceptions only occur at very specific times, and should not affect the Validator's future attempts
-        # at handling messages from SQS
-        if not isinstance(e, ResponseException):
-            raise e
+        except Exception as e:
+            # Log uncaught exceptions and fail all Jobs referencing this FileGeneration
+            error_data = {
+                'message': 'An unhandled exception occurred in the Validator during file generation',
+                'message_type': 'ValidatorInfo',
+                'file_generation_id': file_gen_id,
+                'traceback': traceback.format_exc()
+            }
+            if file_generation:
+                error_data.update(file_gen_data)
+            logger.error(error_data)
+
+            # Try to mark the Jobs as failed, but continue raising the original Exception if not possible
+            try:
+                if file_generation:
+                    # Uncache the FileGeneration
+                    sess.refresh(file_generation)
+                    file_generation.is_cached_file = False
+
+                    # Mark all Jobs waiting on this FileGeneration as failed
+                    generation_jobs = sess.query(Job).filter_by(file_generation_id=file_gen_id).all()
+                    for job in generation_jobs:
+                        if job.job_status in [JOB_STATUS_DICT['waiting'], JOB_STATUS_DICT['ready'],
+                                              JOB_STATUS_DICT['running']]:
+                            mark_job_status(job.job_id, 'failed')
+                            sess.refresh(job)
+                            job.file_generation_id = None
+                            job.error_message = str(e)
+                    sess.commit()
+            except Exception:
+                pass
+
+            # ResponseExceptions only occur at very specific times, and should not affect the Validator's
+            # future attempts at handling messages from SQS
+            if not isinstance(e, ResponseException):
+                raise e
 
 
-@tracer.wrap(name="job.{}.validation_job".format(JOB_TYPE), service=JOB_TYPE.lower(), span_type=SpanTypes.WORKER)
+@tracer.wrap(name="job.{}.validation".format(JOB_TYPE), service=JOB_TYPE.lower(), span_type=SpanTypes.WORKER)
 def validator_process_job(job_id, agency_code, is_retry=False):
     """ Retrieves a Job based on its ID, and kicks off a validation. Handles errors by ensuring the Job (if exists) is
         no longer running.
@@ -215,106 +226,117 @@ def validator_process_job(job_id, agency_code, is_retry=False):
         Raises:
             Any Exceptions raised by the GenerationManager or ValidationManager, excluding those explicitly handled
     """
-    # Add args name and values as span tags on this trace
-    tracer.current_span().set_tags(locals())
-    if is_retry:
-        if cleanup_validation(job_id):
-            log_job_message(
-                logger=logger,
-                message="Attempting a retry of {} after successful retry-cleanup.".format(inspect.stack()[0][3]),
-                job_type=JOB_TYPE,
-                job_id=job_id,
-                is_debug=True
-            )
-        else:
-            log_job_message(
-                logger=logger,
-                message="Retry of {} found to be not necessary after cleanup. "
-                        "Returning from job with success.".format(inspect.stack()[0][3]),
-                job_type=JOB_TYPE,
-                job_id=job_id,
-                is_debug=True
-            )
-            return
+    with SubprocessTrace(
+        name=f"job.{JOB_TYPE}.validation",
+        service=JOB_TYPE.lower(),
+        resource=f"validation_job_id={job_id}",
+        span_type=SpanTypes.WORKER,
+    ) as span:
+        # Add args name and values as span tags on this trace
+        span.set_tags(locals())
+        if is_retry:
+            if cleanup_validation(job_id):
+                log_job_message(
+                    logger=logger,
+                    message="Attempting a retry of {} after successful retry-cleanup.".format(inspect.stack()[0][3]),
+                    job_type=JOB_TYPE,
+                    job_id=job_id,
+                    is_debug=True
+                )
+            else:
+                log_job_message(
+                    logger=logger,
+                    message="Retry of {} found to be not necessary after cleanup. "
+                            "Returning from job with success.".format(inspect.stack()[0][3]),
+                    job_type=JOB_TYPE,
+                    job_id=job_id,
+                    is_debug=True
+                )
+                return
 
-    sess = GlobalDB.db().session
-    job = None
+        sess = GlobalDB.db().session
+        job = None
 
-    try:
-        # Get the job
-        job = sess.query(Job).filter_by(job_id=job_id).one_or_none()
-        if job is None:
-            validation_error_type = ValidationError.jobError
-            write_file_error(job_id, None, validation_error_type)
-            raise ResponseException('Job ID {} not found in database'.format(job_id),
-                                    StatusCode.CLIENT_ERROR, None, validation_error_type)
-
-        mark_job_status(job_id, 'ready')
-
-        # We can either validate or generate a file based on Job ID
-        if job.job_type.name == 'file_upload':
-            # Generate A, E, or F file
-            file_generation_manager = FileGenerationManager(sess, g.is_local, job=job)
-            file_generation_manager.generate_file(agency_code)
-        else:
-            # Run validations
-            validation_manager = ValidationManager(g.is_local, CONFIG_SERVICES['error_report_path'])
-            validation_manager.validate_job(job.job_id)
-
-    except (ResponseException, csv.Error, UnicodeDecodeError, ValueError) as e:
-        # Handle exceptions explicitly raised during validation
-        error_data = {
-            'message': 'An exception occurred in the Validator',
-            'message_type': 'ValidatorInfo',
-            'job_id': job_id,
-            'traceback': traceback.format_exc()
-        }
-
-        if job:
-            error_data.update({'submission_id': job.submission_id, 'file_type': job.file_type.name})
-            logger.error(error_data)
-
-            sess.refresh(job)
-            job.error_message = str(e)
-            if job.filename is not None:
-                error_type = ValidationError.unknownError
-                extra_info = None
-                if isinstance(e, UnicodeDecodeError):
-                    error_type = ValidationError.encodingError
-                elif isinstance(e, ResponseException):
-                    error_type = e.errorType
-                    extra_info = e.extraInfo
-
-                write_file_error(job.job_id, job.filename, error_type, extra_info=extra_info)
-
-            mark_job_status(job.job_id, 'invalid')
-        else:
-            logger.error(error_data)
-            raise e
-
-    except Exception as e:
-        # Log uncaught exceptions and fail the Job
-        error_data = {
-            'message': 'An unhandled exception occurred in the Validator',
-            'message_type': 'ValidatorInfo',
-            'job_id': job_id,
-            'traceback': traceback.format_exc()
-        }
-        if job:
-            error_data.update({'submission_id': job.submission_id, 'file_type': job.file_type.name})
-        logger.error(error_data)
-
-        # Try to mark the Job as failed, but continue raising the original Exception if not possible
         try:
-            mark_job_status(job_id, 'failed')
+            # Get the job
+            job = sess.query(Job).filter_by(job_id=job_id).one_or_none()
+            if job:
+                job_data = {
+                    'submission_id': job.submission_id, 'job_type': job.job_type.name, 'file_type': job.file_type.name,
+                }
+                span.set_tags(job_data)
+            elif job is None:
+                validation_error_type = ValidationError.jobError
+                write_file_error(job_id, None, validation_error_type)
+                raise ResponseException('Job ID {} not found in database'.format(job_id),
+                                        StatusCode.CLIENT_ERROR, None, validation_error_type)
 
-            sess.refresh(job)
-            job.error_message = str(e)
-            sess.commit()
-        except Exception:
-            pass
+            mark_job_status(job_id, 'ready')
 
-        raise e
+            # We can either validate or generate a file based on Job ID
+            if job.job_type.name == 'file_upload':
+                # Generate A, E, or F file
+                file_generation_manager = FileGenerationManager(sess, g.is_local, job=job)
+                file_generation_manager.generate_file(agency_code)
+            else:
+                # Run validations
+                validation_manager = ValidationManager(g.is_local, CONFIG_SERVICES['error_report_path'])
+                validation_manager.validate_job(job.job_id)
+
+        except (ResponseException, csv.Error, UnicodeDecodeError, ValueError) as e:
+            # Handle exceptions explicitly raised during validation
+            error_data = {
+                'message': 'An exception occurred in the Validator',
+                'message_type': 'ValidatorInfo',
+                'job_id': job_id,
+                'traceback': traceback.format_exc()
+            }
+
+            if job:
+                error_data.update(job_data)
+                logger.error(error_data)
+
+                sess.refresh(job)
+                job.error_message = str(e)
+                if job.filename is not None:
+                    error_type = ValidationError.unknownError
+                    extra_info = None
+                    if isinstance(e, UnicodeDecodeError):
+                        error_type = ValidationError.encodingError
+                    elif isinstance(e, ResponseException):
+                        error_type = e.errorType
+                        extra_info = e.extraInfo
+
+                    write_file_error(job.job_id, job.filename, error_type, extra_info=extra_info)
+
+                mark_job_status(job.job_id, 'invalid')
+            else:
+                logger.error(error_data)
+                raise e
+
+        except Exception as e:
+            # Log uncaught exceptions and fail the Job
+            error_data = {
+                'message': 'An unhandled exception occurred in the Validator',
+                'message_type': 'ValidatorInfo',
+                'job_id': job_id,
+                'traceback': traceback.format_exc()
+            }
+            if job:
+                error_data.update(job_data)
+            logger.error(error_data)
+
+            # Try to mark the Job as failed, but continue raising the original Exception if not possible
+            try:
+                mark_job_status(job_id, 'failed')
+
+                sess.refresh(job)
+                job.error_message = str(e)
+                sess.commit()
+            except Exception:
+                pass
+
+            raise e
 
 
 def cleanup_generation(file_gen_id):
@@ -364,26 +386,8 @@ def cleanup_validation(job_id):
     return retry
 
 
-class DatadogEagerlyDropTraceFilter:
-    """
-    A trace filter that eagerly drops a trace, by filtering it out before sending it on to the Datadog Server API.
-    It uses the `self.EAGERLY_DROP_TRACE_KEY` as a sentinel value. If present within any span's tags, the whole
-    trace that the span is part of will be filtered out before being sent to the server.
-    """
-
-    EAGERLY_DROP_TRACE_KEY = "EAGERLY_DROP_TRACE"
-
-    def process_trace(self, trace):
-        """Drop trace if any span tag has tag with key 'EAGERLY_DROP_TRACE'"""
-        return None if any(span.get_tag(self.EAGERLY_DROP_TRACE_KEY) for span in trace) else trace
-
-
 if __name__ == "__main__":
     configure_logging()
-    if tracer.enabled:
-        # Drop uninteresting polls of the queue from the Tracer
-        if tracer.writer._filters:
-            tracer.writer._filters.append(DatadogEagerlyDropTraceFilter())
-        else:
-            tracer.writer._filters = [DatadogEagerlyDropTraceFilter()]
+    # Configure Tracer to drop traces of polls of the queue that have been flagged as uninteresting
+    DatadogEagerlyDropTraceFilter.activate()
     run_app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ cffi==1.13
 click==6.6
 colorama==0.3.3
 coverage==5.3
-ddtrace==0.32.2
+ddtrace==0.46.0
 decorator==4.0.4
 docutils==0.12
 factory-boy==2.7.0

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -119,7 +119,7 @@ def test_drop_key_on_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCapt
     assert DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY not in caplog.text
 
 
-#@pytest.mark.skip("Hangs in Broker tests. Possible subproc or thread locking issue to investigate.")
+@pytest.mark.skip("Works locally, hangs in Travis CI tests. Possible subproc or thread locking issue to investigate.")
 def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixture):
     """Verify that spans created in subprocesses are written to the queue and then flushed to the server,
     when wrapped in the SubprocessTracer"""

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -119,7 +119,7 @@ def test_drop_key_on_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCapt
     assert DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY not in caplog.text
 
 
-@pytest.mark.skip("Works locally, hangs in Travis CI tests. Possible subproc or thread locking issue to investigate.")
+#@pytest.mark.skip("Works locally, hangs in Travis CI tests. Possible subproc or thread locking issue to investigate.")
 def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixture):
     """Verify that spans created in subprocesses are written to the queue and then flushed to the server,
     when wrapped in the SubprocessTracer"""
@@ -161,7 +161,7 @@ def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixt
             worker.terminate()
             try:
                 _drain_captured_log_queue(log_queue, stop_sentinel, caplog, force_immediate_stop=True)
-            except:
+            except Exception:
                 print("Error draining captured log queue when handling subproc TimeoutError")
                 pass
             raise mp.TimeoutError(f"subprocess {worker.name} did not complete in timeout")

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -149,10 +149,10 @@ def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixt
         worker = ctx.Process(
             name=f"{test}_subproc",
             target=_do_things_in_subproc,
-            args=(subproc_test_msg, state),
+            args=(subproc_test_msg, state,),
         )
         worker.start()
-        worker.join()
+        worker.join(timeout=10)
         DatadogLoggingTraceFilter._log.warning(stop_sentinel)
 
     subproc_trace_id, subproc_span_id = state.get(block=True, timeout=10)
@@ -201,3 +201,4 @@ def _do_things_in_subproc(subproc_test_msg, q: mp.Queue):
         x = 2 ** 5
         thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
         assert thirty_two_squares[-1] == 961
+        logging.getLogger(f"{test}_logger").warning("DONE doing things in subproc")

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -1,0 +1,163 @@
+import inspect
+
+import ddtrace
+import logging
+import multiprocessing as mp
+
+from logging.handlers import QueueHandler
+from _pytest.logging import LogCaptureFixture
+from ddtrace.ext import SpanTypes
+
+from dataactcore.utils.tracing import DatadogEagerlyDropTraceFilter, DatadogLoggingTraceFilter, SubprocessTrace
+
+
+def test_logging_trace_spans(caplog: LogCaptureFixture):
+    """Test the DatadogLoggingTraceFilter can actually capture trace span data in log output"""
+    test = f"{inspect.stack()[0][3]}"
+    # Enable log output for this logger
+    DatadogLoggingTraceFilter._log.setLevel("DEBUG")
+    ddtrace.tracer.enabled = True
+    DatadogLoggingTraceFilter.activate()
+    with ddtrace.tracer.trace(
+        name=f"{test}_operation",
+        service=f"{test}_service",
+        resource=f"{test}_resource",
+        span_type=SpanTypes.TEST,
+    ) as span:
+        trace_id = span.trace_id
+        logger = logging.getLogger(f"{test}_logger")
+        test_msg = f"a test message was logged during {test}"
+        logger.warning(test_msg)
+        # do things
+        x = 2**5
+        thirty_two_squares = [m for m in map(lambda y: y**2, range(x))]
+        assert thirty_two_squares[-1] == 961
+    assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
+    assert f"SPAN#{trace_id}" in caplog.text, "span marker not found in logging output"
+    assert f"TRACE#{trace_id}" in caplog.text, "trace marker not found in logging output"
+    assert f"resource {test}_resource" in caplog.text, "traced resource not found in logging output"
+
+
+def test_drop_key_on_trace_spans(caplog: LogCaptureFixture):
+    """Test that traces that have any span with the key that marks them for dropping, are not logged, but those that
+    do not have this marker, are still logged"""
+    test = f"{inspect.stack()[0][3]}"
+    # Enable log output for this logger
+    DatadogLoggingTraceFilter._log.setLevel("DEBUG")
+    ddtrace.tracer.enabled = True
+    DatadogLoggingTraceFilter.activate()
+    DatadogEagerlyDropTraceFilter.activate()
+    with ddtrace.tracer.trace(
+        name=f"{test}_operation",
+        service=f"{test}_service",
+        resource=f"{test}_resource",
+        span_type=SpanTypes.TEST,
+    ) as span:
+        trace_id1 = span.trace_id
+        logger = logging.getLogger(f"{test}_logger")
+        test_msg = f"a test message was logged during {test}"
+        logger.warning(test_msg)
+        # do things
+        x = 2**5
+        thirty_two_squares = [m for m in map(lambda y: y**2, range(x))]
+        assert thirty_two_squares[-1] == 961
+
+        # Drop this span so it is not sent to the server, and not logged by the trace logger
+        DatadogEagerlyDropTraceFilter.drop(span)
+
+    # Do another trace, that is NOT dropped
+    with ddtrace.tracer.trace(
+            name=f"{test}_operation2",
+            service=f"{test}_service2",
+            resource=f"{test}_resource2",
+            span_type=SpanTypes.TEST,
+    ) as span2:
+        trace_id2 = span2.trace_id
+        logger = logging.getLogger(f"{test}_logger")
+        test_msg2 = f"a second test message was logged during {test}"
+        logger.warning(test_msg2)
+        # do things
+        x = 2 ** 7
+
+    assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
+    assert f"SPAN#{trace_id1}" not in caplog.text, "span marker still logged when should have been dropped"
+    assert f"TRACE#{trace_id1}" not in caplog.text, "trace marker still logged when should have been dropped"
+    assert f"resource {test}_resource" in caplog.text, "traced resource still logged when should have been dropped"
+    assert test_msg2 in caplog.text
+    assert f"SPAN#{trace_id2}" in caplog.text, "span marker not found in logging output"
+    assert f"TRACE#{trace_id2}" in caplog.text, "trace marker not found in logging output"
+    assert f"resource {test}_resource2" in caplog.text, "traced resource not found in logging output"
+    assert DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY not in caplog.text
+
+
+def test_subprocess_trace(caplog: LogCaptureFixture):
+    """Verify that spans created in subprocesses are written to the queue and then flushed to the server,
+    when wrapped in the SubprocessTracer"""
+    test = f"{inspect.stack()[0][3]}"
+    # Enable log output for this logger
+    DatadogLoggingTraceFilter._log.setLevel("DEBUG")
+    # And also send its output through a multiprocessing queue to surface logs from the subprocess
+    log_queue = mp.Queue()
+    DatadogLoggingTraceFilter._log.addHandler(QueueHandler(log_queue))
+    ddtrace.tracer.enabled = True
+    DatadogLoggingTraceFilter.activate()
+
+    subproc_test_msg = f"a test message was logged in a subprocess of {test}"
+
+    with ddtrace.tracer.trace(
+        name=f"{test}_operation",
+        service=f"{test}_service",
+        resource=f"{test}_resource",
+        span_type=SpanTypes.TEST,
+    ) as span:
+        trace_id = span.trace_id
+        logger = logging.getLogger(f"{test}_logger")
+        test_msg = f"a test message was logged during {test}"
+        logger.warning(test_msg)
+        ctx = mp.get_context("fork")
+        state = mp.Queue()
+        worker = ctx.Process(
+            name=f"{test}_subproc",
+            target=_do_things_in_subproc,
+            args=(subproc_test_msg, state),
+            daemon=True,
+        )
+        worker.start()
+        worker.join()
+        subproc_trace_id, subproc_span_id = state.get()
+    assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
+    # assert subproc_test_msg in caplog.text, "caplog.text did not seem to capture logging output from subproc in test"
+    assert f"SPAN#{trace_id}" in caplog.text, "span marker not found in logging output"
+    assert f"TRACE#{trace_id}" in caplog.text, "trace marker not found in logging output"
+    assert f"resource {test}_resource" in caplog.text, "traced resource not found in logging output"
+    assert subproc_trace_id == trace_id  # subprocess tracing should be a continuation of the trace in parent process
+
+    # Drain the queue to build the log output from the logger in DatadogLoggingTraceFilter
+    queued_log_text = ""
+    while not log_queue.empty():
+        log_record = log_queue.get()
+        queued_log_text += f"{log_record.getMessage()}\n"
+
+    assert f"{subproc_span_id}" in queued_log_text, "subproc span id not found in logging output"
+    assert f"resource {_do_things_in_subproc.__name__}_resource" in queued_log_text, \
+        "subproc traced resource not found in logging output"
+
+
+def _do_things_in_subproc(subproc_test_msg, q: mp.Queue):
+    test = f"{inspect.stack()[0][3]}"
+    with SubprocessTrace(
+        name=f"{test}_operation",
+        service=f"{test}_service",
+        resource=f"{test}_resource",
+        span_type=SpanTypes.TEST,
+        subproc_test_msg=subproc_test_msg,
+    ) as span:
+        q.put((span.trace_id, span.span_id,))
+        logging.getLogger(f"{test}_logger").warning(subproc_test_msg)
+        subproc_logger = logging.getLogger("subproc_logger")
+        subproc_logger.warning("i'm in a subproc")
+        # do things
+        x = 2**5
+        thirty_two_squares = [m for m in map(lambda y: y**2, range(x))]
+        assert thirty_two_squares[-1] == 961
+

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -190,6 +190,7 @@ def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixt
 
 def _do_things_in_subproc(subproc_test_msg, q: mp.Queue):
     test = "_do_things_in_subproc"
+    logging.getLogger(f"{test}_logger").warning("TRACER: starting subproc func")  # TODO:remove
     with SubprocessTrace(
         name=f"{test}_operation",
         service=f"{test}_service",
@@ -197,15 +198,21 @@ def _do_things_in_subproc(subproc_test_msg, q: mp.Queue):
         span_type=SpanTypes.TEST,
         subproc_test_msg=subproc_test_msg,
     ) as span:
+        logging.getLogger(f"{test}_logger").warning("TRACER: starting subproc func span")  # TODO:remove
         span_ids = (
             span.trace_id,
             span.span_id,
         )
+        logging.getLogger(f"{test}_logger").warning("TRACER: starting subproc return value put in q")  # TODO:remove
         q.put(span_ids, block=True, timeout=5)
+        logging.getLogger(f"{test}_logger").warning("TRACER: starting subproc return value put in q")  # TODO:remove
         logging.getLogger(f"{test}_logger").warning(subproc_test_msg)
         # do things
         x = 2 ** 5
         thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
+        logging.getLogger(f"{test}_logger").warning("TRACER: starting subproc assert")  # TODO:remove
         assert thirty_two_squares[-1] == 961
-
+        logging.getLogger(f"{test}_logger").warning("TRACER: finished subproc assert")  # TODO:remove
+        logging.getLogger(f"{test}_logger").warning("TRACER: finished subproc func span")  # TODO:remove
+    logging.getLogger(f"{test}_logger").warning("TRACER: finished subproc func")  # TODO:remove
     logging.getLogger(f"{test}_logger").warning("DONE doing things in subproc")

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -149,10 +149,16 @@ def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixt
         worker = ctx.Process(
             name=f"{test}_subproc",
             target=_do_things_in_subproc,
-            args=(subproc_test_msg, state,),
+            args=(
+                subproc_test_msg,
+                state,
+            ),
         )
         worker.start()
         worker.join(timeout=10)
+        if worker.is_alive():
+            worker.terminate()
+            raise mp.TimeoutError(f"subprocess {worker.name} did not complete in timeout")
         DatadogLoggingTraceFilter._log.warning(stop_sentinel)
 
     subproc_trace_id, subproc_span_id = state.get(block=True, timeout=10)

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -119,7 +119,7 @@ def test_drop_key_on_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCapt
     assert DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY not in caplog.text
 
 
-@pytest.skip("Hangs in Broker tests. Possible subproc or thread locking issue to investigate.")
+#@pytest.mark.skip("Hangs in Broker tests. Possible subproc or thread locking issue to investigate.")
 def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixture):
     """Verify that spans created in subprocesses are written to the queue and then flushed to the server,
     when wrapped in the SubprocessTracer"""

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -119,9 +119,11 @@ def test_drop_key_on_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCapt
     assert DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY not in caplog.text
 
 
-#@pytest.mark.skip(
-# "Works locally and in Travis CI by itself. But fails when run in Travis with other tests. Investiage test conflict."
-# )
+@pytest.mark.skip(
+    "Works locally and in Travis CI by itself. "
+    "But fails when run in Travis with other tests. "
+    "Investigate test conflict."
+)
 def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixture):
     """Verify that spans created in subprocesses are written to the queue and then flushed to the server,
     when wrapped in the SubprocessTracer"""

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -189,7 +189,7 @@ def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixt
 
 
 def _do_things_in_subproc(subproc_test_msg, q: mp.Queue):
-    test = f"{inspect.stack()[0][3]}"
+    test = "_do_things_in_subproc"
     with SubprocessTrace(
         name=f"{test}_operation",
         service=f"{test}_service",

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -21,11 +21,31 @@ def datadog_tracer() -> ddtrace.Tracer:
     ddtrace.tracer.enabled = tracer_state
 
 
+@pytest.yield_fixture
+def caplog(caplog):
+    """A decorator (pattern) fixture around the pytest caplog fixture that adds the ability to temporarily alter
+    loggers with propagate=False to True for duration of the test, so their output is propagated to the caplog log
+    handler"""
+
+    restore = []
+    for logger in logging.Logger.manager.loggerDict.values():
+        try:
+            if not logger.propagate:
+                logger.propagate = True
+                restore += [logger]
+        except AttributeError:
+            pass
+    yield caplog
+    for logger in restore:
+        logger.propagate = False
+
+
 def test_logging_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixture):
     """Test the DatadogLoggingTraceFilter can actually capture trace span data in log output"""
+
+    # Enable log output for this logger for duration of this test
+    caplog.set_level(logging.DEBUG, DatadogLoggingTraceFilter._log.name)
     test = f"{inspect.stack()[0][3]}"
-    # Enable log output for this logger
-    DatadogLoggingTraceFilter._log.setLevel("DEBUG")
     DatadogLoggingTraceFilter.activate()
     with ddtrace.tracer.trace(
         name=f"{test}_operation",
@@ -38,8 +58,8 @@ def test_logging_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureF
         test_msg = f"a test message was logged during {test}"
         logger.warning(test_msg)
         # do things
-        x = 2**5
-        thirty_two_squares = [m for m in map(lambda y: y**2, range(x))]
+        x = 2 ** 5
+        thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
         assert thirty_two_squares[-1] == 961
     assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
     assert f"SPAN#{trace_id}" in caplog.text, "span marker not found in logging output"
@@ -50,9 +70,10 @@ def test_logging_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureF
 def test_drop_key_on_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixture):
     """Test that traces that have any span with the key that marks them for dropping, are not logged, but those that
     do not have this marker, are still logged"""
+
+    # Enable log output for this logger for duration of this test
+    caplog.set_level(logging.DEBUG, DatadogLoggingTraceFilter._log.name)
     test = f"{inspect.stack()[0][3]}"
-    # Enable log output for this logger
-    DatadogLoggingTraceFilter._log.setLevel("DEBUG")
     DatadogLoggingTraceFilter.activate()
     DatadogEagerlyDropTraceFilter.activate()
     with ddtrace.tracer.trace(
@@ -66,8 +87,8 @@ def test_drop_key_on_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCapt
         test_msg = f"a test message was logged during {test}"
         logger.warning(test_msg)
         # do things
-        x = 2**5
-        thirty_two_squares = [m for m in map(lambda y: y**2, range(x))]
+        x = 2 ** 5
+        thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
         assert thirty_two_squares[-1] == 961
 
         # Drop this span so it is not sent to the server, and not logged by the trace logger
@@ -75,10 +96,10 @@ def test_drop_key_on_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCapt
 
     # Do another trace, that is NOT dropped
     with ddtrace.tracer.trace(
-            name=f"{test}_operation2",
-            service=f"{test}_service2",
-            resource=f"{test}_resource2",
-            span_type=SpanTypes.TEST,
+        name=f"{test}_operation2",
+        service=f"{test}_service2",
+        resource=f"{test}_resource2",
+        span_type=SpanTypes.TEST,
     ) as span2:
         trace_id2 = span2.trace_id
         logger = logging.getLogger(f"{test}_logger")
@@ -101,9 +122,10 @@ def test_drop_key_on_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCapt
 def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixture):
     """Verify that spans created in subprocesses are written to the queue and then flushed to the server,
     when wrapped in the SubprocessTracer"""
+
+    # Enable log output for this logger for duration of this test
+    caplog.set_level(logging.DEBUG, DatadogLoggingTraceFilter._log.name)
     test = f"{inspect.stack()[0][3]}"
-    # Enable log output for this logger
-    DatadogLoggingTraceFilter._log.setLevel("DEBUG")
     # And also send its output through a multiprocessing queue to surface logs from the subprocess
     log_queue = mp.Queue()
     DatadogLoggingTraceFilter._log.addHandler(QueueHandler(log_queue))
@@ -111,6 +133,7 @@ def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixt
 
     subproc_test_msg = f"a test message was logged in a subprocess of {test}"
     state = mp.Queue()
+    stop_sentinel = "-->STOP<--"
 
     with ddtrace.tracer.trace(
         name=f"{test}_operation",
@@ -126,29 +149,37 @@ def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixt
         worker = ctx.Process(
             name=f"{test}_subproc",
             target=_do_things_in_subproc,
-            args=(subproc_test_msg, state,),
-            daemon=True,
+            args=(subproc_test_msg, state),
         )
         worker.start()
         worker.join()
+        DatadogLoggingTraceFilter._log.warning(stop_sentinel)
 
     subproc_trace_id, subproc_span_id = state.get(block=True, timeout=10)
     assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
-    # assert subproc_test_msg in caplog.text, "caplog.text did not seem to capture logging output from subproc in test"
     assert f"SPAN#{trace_id}" in caplog.text, "span marker not found in logging output"
     assert f"TRACE#{trace_id}" in caplog.text, "trace marker not found in logging output"
     assert f"resource {test}_resource" in caplog.text, "traced resource not found in logging output"
     assert subproc_trace_id == trace_id  # subprocess tracing should be a continuation of the trace in parent process
 
-    # Drain the queue to build the log output from the logger in DatadogLoggingTraceFilter
-    queued_log_text = ""
-    while not log_queue.empty():
-        log_record = log_queue.get(block=True, timeout=5)
-        queued_log_text += f"{log_record.getMessage()}\n"
+    # Drain the queue and redirect DatadogLoggingTraceFilter log output to the caplog handler
+    log_records = []
+    draining = True
+    while draining:
+        while not log_queue.empty():
+            log_record = log_queue.get(block=True, timeout=5)
+            log_records.append(log_record)
+        log_msgs = [r.getMessage() for r in log_records]
+        if stop_sentinel in log_msgs:  # check for sentinel, signaling end of queued records
+            draining = False
+    for log_record in log_records:
+        if log_record.getMessage() != stop_sentinel:
+            caplog.handler.handle(log_record)
 
-    assert f"{subproc_span_id}" in queued_log_text, "subproc span id not found in logging output"
-    assert f"resource {_do_things_in_subproc.__name__}_resource" in queued_log_text, \
-        "subproc traced resource not found in logging output"
+    assert f"{subproc_span_id}" in caplog.text, "subproc span id not found in logging output"
+    assert (
+        f"resource {_do_things_in_subproc.__name__}_resource" in caplog.text
+    ), "subproc traced resource not found in logging output"
 
 
 def _do_things_in_subproc(subproc_test_msg, q: mp.Queue):
@@ -160,13 +191,13 @@ def _do_things_in_subproc(subproc_test_msg, q: mp.Queue):
         span_type=SpanTypes.TEST,
         subproc_test_msg=subproc_test_msg,
     ) as span:
-        span_ids = (span.trace_id, span.span_id,)
+        span_ids = (
+            span.trace_id,
+            span.span_id,
+        )
         q.put(span_ids, block=True, timeout=5)
         logging.getLogger(f"{test}_logger").warning(subproc_test_msg)
-        subproc_logger = logging.getLogger("subproc_logger")
-        subproc_logger.warning("i'm in a subproc")
         # do things
-        x = 2**5
-        thirty_two_squares = [m for m in map(lambda y: y**2, range(x))]
+        x = 2 ** 5
+        thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
         assert thirty_two_squares[-1] == 961
-

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -207,4 +207,5 @@ def _do_things_in_subproc(subproc_test_msg, q: mp.Queue):
         x = 2 ** 5
         thirty_two_squares = [m for m in map(lambda y: y ** 2, range(x))]
         assert thirty_two_squares[-1] == 961
-        logging.getLogger(f"{test}_logger").warning("DONE doing things in subproc")
+
+    logging.getLogger(f"{test}_logger").warning("DONE doing things in subproc")

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -119,7 +119,9 @@ def test_drop_key_on_trace_spans(datadog_tracer: ddtrace.Tracer, caplog: LogCapt
     assert DatadogEagerlyDropTraceFilter.EAGERLY_DROP_TRACE_KEY not in caplog.text
 
 
-#@pytest.mark.skip("Works locally, hangs in Travis CI tests. Possible subproc or thread locking issue to investigate.")
+#@pytest.mark.skip(
+# "Works locally and in Travis CI by itself. But fails when run in Travis with other tests. Investiage test conflict."
+# )
 def test_subprocess_trace(datadog_tracer: ddtrace.Tracer, caplog: LogCaptureFixture):
     """Verify that spans created in subprocesses are written to the queue and then flushed to the server,
     when wrapped in the SubprocessTracer"""


### PR DESCRIPTION
_:warning: Best reviewed with whitespace ignored, due to many indent changes (ctx mgrs, try-finally)_

**High-level Description:**
Upgraded datadog `ddtrace-py` library, refactor to accommodate upgraded, and add more tracing into big steps of the validator that run in worker sub-processes

**Technical details:**
- This pushes a good deal of the work to enable trace spans to reach datadog from subprocess traces into a new context manager.
- That context manager is used at the file gen or validation job initiation point
- See linked PR in `data-act-broker-config` for enabling tracing: https://github.com/fedspendingtransparency/data-act-broker-config/pull/619

**Requirements for PR merge:**

**Link to JIRA Ticket:**
[OPS-1660](https://federal-spending-transparency.atlassian.net/browse/OPS-1660)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [NA] Merged concurrently with [Frontend#1234](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1234)
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [NA] Documentation Updated