### PR TITLE
DEV-9013: B19 boc dupes

### DIFF
--- a/dataactvalidator/config/sqlrules/b19_object_class_program_activity.sql
+++ b/dataactvalidator/config/sqlrules/b19_object_class_program_activity.sql
@@ -45,7 +45,7 @@ FROM (
             UPPER(op.availability_type_code),
             op.main_account_code,
             op.sub_account_code,
-            op.object_class,
+            RPAD(op.object_class, 4 ,'0'),
             op.program_activity_code,
             UPPER(op.program_activity_name),
             UPPER(op.by_direct_reimbursable_fun),

--- a/tests/unit/dataactvalidator/test_b19_object_class_program_activity.py
+++ b/tests/unit/dataactvalidator/test_b19_object_class_program_activity.py
@@ -156,4 +156,12 @@ def test_failure(database):
                                      program_activity_code='1', program_activity_name='n',
                                      by_direct_reimbursable_fun='r', disaster_emergency_fund_code='N')
 
-    assert number_of_errors(_FILE, database, models=[op1, op2]) == 1
+    # object class with extra trailing zeroes treated the same as without
+    op3 = ObjectClassProgramActivity(job_id=1, row_number=1, beginning_period_of_availa='1',
+                                     ending_period_of_availabil='1', agency_identifier='1',
+                                     allocation_transfer_agency='1', availability_type_code='1',
+                                     main_account_code='1', sub_account_code='1', object_class='10',
+                                     program_activity_code='1', program_activity_name='n',
+                                     by_direct_reimbursable_fun='r', disaster_emergency_fund_code='N')
+
+    assert number_of_errors(_FILE, database, models=[op1, op2, op3]) == 2


### PR DESCRIPTION
**High level description:**
Padding object class codes to always be 4 characters long for B19 validation

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-9013](https://federal-spending-transparency.atlassian.net/browse/DEV-9013)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation updated