### PR TITLE
DEV-9553: Fix File F Award Linking Logic

### DIFF
--- a/dataactcore/scripts/raw_sql/fileF.sql
+++ b/dataactcore/scripts/raw_sql/fileF.sql
@@ -25,7 +25,7 @@ submission_awards_{0} AS
     WHERE EXISTS (SELECT 1
         FROM afa_sub_{0} AS afa
         WHERE UPPER(TRANSLATE(subaward.award_id, '-', '')) = UPPER(TRANSLATE(afa.fain, '-', ''))
-            AND UPPER(subaward.awarding_sub_tier_agency_c) = UPPER(afa.awarding_sub_tier_agency_c)
+            AND UPPER(subaward.awarding_sub_tier_agency_c) IS NOT DISTINCT FROM UPPER(afa.awarding_sub_tier_agency_c)
             AND subaward.subaward_type = 'sub-grant'
     ))
 SELECT

--- a/dataactcore/scripts/raw_sql/fileF.sql
+++ b/dataactcore/scripts/raw_sql/fileF.sql
@@ -5,7 +5,8 @@ WITH ap_sub_{0} AS (
     FROM award_procurement
     WHERE submission_id = {0}),
 afa_sub_{0} AS (
-    SELECT fain
+    SELECT fain,
+        awarding_sub_tier_agency_c
     FROM award_financial_assistance
     WHERE submission_id = {0}),
 submission_awards_{0} AS
@@ -13,8 +14,8 @@ submission_awards_{0} AS
     FROM subaward
     WHERE EXISTS (SELECT 1
         FROM ap_sub_{0} AS ap
-        WHERE UPPER(subaward.award_id) = UPPER(ap.piid)
-            AND COALESCE(UPPER(subaward.parent_award_id), '') = COALESCE(UPPER(ap.parent_award_id), '')
+        WHERE UPPER(TRANSLATE(subaward.award_id, '-', '')) = UPPER(TRANSLATE(ap.piid, '-', ''))
+            AND UPPER(TRANSLATE(subaward.parent_award_id, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(ap.parent_award_id, '-', ''))
             AND UPPER(subaward.awarding_sub_tier_agency_c) = UPPER(ap.awarding_sub_tier_agency_c)
             AND subaward.subaward_type = 'sub-contract'
     )
@@ -23,7 +24,8 @@ submission_awards_{0} AS
     FROM subaward
     WHERE EXISTS (SELECT 1
         FROM afa_sub_{0} AS afa
-        WHERE UPPER(subaward.award_id) = UPPER(afa.fain)
+        WHERE UPPER(TRANSLATE(subaward.award_id, '-', '')) = UPPER(TRANSLATE(afa.fain, '-', ''))
+            AND UPPER(subaward.awarding_sub_tier_agency_c) = UPPER(afa.awarding_sub_tier_agency_c)
             AND subaward.subaward_type = 'sub-grant'
     ))
 SELECT

--- a/dataactcore/scripts/raw_sql/fileF.sql
+++ b/dataactcore/scripts/raw_sql/fileF.sql
@@ -14,6 +14,7 @@ submission_awards_{0} AS
     FROM subaward
     WHERE EXISTS (SELECT 1
         FROM ap_sub_{0} AS ap
+        -- Subcontract Award linking logic, should be consistent with populate and link subcontract SQL
         WHERE UPPER(TRANSLATE(subaward.award_id, '-', '')) = UPPER(TRANSLATE(ap.piid, '-', ''))
             AND UPPER(TRANSLATE(subaward.parent_award_id, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(ap.parent_award_id, '-', ''))
             AND UPPER(subaward.awarding_sub_tier_agency_c) = UPPER(ap.awarding_sub_tier_agency_c)
@@ -24,6 +25,7 @@ submission_awards_{0} AS
     FROM subaward
     WHERE EXISTS (SELECT 1
         FROM afa_sub_{0} AS afa
+        -- Subgrant Award linking logic, should be consistent with populate and link subgrant SQL
         WHERE UPPER(TRANSLATE(subaward.award_id, '-', '')) = UPPER(TRANSLATE(afa.fain, '-', ''))
             AND UPPER(subaward.awarding_sub_tier_agency_c) IS NOT DISTINCT FROM UPPER(afa.awarding_sub_tier_agency_c)
             AND subaward.subaward_type = 'sub-grant'

--- a/dataactcore/scripts/raw_sql/fileF.sql
+++ b/dataactcore/scripts/raw_sql/fileF.sql
@@ -14,7 +14,6 @@ submission_awards_{0} AS
     FROM subaward
     WHERE EXISTS (SELECT 1
         FROM ap_sub_{0} AS ap
-        -- Subcontract Award linking logic, should be consistent with populate and link subcontract SQL
         WHERE UPPER(TRANSLATE(subaward.award_id, '-', '')) = UPPER(TRANSLATE(ap.piid, '-', ''))
             AND UPPER(TRANSLATE(subaward.parent_award_id, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(ap.parent_award_id, '-', ''))
             AND UPPER(subaward.awarding_sub_tier_agency_c) = UPPER(ap.awarding_sub_tier_agency_c)
@@ -25,7 +24,6 @@ submission_awards_{0} AS
     FROM subaward
     WHERE EXISTS (SELECT 1
         FROM afa_sub_{0} AS afa
-        -- Subgrant Award linking logic, should be consistent with populate and link subgrant SQL
         WHERE UPPER(TRANSLATE(subaward.award_id, '-', '')) = UPPER(TRANSLATE(afa.fain, '-', ''))
             AND UPPER(subaward.awarding_sub_tier_agency_c) IS NOT DISTINCT FROM UPPER(afa.awarding_sub_tier_agency_c)
             AND subaward.subaward_type = 'sub-grant'

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
@@ -30,7 +30,6 @@ aw_dap AS
     WHERE EXISTS (
         SELECT 1
         FROM unlinked_subs
-        -- Subcontract Award linking logic, should be consistent with FileF SQL and poppulate subcontract SQL
         WHERE UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(dap.piid, '-', ''))
             AND UPPER(TRANSLATE(unlinked_subs.parent_award_id, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(dap.parent_award_id, '-', ''))
             AND UPPER(unlinked_subs.awarding_sub_tier_agency_c) = UPPER(dap.awarding_sub_tier_agency_c)
@@ -48,7 +47,6 @@ SET
     naics_description = aw_dap.naics_description
 FROM unlinked_subs
     JOIN aw_dap
-        -- Subcontract Award linking logic, should be consistent with FileF SQL and poppulate subcontract SQL
         ON UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(aw_dap.piid, '-', ''))
         AND UPPER(TRANSLATE(unlinked_subs.parent_award_id, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(aw_dap.parent_award_id, '-', ''))
         AND UPPER(unlinked_subs.awarding_sub_tier_agency_c) = UPPER(aw_dap.awarding_sub_tier_agency_c)

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
@@ -30,6 +30,7 @@ aw_dap AS
     WHERE EXISTS (
         SELECT 1
         FROM unlinked_subs
+        -- Subcontract Award linking logic, should be consistent with FileF SQL and poppulate subcontract SQL
         WHERE UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(dap.piid, '-', ''))
             AND UPPER(TRANSLATE(unlinked_subs.parent_award_id, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(dap.parent_award_id, '-', ''))
             AND UPPER(unlinked_subs.awarding_sub_tier_agency_c) = UPPER(dap.awarding_sub_tier_agency_c)
@@ -47,6 +48,7 @@ SET
     naics_description = aw_dap.naics_description
 FROM unlinked_subs
     JOIN aw_dap
+        -- Subcontract Award linking logic, should be consistent with FileF SQL and poppulate subcontract SQL
         ON UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(aw_dap.piid, '-', ''))
         AND UPPER(TRANSLATE(unlinked_subs.parent_award_id, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(aw_dap.parent_award_id, '-', ''))
         AND UPPER(unlinked_subs.awarding_sub_tier_agency_c) = UPPER(aw_dap.awarding_sub_tier_agency_c)

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_contracts.sql
@@ -31,7 +31,7 @@ aw_dap AS
         SELECT 1
         FROM unlinked_subs
         WHERE UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(dap.piid, '-', ''))
-            AND COALESCE(UPPER(TRANSLATE(unlinked_subs.parent_award_id, '-', '')), '') = COALESCE(UPPER(TRANSLATE(dap.parent_award_id, '-', '')), '')
+            AND UPPER(TRANSLATE(unlinked_subs.parent_award_id, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(dap.parent_award_id, '-', ''))
             AND UPPER(unlinked_subs.awarding_sub_tier_agency_c) = UPPER(dap.awarding_sub_tier_agency_c)
         )
         {0}
@@ -47,8 +47,7 @@ SET
     naics_description = aw_dap.naics_description
 FROM unlinked_subs
     JOIN aw_dap
-        ON (UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(aw_dap.piid, '-', ''))
-        AND COALESCE(UPPER(TRANSLATE(unlinked_subs.parent_award_id, '-', '')), '') = COALESCE(UPPER(TRANSLATE(aw_dap.parent_award_id, '-', '')), '')
+        ON UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(aw_dap.piid, '-', ''))
+        AND UPPER(TRANSLATE(unlinked_subs.parent_award_id, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(aw_dap.parent_award_id, '-', ''))
         AND UPPER(unlinked_subs.awarding_sub_tier_agency_c) = UPPER(aw_dap.awarding_sub_tier_agency_c)
-        )
 WHERE subaward.id = unlinked_subs.id;

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_grants.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_grants.sql
@@ -34,6 +34,7 @@ aw_pafa AS
             SELECT 1
             FROM unlinked_subs
             WHERE pafa.record_type <> 1
+                -- Subgrant Award linking logic, should be consistent with FileF SQL and populate subgrant SQL
                 AND UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(pafa.fain, '-', ''))
                 AND UPPER(unlinked_subs.awarding_sub_tier_agency_c) IS NOT DISTINCT FROM UPPER(pafa.awarding_sub_tier_agency_c)
         )
@@ -57,6 +58,7 @@ SET
     business_types = aw_pafa.business_types_desc
 FROM unlinked_subs
      JOIN aw_pafa
+        -- Subgrant Award linking logic, should be consistent with FileF SQL and populate subgrant SQL
         ON UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(aw_pafa.fain, '-', ''))
         AND UPPER(unlinked_subs.awarding_sub_tier_agency_c) IS NOT DISTINCT FROM UPPER(aw_pafa.awarding_sub_tier_agency_c)
 WHERE subaward.id = unlinked_subs.id;

--- a/dataactcore/scripts/raw_sql/link_broken_subaward_grants.sql
+++ b/dataactcore/scripts/raw_sql/link_broken_subaward_grants.sql
@@ -34,7 +34,6 @@ aw_pafa AS
             SELECT 1
             FROM unlinked_subs
             WHERE pafa.record_type <> 1
-                -- Subgrant Award linking logic, should be consistent with FileF SQL and populate subgrant SQL
                 AND UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(pafa.fain, '-', ''))
                 AND UPPER(unlinked_subs.awarding_sub_tier_agency_c) IS NOT DISTINCT FROM UPPER(pafa.awarding_sub_tier_agency_c)
         )
@@ -58,7 +57,6 @@ SET
     business_types = aw_pafa.business_types_desc
 FROM unlinked_subs
      JOIN aw_pafa
-        -- Subgrant Award linking logic, should be consistent with FileF SQL and populate subgrant SQL
         ON UPPER(TRANSLATE(unlinked_subs.award_id, '-', '')) = UPPER(TRANSLATE(aw_pafa.fain, '-', ''))
         AND UPPER(unlinked_subs.awarding_sub_tier_agency_c) IS NOT DISTINCT FROM UPPER(aw_pafa.awarding_sub_tier_agency_c)
 WHERE subaward.id = unlinked_subs.id;

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -19,7 +19,6 @@ WITH aw_dap AS
     WHERE EXISTS (
         SELECT 1
         FROM fsrs_procurement
-        -- Subcontract Award linking logic, should be consistent with FileF SQL and link broken subcontract SQL
         WHERE UPPER(TRANSLATE(fsrs_procurement.contract_number, '-', '')) = UPPER(TRANSLATE(dap.piid, '-', ''))
             AND UPPER(TRANSLATE(fsrs_procurement.idv_reference_number, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(dap.parent_award_id, '-', ''))
             AND UPPER(fsrs_procurement.contracting_office_aid) = UPPER(dap.awarding_sub_tier_agency_c)
@@ -315,7 +314,6 @@ FROM fsrs_procurement
     JOIN fsrs_subcontract
         ON fsrs_subcontract.parent_id = fsrs_procurement.id
     LEFT OUTER JOIN aw_dap
-        -- Subcontract Award linking logic, should be consistent with FileF SQL and link broken subcontract SQL
         ON UPPER(TRANSLATE(fsrs_procurement.contract_number, '-', '')) = UPPER(TRANSLATE(aw_dap.piid, '-', ''))
         AND UPPER(TRANSLATE(fsrs_procurement.idv_reference_number, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(aw_dap.parent_award_id, '-', ''))
         AND UPPER(fsrs_procurement.contracting_office_aid) = UPPER(aw_dap.awarding_sub_tier_agency_c)

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -314,9 +314,9 @@ FROM fsrs_procurement
     JOIN fsrs_subcontract
         ON fsrs_subcontract.parent_id = fsrs_procurement.id
     LEFT OUTER JOIN aw_dap
-        ON (UPPER(TRANSLATE(fsrs_procurement.contract_number, '-', '')) = UPPER(TRANSLATE(aw_dap.piid, '-', ''))
+        ON UPPER(TRANSLATE(fsrs_procurement.contract_number, '-', '')) = UPPER(TRANSLATE(aw_dap.piid, '-', ''))
         AND UPPER(TRANSLATE(fsrs_procurement.idv_reference_number, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(aw_dap.parent_award_id, '-', ''))
-        AND UPPER(fsrs_procurement.contracting_office_aid) = UPPER(aw_dap.awarding_sub_tier_agency_c))
+        AND UPPER(fsrs_procurement.contracting_office_aid) = UPPER(aw_dap.awarding_sub_tier_agency_c)
     LEFT OUTER JOIN country_code AS le_country
         ON UPPER(fsrs_procurement.company_address_country) = UPPER(le_country.country_code)
     LEFT OUTER JOIN country_code AS ppop_country

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_contracts.sql
@@ -19,6 +19,7 @@ WITH aw_dap AS
     WHERE EXISTS (
         SELECT 1
         FROM fsrs_procurement
+        -- Subcontract Award linking logic, should be consistent with FileF SQL and link broken subcontract SQL
         WHERE UPPER(TRANSLATE(fsrs_procurement.contract_number, '-', '')) = UPPER(TRANSLATE(dap.piid, '-', ''))
             AND UPPER(TRANSLATE(fsrs_procurement.idv_reference_number, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(dap.parent_award_id, '-', ''))
             AND UPPER(fsrs_procurement.contracting_office_aid) = UPPER(dap.awarding_sub_tier_agency_c)
@@ -314,6 +315,7 @@ FROM fsrs_procurement
     JOIN fsrs_subcontract
         ON fsrs_subcontract.parent_id = fsrs_procurement.id
     LEFT OUTER JOIN aw_dap
+        -- Subcontract Award linking logic, should be consistent with FileF SQL and link broken subcontract SQL
         ON UPPER(TRANSLATE(fsrs_procurement.contract_number, '-', '')) = UPPER(TRANSLATE(aw_dap.piid, '-', ''))
         AND UPPER(TRANSLATE(fsrs_procurement.idv_reference_number, '-', '')) IS NOT DISTINCT FROM UPPER(TRANSLATE(aw_dap.parent_award_id, '-', ''))
         AND UPPER(fsrs_procurement.contracting_office_aid) = UPPER(aw_dap.awarding_sub_tier_agency_c)

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
@@ -380,8 +380,8 @@ FROM fsrs_grant
     JOIN fsrs_subgrant
         ON fsrs_subgrant.parent_id = fsrs_grant.id
     LEFT OUTER JOIN aw_pafa
-        ON UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(aw_pafa.fain, '-', '')
-        AND UPPER(fsrs_grant.federal_agency_id) IS NOT DISTINCT FROM UPPER(aw_pafa.awarding_sub_tier_agency_c))
+        ON UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(aw_pafa.fain, '-', ''))
+        AND UPPER(fsrs_grant.federal_agency_id) IS NOT DISTINCT FROM UPPER(aw_pafa.awarding_sub_tier_agency_c)
     LEFT OUTER JOIN country_code AS le_country
         ON UPPER(fsrs_grant.awardee_address_country) = UPPER(le_country.country_code)
     LEFT OUTER JOIN country_code AS ppop_country

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
@@ -28,7 +28,6 @@ WITH aw_pafa AS
             FROM fsrs_grant
             WHERE record_type <> 1
                 AND fsrs_grant.id {0} {1}
-                -- Subgrant Award linking logic, should be consistent with FileF SQL and link broken subgrant SQL
                 AND UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(pafa.fain, '-', ''))
                 AND UPPER(fsrs_grant.federal_agency_id) IS NOT DISTINCT FROM UPPER(pafa.awarding_sub_tier_agency_c)
         )
@@ -381,7 +380,6 @@ FROM fsrs_grant
     JOIN fsrs_subgrant
         ON fsrs_subgrant.parent_id = fsrs_grant.id
     LEFT OUTER JOIN aw_pafa
-        -- Subgrant Award linking logic, should be consistent with FileF SQL and link broken subgrant SQL
         ON UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(aw_pafa.fain, '-', '')
         AND UPPER(fsrs_grant.federal_agency_id) IS NOT DISTINCT FROM UPPER(aw_pafa.awarding_sub_tier_agency_c))
     LEFT OUTER JOIN country_code AS le_country

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
@@ -28,6 +28,7 @@ WITH aw_pafa AS
             FROM fsrs_grant
             WHERE record_type <> 1
                 AND fsrs_grant.id {0} {1}
+                -- Subgrant Award linking logic, should be consistent with FileF SQL and link broken subgrant SQL
                 AND UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(pafa.fain, '-', ''))
                 AND UPPER(fsrs_grant.federal_agency_id) IS NOT DISTINCT FROM UPPER(pafa.awarding_sub_tier_agency_c)
         )
@@ -380,6 +381,7 @@ FROM fsrs_grant
     JOIN fsrs_subgrant
         ON fsrs_subgrant.parent_id = fsrs_grant.id
     LEFT OUTER JOIN aw_pafa
+        -- Subgrant Award linking logic, should be consistent with FileF SQL and link broken subgrant SQL
         ON UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(aw_pafa.fain, '-', '')
         AND UPPER(fsrs_grant.federal_agency_id) IS NOT DISTINCT FROM UPPER(aw_pafa.awarding_sub_tier_agency_c))
     LEFT OUTER JOIN country_code AS le_country

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
@@ -29,7 +29,7 @@ WITH aw_pafa AS
             WHERE record_type <> 1
                 AND fsrs_grant.id {0} {1}
                 AND UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(pafa.fain, '-', ''))
-                AND UPPER(fsrs_grant.federal_agency_id) = UPPER(pafa.awarding_sub_tier_agency_c)
+                AND UPPER(fsrs_grant.federal_agency_id) IS NOT DISTINCT FROM UPPER(pafa.awarding_sub_tier_agency_c)
         )
     ORDER BY UPPER(pafa.fain), UPPER(pafa.awarding_sub_tier_agency_c), pafa.action_date),
 grant_pduns AS
@@ -381,7 +381,7 @@ FROM fsrs_grant
         ON fsrs_subgrant.parent_id = fsrs_grant.id
     LEFT OUTER JOIN aw_pafa
         ON UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(aw_pafa.fain, '-', '')
-        AND UPPER(fsrs_grant.federal_agency_id) = UPPER(aw_pafa.awarding_sub_tier_agency_c))
+        AND UPPER(fsrs_grant.federal_agency_id) IS NOT DISTINCT FROM UPPER(aw_pafa.awarding_sub_tier_agency_c))
     LEFT OUTER JOIN country_code AS le_country
         ON UPPER(fsrs_grant.awardee_address_country) = UPPER(le_country.country_code)
     LEFT OUTER JOIN country_code AS ppop_country

--- a/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
+++ b/dataactcore/scripts/raw_sql/populate_subaward_table_grants.sql
@@ -29,7 +29,7 @@ WITH aw_pafa AS
             WHERE record_type <> 1
                 AND fsrs_grant.id {0} {1}
                 AND UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(pafa.fain, '-', ''))
-                AND UPPER(fsrs_grant.federal_agency_id) IS NOT DISTINCT FROM UPPER(pafa.awarding_sub_tier_agency_c)
+                AND UPPER(fsrs_grant.federal_agency_id) = UPPER(pafa.awarding_sub_tier_agency_c)
         )
     ORDER BY UPPER(pafa.fain), UPPER(pafa.awarding_sub_tier_agency_c), pafa.action_date),
 grant_pduns AS
@@ -380,8 +380,8 @@ FROM fsrs_grant
     JOIN fsrs_subgrant
         ON fsrs_subgrant.parent_id = fsrs_grant.id
     LEFT OUTER JOIN aw_pafa
