### PR TITLE
DEV-9571: MT CD

### DIFF
--- a/dataactvalidator/scripts/read_zips.py
+++ b/dataactvalidator/scripts/read_zips.py
@@ -293,7 +293,7 @@ def parse_zip4_file(f, sess):
                     congressional_district = curr_row[162:164]
 
                 # certain states require specific CDs
-                if state in ["AK", "DE", "MT", "ND", "SD", "VT", "WY"]:
+                if state in ["AK", "DE", "ND", "SD", "VT", "WY"]:
                     congressional_district = "00"
                 elif state in ["AS", "DC", "GU", "MP", "PR", "VI"]:
                     congressional_district = "98"


### PR DESCRIPTION
**High level description:**
Stop setting the CD for all MT zips to 00

**Technical details:**
Since MT has been split into 2 CDs we are now just going to use the value given to us by USPS to determine what the CD is.

**Link to JIRA Ticket:**
[DEV-9571](https://federal-spending-transparency.atlassian.net/browse/DEV-9571)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Style Guide check completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation updated