### PR TITLE
Fix: Running Flake8 with the current build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ Flask-Deprecate==0.1.3
 Flask-Login==0.3.2
 freezegun==0.3.7
 future==0.15.2
+importlib_metadata==4.13.0
 iso3166==0.7
 itsdangerous==0.24
 Jinja2==2.11.3


### PR DESCRIPTION
**High level description:**
Running flake8 with a completely new build from scratch breaks due to a bizarre dependency chain issue in one of the packages. The fix included is referenced here - https://github.com/python/importlib_metadata/issues/406

**Technical details:**
N/A

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated