### PR TITLE
DEV-9874: Stop auto-nulling PA file

### DIFF
--- a/dataactvalidator/scripts/load_program_activity.py
+++ b/dataactvalidator/scripts/load_program_activity.py
@@ -144,7 +144,7 @@ def load_program_activity_data(base_path, force_reload=False, export=False):
         with create_app().app_context():
             sess = GlobalDB.db().session
             try:
-                raw_data = pd.read_csv(program_activity_file, dtype=str, keep_default_na=False)
+                raw_data = pd.read_csv(program_activity_file, dtype=str, na_filter=False)
             except pd.io.common.EmptyDataError:
                 log_blank_file()
                 exit_if_nonlocal(4)  # exit code chosen arbitrarily, to indicate distinct failure states

--- a/dataactvalidator/scripts/load_program_activity.py
+++ b/dataactvalidator/scripts/load_program_activity.py
@@ -144,7 +144,7 @@ def load_program_activity_data(base_path, force_reload=False, export=False):
         with create_app().app_context():
             sess = GlobalDB.db().session
             try:
-                raw_data = pd.read_csv(program_activity_file, dtype=str)
+                raw_data = pd.read_csv(program_activity_file, dtype=str, keep_default_na=False)
             except pd.io.common.EmptyDataError:
                 log_blank_file()
                 exit_if_nonlocal(4)  # exit code chosen arbitrarily, to indicate distinct failure states


### PR DESCRIPTION
**High level description:**
Turn off auto-null for pandas on PA file read because they sometimes send `N/A` as a valid entry

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-9874](https://federal-spending-transparency.atlassian.net/browse/DEV-9874)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Style Guide check completed
- Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation updated