### PR TITLE
Zips Hotfix: Generate link to the census file later

### DIFF
--- a/dataactvalidator/scripts/read_zips.py
+++ b/dataactvalidator/scripts/read_zips.py
@@ -436,13 +436,13 @@ def read_zips():
         hot_swap_zip_tables(sess)
         update_external_data_load_date(start_time, datetime.now(), 'zip_code')
 
+        update_state_congr_table_current(sess)
         if CONFIG_BROKER["use_aws"]:
             census_file = s3_client.generate_presigned_url('get_object', {'Bucket': CONFIG_BROKER['sf_133_bucket'],
                                                                           'Key': "census_congressional_districts.csv"},
                                                            ExpiresIn=600)
         else:
             census_file = os.path.join(base_path, "census_congressional_districts.csv")
-        update_state_congr_table_current(sess)
         update_state_congr_table_census(census_file, sess)
         if CONFIG_BROKER['use_aws']:
             export_state_congr_table(sess)

--- a/dataactvalidator/scripts/read_zips.py
+++ b/dataactvalidator/scripts/read_zips.py
@@ -421,10 +421,6 @@ def read_zips():
             citystate_file = s3_client.generate_presigned_url('get_object', {'Bucket': CONFIG_BROKER['sf_133_bucket'],
                                                                              'Key': "ctystate.txt"}, ExpiresIn=600)
             parse_citystate_file(urllib.request.urlopen(citystate_file), sess)
-
-            census_file = s3_client.generate_presigned_url('get_object', {'Bucket': CONFIG_BROKER['sf_133_bucket'],
-                                                                          'Key': "census_congressional_districts.csv"},
-                                                           ExpiresIn=600)
         else:
             base_path = os.path.join(CONFIG_BROKER["path"], "dataactvalidator", "config", CONFIG_BROKER["zip_folder"])
             # creating the list while ignoring hidden files on mac
@@ -436,12 +432,16 @@ def read_zips():
             citystate_file = os.path.join(CONFIG_BROKER["path"], "dataactvalidator", "config", "ctystate.txt")
             parse_citystate_file(open(citystate_file), sess)
 
-            census_file = os.path.join(base_path, "census_congressional_districts.csv")
-
         group_zips(sess)
         hot_swap_zip_tables(sess)
         update_external_data_load_date(start_time, datetime.now(), 'zip_code')
 
+        if CONFIG_BROKER["use_aws"]:
+            census_file = s3_client.generate_presigned_url('get_object', {'Bucket': CONFIG_BROKER['sf_133_bucket'],
+                                                                          'Key': "census_congressional_districts.csv"},
+                                                           ExpiresIn=600)
+        else:
+            census_file = os.path.join(base_path, "census_congressional_districts.csv")
         update_state_congr_table_current(sess)
         update_state_congr_table_census(census_file, sess)
         if CONFIG_BROKER['use_aws']:


### PR DESCRIPTION
**High level description:**
Generating the link to the census file later immediately before it gets used to prevent expired links.

**Technical details:**
N/A

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation Updated