### PR TITLE
Pin Python release in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7.10
 
 RUN apt-get -y update
 RUN apt-get install -y postgresql-client


### PR DESCRIPTION
**High level description:**
We need to pin the release version of Python in the Dockerfile. Python 3.7.11 had some breaking changes to some of C libraries.

**Technical details:**
Don't forget to rebuild the container using the docker-broker-backend job for each environment. 

**Link to JIRA Ticket:**
NONE

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [ ] Merged concurrently with [Frontend#1234](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1234)
- [ ] Unit & integration tests updated with relevant test cases
- [ ] Frontend impact assessment completed
- [ ] Documentation Updated