### PR TITLE
DEV-7870: Reverting/readding DEFC 9 exception to C27 (hotfix)

### DIFF
--- a/dataactvalidator/config/sqlrules/c27_award_financial.sql
+++ b/dataactvalidator/config/sqlrules/c27_award_financial.sql
@@ -57,7 +57,8 @@ WHERE NOT EXISTS (
         AND UPPER(COALESCE(po.piid, '')) = UPPER(COALESCE(af.piid, ''))
         AND UPPER(COALESCE(po.parent_award_id, '')) = UPPER(COALESCE(af.parent_award_id, ''))
         AND UPPER(COALESCE(po.tas, '')) = UPPER(COALESCE(af.tas, ''))
-        AND UPPER(COALESCE(po.disaster_emergency_fund_code, '')) = UPPER(COALESCE(af.disaster_emergency_fund_code, ''))
+        AND (UPPER(COALESCE(po.disaster_emergency_fund_code, '')) = UPPER(COALESCE(af.disaster_emergency_fund_code, ''))
+            OR UPPER(COALESCE(po.disaster_emergency_fund_code, '')) = '9')
         AND af.submission_id = {0}
         AND af.gross_outlay_amount_by_awa_cpe IS NOT NULL
 );

--- a/tests/unit/dataactvalidator/test_c27_award_financial.py
+++ b/tests/unit/dataactvalidator/test_c27_award_financial.py
@@ -45,7 +45,10 @@ def test_success(database):
     caf_tas = CertifiedAwardFinancialFactory(submission_id=sub_1.submission_id, tas='different_tas', fain='hiJK',
                                              uri=None, piid=None, parent_award_id=None,
                                              disaster_emergency_fund_code='n', gross_outlay_amount_by_awa_cpe=5)
-    database.session.add_all([sub_1, caf_fain, caf_uri, caf_piid, caf_paid, caf_zero, caf_null, caf_tas])
+    caf_all_9 = CertifiedAwardFinancialFactory(submission_id=sub_1.submission_id, tas='test_tas', fain='aBcD',
+                                               uri='eFgH', piid='mNoP', parent_award_id='qRsT',
+                                               disaster_emergency_fund_code='9', gross_outlay_amount_by_awa_cpe=5)
+    database.session.add_all([sub_1, caf_fain, caf_uri, caf_piid, caf_paid, caf_zero, caf_null, caf_tas, caf_all_9])
     database.session.commit()
 
     # quarterly submission with each of the previous values (one of them is 0 now)
@@ -72,11 +75,16 @@ def test_success(database):
     af_tas = AwardFinancialFactory(submission_id=sub_q.submission_id, tas='different_tas', fain='hijk', uri=None,
                                    piid=None, parent_award_id=None, disaster_emergency_fund_code='n',
                                    gross_outlay_amount_by_awa_cpe=2)
+    # matches the DEFC of 9 with a different DEFC
+    af_9_match = AwardFinancialFactory(submission_id=sub_q.submission_id, tas='test_tas', fain='aBcD', uri='eFgH',
+                                       piid='mNoP', parent_award_id='qRsT', disaster_emergency_fund_code='n',
+                                       gross_outlay_amount_by_awa_cpe=5)
+
     # Additional line doesn't mess anything up
     af_bonus = AwardFinancialFactory(submission_id=sub_q.submission_id, tas='something_different')
 
     errors = number_of_errors(_FILE, database, models=[af_fain, af_uri, af_piid, af_paid, af_zero, af_null, af_tas,
-                                                       af_bonus],
+                                                       af_9_match, af_bonus],
                               submission=sub_q)
     assert errors == 0
 
@@ -104,11 +112,15 @@ def test_success(database):
     af_tas = AwardFinancialFactory(submission_id=sub_p.submission_id, tas='different_tas', fain='hijk', uri=None,
                                    piid=None, parent_award_id=None, disaster_emergency_fund_code='n',
                                    gross_outlay_amount_by_awa_cpe=2)
+    # matches the DEFC of 9 with a different DEFC
+    af_9_match = AwardFinancialFactory(submission_id=sub_p.submission_id, tas='test_tas', fain='aBcD', uri='eFgH',
+                                       piid='mNoP', parent_award_id='qRsT', disaster_emergency_fund_code='n',
+                                       gross_outlay_amount_by_awa_cpe=5)
     # Additional line doesn't mess anything up
     af_bonus = AwardFinancialFactory(submission_id=sub_p.submission_id, tas='something_different')
 
     errors = number_of_errors(_FILE, database, models=[af_fain, af_uri, af_piid, af_paid, af_zero, af_null, af_tas,
-                                                       af_bonus],
+                                                       af_9_match, af_bonus],
                               submission=sub_p)
     assert errors == 0
 
@@ -130,8 +142,11 @@ def test_success(database):
     af_tas = AwardFinancialFactory(submission_id=sub_4.submission_id, tas='different_tas', fain='hijk', uri=None,
                                    piid=None, parent_award_id=None, disaster_emergency_fund_code='n',
                                    gross_outlay_amount_by_awa_cpe=2)
+    af_9_match = AwardFinancialFactory(submission_id=sub_4.submission_id, tas='test_tas', fain='aBcD', uri='eFgH',
+                                       piid='mNoP', parent_award_id='qRsT', disaster_emergency_fund_code='n',
+                                       gross_outlay_amount_by_awa_cpe=5)
 
