### PR TITLE
DEV-8252: prevent fy22 quarterly submissions

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -273,11 +273,14 @@ class FileHandler:
                                                      reporting_fiscal_year, reporting_fiscal_period,
                                                      submission_data['is_quarter_format'], filter_published='published')
                 submission_data['published_submission_ids'] = [pub_sub.submission_id for pub_sub in pub_subs]
-                # If there are already published submissions in this period/quarter or if it's a quarterly submission
-                # that is FY22 or later (starting FY22 all submissions must be monthly), force the new submission to be
-                # a test
-                if len(submission_data['published_submission_ids']) > 0 or\
-                        (reporting_fiscal_year >= 2022 and submission_data['is_quarter_format']):
+                # If it's a quarterly submission that is FY22 or later (starting FY22 all submissions must be monthly),
+                # throw an error
+                if reporting_fiscal_year >= 2022 and submission_data['is_quarter_format']:
+                    raise ResponseException('Quarterly submissions may not be created for FY22 or later',
+                                            StatusCode.CLIENT_ERROR)
+                # If there are already published submissions in this period/quarter, force the new submission to be a
+                # test
+                if len(submission_data['published_submission_ids']) > 0:
                     test_submission = True
 
             submission = create_submission(g.user.user_id, submission_data, existing_submission_obj, test_submission)


### PR DESCRIPTION
**High level description:**
Preventing the creation of quarterly submissions in FY22 or later

**Technical details:**
Throws an error when the user tries to create a quarterly submission with FY22 or later as opposed to the previous action of automatically setting it to a test submission.

**Link to JIRA Ticket:**
[DEV-8252](https://federal-spending-transparency.atlassian.net/browse/DEV-8252)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Merged concurrently with or after [Frontend#1644](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1644)
- Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- Documentation Updated