### PR TITLE
DEV-9826: fabs derivations canonical state

### DIFF
--- a/dataactbroker/helpers/fabs_derivations_helper.py
+++ b/dataactbroker/helpers/fabs_derivations_helper.py
@@ -335,6 +335,7 @@ def derive_ppop_location_data(sess, submission_id):
         SET place_of_perform_county_co = county_number
         FROM zips_grouped_historical
         WHERE place_of_performance_zip5 = zip5
+            AND place_of_perfor_state_code = state_abbreviation
             AND place_of_perform_county_co IS NULL
             AND cast_as_date(action_date) < '{zip_date}';
     """
@@ -350,6 +351,7 @@ def derive_ppop_location_data(sess, submission_id):
         SET place_of_perform_county_co = county_number
         FROM zips_grouped
         WHERE place_of_performance_zip5 = zip5
+            AND place_of_perfor_state_code = state_abbreviation
             AND place_of_perform_county_co IS NULL
             AND cast_as_date(action_date) >= '{zip_date}';
     """
@@ -533,6 +535,20 @@ def derive_le_location_data(sess, submission_id):
                    'updated {}'.format(res.rowcount), submission_id, query_start)
 
     query_start = datetime.now()
+    log_derivation('Beginning legal entity state derivation', submission_id)
+    # Deriving congressional info for remaining blanks (with zip code)
+    query = """
+            UPDATE tmp_fabs_{submission_id}
+            SET legal_entity_state_code = state_code
+            FROM zip_city
+            WHERE legal_entity_zip5 = zip_code
+                AND legal_entity_state_code IS NULL;
+        """
+    res = sess.execute(query.format(submission_id=submission_id))
+    log_derivation('Completed legal entity state derivation, '
+                   'updated {}'.format(res.rowcount), submission_id, query_start)
+
+    query_start = datetime.now()
     log_derivation('Beginning historical legal entity congressional for 5-digit zip derivation', submission_id)
     # Deriving historical congressional info for remaining blanks (with zip code)
     query = """
@@ -540,6 +556,7 @@ def derive_le_location_data(sess, submission_id):
         SET legal_entity_congressional = congressional_district_no
         FROM cd_zips_grouped_historical
         WHERE legal_entity_zip5 = zip5
+            AND legal_entity_state_code = state_abbreviation
             AND legal_entity_congressional IS NULL
             AND cast_as_date(action_date) < '{zip_date}';
     """
@@ -555,6 +572,7 @@ def derive_le_location_data(sess, submission_id):
         SET legal_entity_congressional = congressional_district_no
         FROM cd_zips_grouped
         WHERE legal_entity_zip5 = zip5
+            AND legal_entity_state_code = state_abbreviation
             AND legal_entity_congressional IS NULL
             AND cast_as_date(action_date) >= '{zip_date}';
     """
@@ -567,10 +585,10 @@ def derive_le_location_data(sess, submission_id):
     # Deriving county and state code info for remaining blanks (with zip code)
     query = """
         UPDATE tmp_fabs_{submission_id}
-        SET legal_entity_county_code = county_number,
-            legal_entity_state_code = state_abbreviation
+        SET legal_entity_county_code = county_number
         FROM zips_grouped_historical
         WHERE legal_entity_zip5 = zip5
+            AND legal_entity_state_code = state_abbreviation
             AND legal_entity_county_code IS NULL
             AND cast_as_date(action_date) < '{zip_date}';
     """
@@ -583,10 +601,10 @@ def derive_le_location_data(sess, submission_id):
     # Deriving county and state code info for remaining blanks (with zip code)
     query = """
         UPDATE tmp_fabs_{submission_id}
-        SET legal_entity_county_code = county_number,
-            legal_entity_state_code = state_abbreviation
+        SET legal_entity_county_code = county_number
         FROM zips_grouped
         WHERE legal_entity_zip5 = zip5
+            AND legal_entity_state_code = state_abbreviation
             AND legal_entity_county_code IS NULL
             AND cast_as_date(action_date) >= '{zip_date}';
     """

--- a/tests/unit/dataactbroker/test_fabs_derivations.py
+++ b/tests/unit/dataactbroker/test_fabs_derivations.py
@@ -41,10 +41,14 @@ def initialize_db_values(db):
     cd_zips_grouped_historical = CDZipsGroupedHistoricalFactory(zip5='11111', state_abbreviation='NY',
                                                                 congressional_district_no='03')
     # Cities
-    zip_city = ZipCityFactory(zip_code=zip_code_1.zip5, preferred_city_name='Test City')
-    zip_city_2 = ZipCityFactory(zip_code=zip_code_3.zip5, preferred_city_name='Test City 2')
-    zip_city_3 = ZipCityFactory(zip_code=zip_code_4.zip5, preferred_city_name='Test City 3')
-    zip_city_4 = ZipCityFactory(zip_code=zip_code_historical_1.zip5, preferred_city_name='Historical Test City')
+    zip_city = ZipCityFactory(zip_code=zip_code_1.zip5, preferred_city_name='Test City',
+                              state_code=zip_code_1.state_abbreviation)
+    zip_city_2 = ZipCityFactory(zip_code=zip_code_3.zip5, preferred_city_name='Test City 2',
+                                state_code=zip_code_3.state_abbreviation)
+    zip_city_3 = ZipCityFactory(zip_code=zip_code_4.zip5, preferred_city_name='Test City 3',
+                                state_code=zip_code_4.state_abbreviation)
+    zip_city_4 = ZipCityFactory(zip_code=zip_code_historical_1.zip5, preferred_city_name='Historical Test City',
+                                state_code=zip_code_historical_1.state_abbreviation)
     city_code = CityCodeFactory(feature_name='Test City', city_code='00001', state_code='NY',
                                 county_number=zip_code_1.county_number, county_name='Test City County')
     # States


### PR DESCRIPTION
**High level description:**
Updating FABS legal entity location derivations to use the canonical state when deriving legal entity state. Also using that canonical state anywhere that it might matter for derivations

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-9826](https://federal-spending-transparency.atlassian.net/browse/DEV-9826)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation updated