-    errors = number_of_errors(_FILE, database, models=[af_fain, af_uri, af_piid, af_paid, af_tas],
+    errors = number_of_errors(_FILE, database, models=[af_fain, af_uri, af_piid, af_paid, af_tas, af_9_match],
                               submission=sub_4)
     assert errors == 0
 
@@ -155,13 +170,13 @@ def test_failure(database):
     caf_fain = CertifiedAwardFinancialFactory(submission_id=sub_1.submission_id, tas='test_tas', fain='abcd', uri=None,
                                               piid=None, parent_award_id=None, disaster_emergency_fund_code='N',
                                               gross_outlay_amount_by_awa_cpe=5)
-    caf_defc = CertifiedAwardFinancialFactory(submission_id=sub_1.submission_id, tas='test_tas', fain='abcd', uri=None,
-                                              piid=None, parent_award_id='testingHere',
-                                              disaster_emergency_fund_code='O', gross_outlay_amount_by_awa_cpe=5)
-    database.session.add_all([sub_1, caf_fain, caf_defc])
+    caf_defc_9 = CertifiedAwardFinancialFactory(submission_id=sub_1.submission_id, tas='test_tas', fain='abcd',
+                                                uri=None, piid=None, parent_award_id='testingHere',
+                                                disaster_emergency_fund_code='9', gross_outlay_amount_by_awa_cpe=5)
+    database.session.add_all([sub_1, caf_fain, caf_defc_9])
     database.session.commit()
 
-    # submission missing previous period value
+    # submission missing previous period value, missing value of 9 still registers an error
     sub_2 = SubmissionFactory(submission_id=2, reporting_fiscal_year=2020, reporting_fiscal_period=4, cgac_code='test',
                               frec_code=None, is_quarter_format=False, d2_submission=False)
 
@@ -174,11 +189,11 @@ def test_failure(database):
     af_other = AwardFinancialFactory(submission_id=sub_3.submission_id, tas='test_tas', fain='abcd', uri='efgh',
                                      piid=None, parent_award_id=None, disaster_emergency_fund_code='n',
                                      gross_outlay_amount_by_awa_cpe=5)
-    af_defc = AwardFinancialFactory(submission_id=sub_3.submission_id, tas='test_tas', fain='abcd', uri=None,
-                                    piid=None, parent_award_id='testingHere', disaster_emergency_fund_code='O',
-                                    gross_outlay_amount_by_awa_cpe=5)
+    af_defc_9 = AwardFinancialFactory(submission_id=sub_3.submission_id, tas='test_tas', fain='abcd', uri=None,
+                                      piid=None, parent_award_id='testingHere', disaster_emergency_fund_code='9',
+                                      gross_outlay_amount_by_awa_cpe=5)
 
-    errors = number_of_errors(_FILE, database, models=[af_other, af_defc], submission=sub_3)
+    errors = number_of_errors(_FILE, database, models=[af_other, af_defc_9], submission=sub_3)
     assert errors == 1
 
     # submission with a row that matches but has gross outlay of NULL
@@ -187,9 +202,9 @@ def test_failure(database):
     af_null = AwardFinancialFactory(submission_id=sub_4.submission_id, tas='test_tas', fain='abcd', uri=None,
                                     piid=None, parent_award_id=None, disaster_emergency_fund_code='n',
                                     gross_outlay_amount_by_awa_cpe=None)
-    af_defc = AwardFinancialFactory(submission_id=sub_4.submission_id, tas='test_tas', fain='abcd', uri=None,
-                                    piid=None, parent_award_id='testingHere', disaster_emergency_fund_code='o',
-                                    gross_outlay_amount_by_awa_cpe=5)
+    af_defc_9 = AwardFinancialFactory(submission_id=sub_4.submission_id, tas='test_tas', fain='abcd', uri=None,
+                                      piid=None, parent_award_id='testingHere', disaster_emergency_fund_code='n',
+                                      gross_outlay_amount_by_awa_cpe=5)
 
-    errors = number_of_errors(_FILE, database, models=[af_null, af_defc], submission=sub_4)
+    errors = number_of_errors(_FILE, database, models=[af_null, af_defc_9], submission=sub_4)
     assert errors == 1

--- a/tests/unit/dataactvalidator/test_c27_award_financial.py
+++ b/tests/unit/dataactvalidator/test_c27_award_financial.py
@@ -4,7 +4,7 @@ from tests.unit.dataactvalidator.utils import number_of_errors, query_columns, p
 
 from dataactcore.models.lookups import PUBLISH_STATUS_DICT
 
-_FILE = 'c27_award_financial' 
+_FILE = 'c27_award_financial'
 
 
 def test_column_headers(database):

--- a/tests/unit/dataactvalidator/test_c27_award_financial.py
+++ b/tests/unit/dataactvalidator/test_c27_award_financial.py
@@ -4,7 +4,7 @@ from tests.unit.dataactvalidator.utils import number_of_errors, query_columns, p
 
 from dataactcore.models.lookups import PUBLISH_STATUS_DICT
 
-_FILE = 'c27_award_financial'
+_FILE = 'c27_award_financial' 
 
 
 def test_column_headers(database):


### PR DESCRIPTION
**High level description:**
Reverts/readds the DEFC 9 exception to C27

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-7870](https://federal-spending-transparency.atlassian.net/browse/DEV-7870)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated