### PR TITLE
DEV-8246: Current User -> Active User

### DIFF
--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -855,7 +855,7 @@ def process_dabs_publish(submission, file_manager):
     """
     publish_checks(submission)
 
-    current_user_id = g.user.user_id
+    active_user_id = g.user.user_id
     sess = GlobalDB.db().session
 
     # Determine if this is the first time this submission is being published
@@ -865,7 +865,7 @@ def process_dabs_publish(submission, file_manager):
     submission.publish_status_id = PUBLISH_STATUS_DICT['publishing']
 
     # create the publish_history entry
-    publish_history = PublishHistory(user_id=current_user_id, submission_id=submission.submission_id)
+    publish_history = PublishHistory(user_id=active_user_id, submission_id=submission.submission_id)
     sess.add(publish_history)
     sess.commit()
 
@@ -880,7 +880,7 @@ def process_dabs_publish(submission, file_manager):
     file_manager.move_published_files(submission, publish_history, None, file_manager.is_local)
 
     # set submission contents
-    submission.publishing_user_id = current_user_id
+    submission.publishing_user_id = active_user_id
     submission.publish_status_id = PUBLISH_STATUS_DICT['published']
     publish_history.updated_at = datetime.utcnow()
     sess.commit()
@@ -907,7 +907,7 @@ def process_dabs_certify(submission):
             ValueError if this is somehow called without a PublishHistory associated with the submission ID or if there
             is already a certification associated with the most recent publication
     """
-    current_user_id = g.user.user_id
+    active_user_id = g.user.user_id
     sess = GlobalDB.db().session
 
     max_pub_history = sess.query(func.max(PublishHistory.publish_history_id).label('max_id')). \
@@ -923,7 +923,7 @@ def process_dabs_certify(submission):
         if pub_file.certify_history_id is not None:
             raise ValueError('This submission already has a certification associated with the most recent publication.')
 
-    certify_history = CertifyHistory(user_id=current_user_id, submission_id=submission.submission_id)
+    certify_history = CertifyHistory(user_id=active_user_id, submission_id=submission.submission_id)
     sess.add(certify_history)
     sess.commit()
 

--- a/dataactbroker/routes/user_routes.py
+++ b/dataactbroker/routes/user_routes.py
@@ -34,9 +34,9 @@ def add_user_routes(app, system_email, bcrypt):
         """ List all users with submissions that the requesting user has permissions for """
         return list_submission_users(d2_submission)
 
-    @app.route("/v1/current_user/", methods=["GET"])
+    @app.route("/v1/active_user/", methods=["GET"])
     @requires_login
-    def current_user():
+    def active_user():
         """ gets the current user information """
         return JsonResponse.create(StatusCode.OK, json_for_user(g.user, session['sid']))
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -102,7 +102,7 @@ It may take about 30+ seconds for all containers to report as running and ready.
 
 _**To the API:**_
 ```
-$ curl http://localhost:9999/v1/current_user/
+$ curl http://localhost:9999/v1/active_user/
 ```
 ```
 {"message": "Login Required"}

--- a/doc/README.md
+++ b/doc/README.md
@@ -147,7 +147,7 @@ Settings routes are used to set agency-wide settings for the DABS Dashboard. The
 ### User Routes
 User routes are used to get information about available users or get/set information about the currently logged in user.
 
-- [current\_user](./api_docs/user/current_user.md)
+- [active\_user](./api_docs/user/active_user.md)
 - [list\_submission\_users](./api_docs/user/list_submission_users.md)
 - [list\_user\_emails](./api_docs/user/list_user_emails.md)
 - [set\_skip\_guide](./api_docs/user/set_skip_guide.md)

--- a/doc/api_docs/login/login.md
+++ b/doc/api_docs/login/login.md
@@ -2,7 +2,7 @@
 
 **THIS ENDPOINT IS FOR LOCAL DEVELOPMENT ONLY AND CANNOT BE USED TO AUTHENTICATE INTO BROKER IN PRODUCTION**
 
-This route checks the username and password against a credentials file. It is used solely as a workaround for developing on a local instance of the broker to bypass MAX.gov login. Accepts input as json or form-urlencoded, with keys "username" and "password". See `current_user` docs for details.
+This route checks the username and password against a credentials file. It is used solely as a workaround for developing on a local instance of the broker to bypass MAX.gov login. Accepts input as json or form-urlencoded, with keys "username" and "password". See `active_user` docs for details.
 
 ## Body (JSON)
 

--- a/doc/api_docs/user/active_user.md
+++ b/doc/api_docs/user/active_user.md
@@ -1,5 +1,5 @@
 # GET "/v1/active\_user/"
-Gets the information of the current that is logged in to the system.
+Gets the information of the active user that is logged into the system.
 
 ## Sample Request
 `/v1/active_user/`

--- a/doc/api_docs/user/active_user.md
+++ b/doc/api_docs/user/active_user.md
@@ -1,8 +1,8 @@
-# GET "/v1/current\_user/"
+# GET "/v1/active\_user/"
 Gets the information of the current that is logged in to the system.
 
 ## Sample Request
-`/v1/current_user/`
+`/v1/active_user/`
     
 ## Request Params
 N/A

--- a/tests/integration/userTests.py
+++ b/tests/integration/userTests.py
@@ -48,9 +48,9 @@ class UserTests(BaseTestAPI):
         super(UserTests, self).setUp()
         self.login_admin_user()
 
-    def test_current_user(self):
+    def test_active_user(self):
         """Test retrieving current user information."""
-        response = self.app.get("/v1/current_user/", headers={"x-session-id": self.session_id})
+        response = self.app.get("/v1/active_user/", headers={"x-session-id": self.session_id})
         self.check_response(response, StatusCode.OK)
         assert response.json["name"] == "Administrator"
         assert not response.json["skip_guide"]

--- a/tests/unit/dataactbroker/test_permissions.py
+++ b/tests/unit/dataactbroker/test_permissions.py
@@ -12,7 +12,7 @@ from tests.unit.dataactcore.factories.job import SubmissionFactory
 from tests.unit.dataactcore.factories.user import UserFactory
 
 
-def test_current_user_can_dabs_cgac_reader(database, monkeypatch, user_constants):
+def test_active_user_can_dabs_cgac_reader(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_reader = UserFactory(affiliations=[
         UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_TYPE_DICT['reader'])
@@ -23,23 +23,23 @@ def test_current_user_can_dabs_cgac_reader(database, monkeypatch, user_constants
     monkeypatch.setattr(permissions, 'g', Mock(user=user_reader))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('reader', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('reader', cgac_code=user_cgac.cgac_code)
 
     # wrong permission level, wrong agency, but superuser
     user_reader.website_admin = True
-    assert permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
+    assert permissions.active_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
 
-def test_current_user_can_dabs_cgac_writer(database, monkeypatch, user_constants):
+def test_active_user_can_dabs_cgac_writer(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_writer = UserFactory(affiliations=[
         UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_TYPE_DICT['writer'])
@@ -50,24 +50,24 @@ def test_current_user_can_dabs_cgac_writer(database, monkeypatch, user_constants
     monkeypatch.setattr(permissions, 'g', Mock(user=user_writer))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('writer', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('writer', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('writer', cgac_code=user_cgac.cgac_code)
 
     # wrong permission level, wrong agency, but superuser
     user_writer.website_admin = True
-    assert permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
+    assert permissions.active_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
 
-def test_current_user_can_dabs_cgac_submitter(database, monkeypatch, user_constants):
+def test_active_user_can_dabs_cgac_submitter(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_submitter = UserFactory(affiliations=[
         UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_TYPE_DICT['submitter'])
@@ -78,25 +78,25 @@ def test_current_user_can_dabs_cgac_submitter(database, monkeypatch, user_consta
     monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('writer', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('writer', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('submitter', cgac_code=user_cgac.cgac_code)
 
     # wrong agency, but superuser
     user_submitter.website_admin = True
-    assert permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
+    assert permissions.active_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
 
-def test_current_user_can_dabs_frec_reader(database, monkeypatch, user_constants):
+def test_active_user_can_dabs_frec_reader(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_frec, other_frec = FRECFactory(cgac=user_cgac), FRECFactory(cgac=other_cgac)
     user_reader = UserFactory(affiliations=[
@@ -108,23 +108,23 @@ def test_current_user_can_dabs_frec_reader(database, monkeypatch, user_constants
     monkeypatch.setattr(permissions, 'g', Mock(user=user_reader))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('reader', frec_code=other_frec.frec_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', frec_code=user_frec.frec_code)
-    assert not permissions.current_user_can('submitter', frec_code=user_frec.frec_code)
-    assert not permissions.current_user_can('editfabs', cgac_code=user_frec.frec_code)
-    assert not permissions.current_user_can('fabs', cgac_code=user_frec.frec_code)
+    assert not permissions.active_user_can('writer', frec_code=user_frec.frec_code)
+    assert not permissions.active_user_can('submitter', frec_code=user_frec.frec_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=user_frec.frec_code)
+    assert not permissions.active_user_can('fabs', cgac_code=user_frec.frec_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('reader', frec_code=user_frec.frec_code)
 
     # wrong permission level, wrong agency, but superuser
     user_reader.website_admin = True
-    assert permissions.current_user_can('submitter', frec_code=other_frec.frec_code)
+    assert permissions.active_user_can('submitter', frec_code=other_frec.frec_code)
 
 
-def test_current_user_can_dabs_frec_writer(database, monkeypatch, user_constants):
+def test_active_user_can_dabs_frec_writer(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_frec, other_frec = FRECFactory(cgac=user_cgac), FRECFactory(cgac=other_cgac)
     user_writer = UserFactory(affiliations=[
@@ -136,24 +136,24 @@ def test_current_user_can_dabs_frec_writer(database, monkeypatch, user_constants
     monkeypatch.setattr(permissions, 'g', Mock(user=user_writer))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', frec_code=other_frec.frec_code)
-    assert not permissions.current_user_can('writer', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('reader', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('writer', frec_code=other_frec.frec_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('submitter', frec_code=user_frec.frec_code)
-    assert not permissions.current_user_can('editfabs', cgac_code=user_frec.frec_code)
-    assert not permissions.current_user_can('fabs', cgac_code=user_frec.frec_code)
+    assert not permissions.active_user_can('submitter', frec_code=user_frec.frec_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=user_frec.frec_code)
+    assert not permissions.active_user_can('fabs', cgac_code=user_frec.frec_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', frec_code=user_frec.frec_code)
-    assert permissions.current_user_can('writer', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('reader', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('writer', frec_code=user_frec.frec_code)
 
     # wrong permission level, wrong agency, but superuser
     user_writer.website_admin = True
-    assert permissions.current_user_can('submitter', frec_code=other_frec.frec_code)
+    assert permissions.active_user_can('submitter', frec_code=other_frec.frec_code)
 
 
-def test_current_user_can_dabs_frec_submitter(database, monkeypatch, user_constants):
+def test_active_user_can_dabs_frec_submitter(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_frec, other_frec = FRECFactory(cgac=user_cgac), FRECFactory(cgac=other_cgac)
     user_submitter = UserFactory(affiliations=[
@@ -165,25 +165,25 @@ def test_current_user_can_dabs_frec_submitter(database, monkeypatch, user_consta
     monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', frec_code=other_frec.frec_code)
-    assert not permissions.current_user_can('writer', frec_code=other_frec.frec_code)
-    assert not permissions.current_user_can('submitter', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('reader', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('writer', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('submitter', frec_code=other_frec.frec_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('editfabs', cgac_code=user_frec.frec_code)
-    assert not permissions.current_user_can('fabs', cgac_code=user_frec.frec_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=user_frec.frec_code)
+    assert not permissions.active_user_can('fabs', cgac_code=user_frec.frec_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', frec_code=user_frec.frec_code)
-    assert permissions.current_user_can('writer', frec_code=user_frec.frec_code)
-    assert permissions.current_user_can('submitter', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('reader', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('writer', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('submitter', frec_code=user_frec.frec_code)
 
     # wrong agency, but superuser
     user_submitter.website_admin = True
-    assert permissions.current_user_can('submitter', frec_code=other_frec.frec_code)
+    assert permissions.active_user_can('submitter', frec_code=other_frec.frec_code)
 
 
-def test_current_user_can_fabs_cgac_editfabs(database, monkeypatch, user_constants):
+def test_active_user_can_fabs_cgac_editfabs(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_editfabs = UserFactory(affiliations=[
         UserAffiliation(cgac=user_cgac, permission_type_id=ALL_PERMISSION_TYPES_DICT['editfabs'])
@@ -194,24 +194,24 @@ def test_current_user_can_fabs_cgac_editfabs(database, monkeypatch, user_constan
     monkeypatch.setattr(permissions, 'g', Mock(user=user_editfabs))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('editfabs', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('editfabs', cgac_code=user_cgac.cgac_code)
 
     # wrong permission level, wrong agency, but superuser
     user_editfabs.website_admin = True
-    assert permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
+    assert permissions.active_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
 
-def test_current_user_can_fabs_cgac_fabs(database, monkeypatch, user_constants):
+def test_active_user_can_fabs_cgac_fabs(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_fabs = UserFactory(affiliations=[
         UserAffiliation(cgac=user_cgac, permission_type_id=ALL_PERMISSION_TYPES_DICT['fabs'])
@@ -222,25 +222,25 @@ def test_current_user_can_fabs_cgac_fabs(database, monkeypatch, user_constants):
     monkeypatch.setattr(permissions, 'g', Mock(user=user_fabs))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('editfabs', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('submitter', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # wrong agency, but superuser
     user_fabs.website_admin = True
-    assert permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
+    assert permissions.active_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
 
-def test_current_user_can_fabs_frec_editfabs(database, monkeypatch, user_constants):
+def test_active_user_can_fabs_frec_editfabs(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_frec, other_frec = FRECFactory(cgac=user_cgac), FRECFactory(cgac=other_cgac)
     user_editfabs = UserFactory(affiliations=[
@@ -252,24 +252,24 @@ def test_current_user_can_fabs_frec_editfabs(database, monkeypatch, user_constan
     monkeypatch.setattr(permissions, 'g', Mock(user=user_editfabs))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', frec_code=other_frec.frec_code)
-    assert not permissions.current_user_can('editfabs', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('reader', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('editfabs', frec_code=other_frec.frec_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', frec_code=user_frec.frec_code)
-    assert not permissions.current_user_can('submitter', frec_code=user_frec.frec_code)
-    assert not permissions.current_user_can('fabs', frec_code=user_frec.frec_code)
+    assert not permissions.active_user_can('writer', frec_code=user_frec.frec_code)
+    assert not permissions.active_user_can('submitter', frec_code=user_frec.frec_code)
+    assert not permissions.active_user_can('fabs', frec_code=user_frec.frec_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', frec_code=user_frec.frec_code)
-    assert permissions.current_user_can('editfabs', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('reader', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('editfabs', frec_code=user_frec.frec_code)
 
     # wrong permission level, wrong agency, but superuser
     user_editfabs.website_admin = True
-    assert permissions.current_user_can('fabs', frec_code=other_frec.frec_code)
+    assert permissions.active_user_can('fabs', frec_code=other_frec.frec_code)
 
 
-def test_current_user_can_fabs_frec_fabs(database, monkeypatch, user_constants):
+def test_active_user_can_fabs_frec_fabs(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_frec, other_frec = FRECFactory(cgac=user_cgac), FRECFactory(cgac=other_cgac)
     user_fabs = UserFactory(affiliations=[
@@ -281,25 +281,25 @@ def test_current_user_can_fabs_frec_fabs(database, monkeypatch, user_constants):
     monkeypatch.setattr(permissions, 'g', Mock(user=user_fabs))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', frec_code=other_frec.frec_code)
-    assert not permissions.current_user_can('editfabs', frec_code=other_frec.frec_code)
-    assert not permissions.current_user_can('fabs', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('reader', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('editfabs', frec_code=other_frec.frec_code)
+    assert not permissions.active_user_can('fabs', frec_code=other_frec.frec_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', frec_code=user_frec.frec_code)
-    assert not permissions.current_user_can('submitter', frec_code=user_frec.frec_code)
+    assert not permissions.active_user_can('writer', frec_code=user_frec.frec_code)
+    assert not permissions.active_user_can('submitter', frec_code=user_frec.frec_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', frec_code=user_frec.frec_code)
-    assert permissions.current_user_can('editfabs', frec_code=user_frec.frec_code)
-    assert permissions.current_user_can('fabs', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('reader', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('editfabs', frec_code=user_frec.frec_code)
+    assert permissions.active_user_can('fabs', frec_code=user_frec.frec_code)
 
     # wrong agency, but superuser
     user_fabs.website_admin = True
-    assert permissions.current_user_can('fabs', frec_code=other_frec.frec_code)
+    assert permissions.active_user_can('fabs', frec_code=other_frec.frec_code)
 
 
-def test_current_user_can_multiple_fabs_permissions(database, monkeypatch, user_constants):
+def test_active_user_can_multiple_fabs_permissions(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_fabs = UserFactory(affiliations=[
         UserAffiliation(cgac=user_cgac, permission_type_id=ALL_PERMISSION_TYPES_DICT['editfabs']),
@@ -311,25 +311,25 @@ def test_current_user_can_multiple_fabs_permissions(database, monkeypatch, user_
     monkeypatch.setattr(permissions, 'g', Mock(user=user_fabs))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('editfabs', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('submitter', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # wrong agency, but superuser
     user_fabs.website_admin = True
-    assert permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
+    assert permissions.active_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
 
-def test_current_user_can_multiple_dabs_permissions(database, monkeypatch, user_constants):
+def test_active_user_can_multiple_dabs_permissions(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_submitter = UserFactory(affiliations=[
         UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_TYPE_DICT['writer']),
@@ -341,25 +341,25 @@ def test_current_user_can_multiple_dabs_permissions(database, monkeypatch, user_
     monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('writer', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('writer', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
-    assert not permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('submitter', cgac_code=user_cgac.cgac_code)
 
     # wrong agency, but superuser
     user_submitter.website_admin = True
-    assert permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
+    assert permissions.active_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
 
-def test_current_user_can_multiple_dabs_fabs_permissions(database, monkeypatch, user_constants):
+def test_active_user_can_multiple_dabs_fabs_permissions(database, monkeypatch, user_constants):
     user_cgac, other_cgac = [CGACFactory() for _ in range(2)]
     user_submitter = UserFactory(affiliations=[
         UserAffiliation(cgac=user_cgac, permission_type_id=PERMISSION_TYPE_DICT['writer']),
@@ -371,41 +371,41 @@ def test_current_user_can_multiple_dabs_fabs_permissions(database, monkeypatch, 
     monkeypatch.setattr(permissions, 'g', Mock(user=user_submitter))
 
     # has permission level, but wrong agency
-    assert not permissions.current_user_can('reader', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('writer', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('editfabs', cgac_code=other_cgac.cgac_code)
-    assert not permissions.current_user_can('fabs', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('reader', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('writer', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('editfabs', cgac_code=other_cgac.cgac_code)
+    assert not permissions.active_user_can('fabs', cgac_code=other_cgac.cgac_code)
 
     # has agency, but not permission level
-    assert not permissions.current_user_can('submitter', cgac_code=user_cgac.cgac_code)
+    assert not permissions.active_user_can('submitter', cgac_code=user_cgac.cgac_code)
 
     # right agency, right permission
-    assert permissions.current_user_can('reader', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('writer', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('editfabs', cgac_code=user_cgac.cgac_code)
-    assert permissions.current_user_can('fabs', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('reader', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('writer', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('editfabs', cgac_code=user_cgac.cgac_code)
+    assert permissions.active_user_can('fabs', cgac_code=user_cgac.cgac_code)
 
     # wrong agency, but superuser
     user_submitter.website_admin = True
-    assert permissions.current_user_can('submitter', cgac_code=other_cgac.cgac_code)
+    assert permissions.active_user_can('submitter', cgac_code=other_cgac.cgac_code)
 
 
-def test_current_user_can_on_submission(monkeypatch, database):
+def test_active_user_can_on_submission(monkeypatch, database):
     submission = SubmissionFactory()
     user = UserFactory()
     database.session.add_all([submission, user])
     database.session.commit()
 
-    current_user_can = Mock()
+    active_user_can = Mock()
     monkeypatch.setattr(permissions, 'g', Mock(user=user))
-    monkeypatch.setattr(permissions, 'current_user_can', current_user_can)
+    monkeypatch.setattr(permissions, 'active_user_can', active_user_can)
 
-    current_user_can.return_value = True
-    assert permissions.current_user_can_on_submission('reader', submission)
-    current_user_can.return_value = False
-    assert not permissions.current_user_can_on_submission('reader', submission)
+    active_user_can.return_value = True
+    assert permissions.active_user_can_on_submission('reader', submission)
+    active_user_can.return_value = False
+    assert not permissions.active_user_can_on_submission('reader', submission)
     submission.user_id = user.user_id
-    assert permissions.current_user_can_on_submission('reader', submission)
+    assert permissions.active_user_can_on_submission('reader', submission)
 
 
 def test_requires_submission_perm_no_submission(database, test_app):


### PR DESCRIPTION
**High level description:**
Replacing `current_user` endpoint with `active_user`. This resolves an issue with remote environments that detected a "SQL injection" whenever the endpoint was hit, causing users to be timed out of the environment for 10 minutes.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-8246](https://federal-spending-transparency.atlassian.net/browse/DEV-8246)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Tested on sandbox and confirmed bug has been resolved.
- [ ] Merged concurrently with [Frontend#1640](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1640)
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation Updated