-        ON (UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(aw_pafa.fain, '-', ''))
-        AND UPPER(fsrs_grant.federal_agency_id) IS NOT DISTINCT FROM UPPER(aw_pafa.awarding_sub_tier_agency_c))
+        ON UPPER(TRANSLATE(fsrs_grant.fain, '-', '')) = UPPER(TRANSLATE(aw_pafa.fain, '-', '')
+        AND UPPER(fsrs_grant.federal_agency_id) = UPPER(aw_pafa.awarding_sub_tier_agency_c))
     LEFT OUTER JOIN country_code AS le_country
         ON UPPER(fsrs_grant.awardee_address_country) = UPPER(le_country.country_code)
     LEFT OUTER JOIN country_code AS ppop_country

--- a/tests/unit/dataactcore/test_fileF.py
+++ b/tests/unit/dataactcore/test_fileF.py
@@ -109,21 +109,27 @@ def test_generate_file_f_sql(database, monkeypatch):
 
     d1_show = AwardProcurementFactory(submission_id=sub1.submission_id, piid='PIID1', parent_award_id='PID1',
                                       awarding_sub_tier_agency_c='ASAC1')
-    d2_show = AwardFinancialAssistanceFactory(submission_id=sub1.submission_id, fain='FAIN1')
+    d2_show = AwardFinancialAssistanceFactory(submission_id=sub1.submission_id, fain='FAIN1',
+                                              awarding_sub_tier_agency_c='SUBTIER1')
     d1_hide = AwardProcurementFactory(submission_id=sub2.submission_id, piid='PIID2', parent_award_id='PID2',
                                       awarding_sub_tier_agency_c='ASAC2')
-    d2_hide = AwardFinancialAssistanceFactory(submission_id=sub2.submission_id, fain='FAIN2')
+    d2_hide = AwardFinancialAssistanceFactory(submission_id=sub2.submission_id, fain='FAIN2',
+                                              awarding_sub_tier_agency_c='SUBTIER2')
 
     sub_contracts_show = [SubawardFactory(id=i, subaward_type='sub-contract', award_id=d1_show.piid,
                                           parent_award_id=d1_show.parent_award_id,
                                           awarding_sub_tier_agency_c=d1_show.awarding_sub_tier_agency_c)
                           for i in range(0, 5)]
-    sub_grants_show = [SubawardFactory(id=i, subaward_type='sub-grant', award_id=d2_show.fain) for i in range(5, 10)]
+    sub_grants_show = [SubawardFactory(id=i, subaward_type='sub-grant', award_id=d2_show.fain,
+                                       awarding_sub_tier_agency_c=d2_show.awarding_sub_tier_agency_c)
+                       for i in range(5, 10)]
     sub_contracts_hide = [SubawardFactory(id=i, subaward_type='sub-contract', award_id=d1_hide.piid,
                                           parent_award_id=d1_hide.parent_award_id,
                                           awarding_sub_tier_agency_c=d1_hide.awarding_sub_tier_agency_c)
                           for i in range(10, 15)]
-    sub_grants_hide = [SubawardFactory(id=i, subaward_type='sub-grant', award_id=d2_hide.fain) for i in range(15, 20)]
+    sub_grants_hide = [SubawardFactory(id=i, subaward_type='sub-grant', award_id=d2_hide.fain,
+                                       awarding_sub_tier_agency_c=d2_hide.awarding_sub_tier_agency_c)
+                       for i in range(15, 20)]
     subawards = sub_contracts_show + sub_grants_show + sub_contracts_hide + sub_grants_hide
 
     sess.add_all([sub1, sub2, d1_hide, d1_show, d2_hide, d2_show] + subawards)


### PR DESCRIPTION
**High level description:**
Resolving bug with File F that was excluding subtiers when linking grants.

**Technical details:**
Ensured the subaward linking logic was consistent among:
* File F SQL
* Populate Subaward SQL
* Fix Broken Subaward Links SQL

Also noting you can't add comments to the SQL, so we need to ensure this logic is documented somewhere and remains consistent.

**Link to JIRA Ticket:**
[DEV-9553](https://federal-spending-transparency.atlassian.net/browse/DEV-9553)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Tested locally
- [x] Frontend impact assessment completed
- [x] Documentation Updated