### PR TITLE
DEV-9707: fabs threshold table derivations

### DIFF
--- a/dataactbroker/helpers/fabs_derivations_helper.py
+++ b/dataactbroker/helpers/fabs_derivations_helper.py
@@ -301,8 +301,9 @@ def derive_ppop_location_data(sess, submission_id):
     query = """
         UPDATE tmp_fabs_{submission_id}
         SET place_of_performance_congr = congressional_district_no
-        FROM zips_grouped_historical
+        FROM cd_zips_grouped_historical
         WHERE place_of_performance_zip5 = zip5
+            AND place_of_perfor_state_code = state_abbreviation
             AND place_of_performance_congr IS NULL
             AND cast_as_date(action_date) < '{zip_date}';
     """
@@ -316,8 +317,9 @@ def derive_ppop_location_data(sess, submission_id):
     query = """
         UPDATE tmp_fabs_{submission_id}
         SET place_of_performance_congr = congressional_district_no
-        FROM zips_grouped
+        FROM cd_zips_grouped
         WHERE place_of_performance_zip5 = zip5
+            AND place_of_perfor_state_code = state_abbreviation
             AND place_of_performance_congr IS NULL
             AND cast_as_date(action_date) >= '{zip_date}';
     """
@@ -536,7 +538,7 @@ def derive_le_location_data(sess, submission_id):
     query = """
         UPDATE tmp_fabs_{submission_id}
         SET legal_entity_congressional = congressional_district_no
-        FROM zips_grouped_historical
+        FROM cd_zips_grouped_historical
         WHERE legal_entity_zip5 = zip5
             AND legal_entity_congressional IS NULL
             AND cast_as_date(action_date) < '{zip_date}';
@@ -551,7 +553,7 @@ def derive_le_location_data(sess, submission_id):
     query = """
         UPDATE tmp_fabs_{submission_id}
         SET legal_entity_congressional = congressional_district_no
-        FROM zips_grouped
+        FROM cd_zips_grouped
         WHERE legal_entity_zip5 = zip5
             AND legal_entity_congressional IS NULL
             AND cast_as_date(action_date) >= '{zip_date}';


### PR DESCRIPTION
**High level description:**
Updating the FABS derivations that can to use the new threshold tables

**Technical details:**
Any congressional district derivations in FABS that only need zip5 now use the threshold version of the zips grouped table

**Link to JIRA Ticket:**
[DEV-9707](https://federal-spending-transparency.atlassian.net/browse/DEV-9707)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Style Guide check completed
- [x] Merged after [Backend#2419](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/2419)
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation updated