### PR TITLE
Fix: Sort Flex Fields in E/W Report

### DIFF
--- a/dataactbroker/helpers/validation_helper.py
+++ b/dataactbroker/helpers/validation_helper.py
@@ -185,12 +185,13 @@ def concat_flex(row):
         on commas
 
         Args:
-            row: the dataframe row containing the submission row flex fields
+            row: the dataframe or dict row containing the submission row flex fields
 
         Returns:
             A concatenated list of "header: cell" pairs for the flex fields, joined by commas
     """
-    return ', '.join([name + ': ' + (row[name] or '') for name in row.keys().sort_values() if name != 'row_number'])
+    sorted_keys = row.keys().sort_values() if isinstance(row.keys(), pd.Index) else sorted(row.keys())
+    return ', '.join([name + ': ' + (row[name] or '') for name in sorted_keys if name != 'row_number'])
 
 
 def derive_unique_id(row, is_fabs):

--- a/dataactbroker/helpers/validation_helper.py
+++ b/dataactbroker/helpers/validation_helper.py
@@ -190,7 +190,7 @@ def concat_flex(row):
         Returns:
             A concatenated list of "header: cell" pairs for the flex fields, joined by commas
     """
-    return ', '.join([name + ': ' + (row[name] or '') for name in sorted(row.keys()) if name != 'row_number'])
+    return ', '.join([name + ': ' + (row[name] or '') for name in row.keys().sort_values() if name != 'row_number'])
 
 
 def derive_unique_id(row, is_fabs):

--- a/tests/unit/dataactbroker/test_validation_helper.py
+++ b/tests/unit/dataactbroker/test_validation_helper.py
@@ -170,10 +170,16 @@ def test_clean_numbers_vectorized_mixed_types():
 def test_concat_flex():
     # Tests a blank value, column sorting, ignoring row number, and the basic functionality
     flex_row = {'row_number': '4', 'col 3': None, 'col 2': 'B', 'col 1': 'A'}
+    flex_df = pd.DataFrame({'row_number': ['4'], 'col 3': [None], 'col 2': ['B'], 'col 1': ['A']})
     assert validation_helper.concat_flex(flex_row) == 'col 1: A, col 2: B, col 3: '
+    flex_df['concatted'] = flex_df.apply(lambda x: validation_helper.concat_flex(x), axis=1)
+    assert flex_df['concatted'][0] == 'col 1: A, col 2: B, col 3: '
 
     flex_row = {'just one': 'column'}
+    flex_df = pd.DataFrame({'just one': ['column']})
     assert validation_helper.concat_flex(flex_row) == 'just one: column'
+    flex_df['concatted'] = flex_df.apply(lambda x: validation_helper.concat_flex(x), axis=1)
+    assert flex_df['concatted'][0] == 'just one: column'
 
 
 def test_derive_unique_id():


### PR DESCRIPTION
**High level description:**
Minor fix for consistently sorting the Flex Fields in the Error and Warning report. This is more for the error_warning_file tests to consistently pass.

**Technical details:**
N/A

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated