### PR TITLE
DEV-7070: SF133 Loader, Single Character DEFCs

### DIFF
--- a/dataactvalidator/scripts/load_sf133.py
+++ b/dataactvalidator/scripts/load_sf133.py
@@ -166,6 +166,10 @@ def load_sf133(filename, fiscal_year, fiscal_period, force_sf133_load=False, met
         # Uppercasing DEFC to save on indexing
         # Empty values are still empty strings ('') at this point
         data['disaster_emergency_fund_code'] = data['disaster_emergency_fund_code'].str.upper()
+        # only keep the last character of any DEFC provided
+        # TODO: Remove when Broker supports 3 character DEFCs
+        last_char_only = (lambda defc: str(defc)[-1] if defc else '')
+        data['disaster_emergency_fund_code'] = data['disaster_emergency_fund_code'].apply(last_char_only)
 
         # we didn't use the the 'keep_null' option when padding allocation transfer agency, because nulls in that column
         # break the pivot (see above comments). so, replace the ata '000' with an empty value before inserting to db


### PR DESCRIPTION
**High level description:**
Update the GTAS SF133 loader to only store single character DEFCs (by extracting only the last character if more are provided) 

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-7070](https://federal-spending-transparency.atlassian.net/browse/DEV-7070)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Tested locally
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated