### PR TITLE
DEV-10749: /v1/proxy_login Endpoint

### DIFF
--- a/dataactbroker/handlers/account_handler.py
+++ b/dataactbroker/handlers/account_handler.py
@@ -116,6 +116,10 @@ class AccountHandler:
             safe_dictionary = RequestDictionary(self.request)
 
             email = safe_dictionary.get_value('email')
+            token = safe_dictionary.get_value('token')
+
+            if token != CONFIG_BROKER['api_proxy_token']:
+                raise ValueError("Invalid token")
 
             try:
                 user = sess.query(User).filter(func.lower(User.email) == func.lower(email)).one()

--- a/dataactbroker/handlers/account_handler.py
+++ b/dataactbroker/handlers/account_handler.py
@@ -127,7 +127,7 @@ class AccountHandler:
                 raise ValueError("Invalid email")
 
             try:
-                return self.create_session_and_response(session, user)
+                return self.create_session_and_response(session, user, user_details=False)
             except ValueError as ve:
                 LoginSession.logout(session)
                 raise ve
@@ -291,18 +291,21 @@ class AccountHandler:
             return JsonResponse.error(e, StatusCode.INTERNAL_ERROR, error=str(e))
 
     @staticmethod
-    def create_session_and_response(session, user):
+    def create_session_and_response(session, user, user_details=True):
         """ Create a session.
 
             Args:
                 session: Session object from flask
                 user: Users object
+                user_details: whether to include the user details in the response
 
             Returns:
                 JsonResponse containing the JSON for the user
         """
         LoginSession.login(session, user.user_id)
         data = json_for_user(user, session['sid'])
+        if not user_details:
+            data = {k: v for k, v in data.items() if k in ['session_id']}
         data['message'] = 'Login successful'
         return JsonResponse.create(StatusCode.OK, data)
 

--- a/dataactbroker/routes/login_routes.py
+++ b/dataactbroker/routes/login_routes.py
@@ -13,6 +13,11 @@ def add_login_routes(app, bcrypt):
         account_manager = AccountHandler(request, bcrypt=bcrypt)
         return account_manager.login(session)
 
+    @app.route("/v1/proxy_login/", methods=["POST"])
+    def proxy_login():
+        account_manager = AccountHandler(request)
+        return account_manager.proxy_login(session)
+
     @app.route("/v1/max_login/", methods=["POST"])
     @deprecate_route("MAX login will no longer be supported on October 1st, 2023."
                      " Instead, CAIA login is supported now (via /v1/caia_login) and will be the only option then.")

--- a/dataactcore/local_secrets_example.yml
+++ b/dataactcore/local_secrets_example.yml
@@ -14,6 +14,9 @@ broker:
     admin_email: valid.email@domain.com
     admin_password: password
 
+    # Sets the security token for the API Proxy Login endpoint
+    api_proxy_token: password
+
     ## AWS Configuration Settings ##
 
     # If set to true the application will use AWS for the storage of files

--- a/tests/unit/dataactbroker/test_login_routes.py
+++ b/tests/unit/dataactbroker/test_login_routes.py
@@ -1,11 +1,15 @@
 import json
 from unittest.mock import patch
-
-
-import dataactbroker.handlers.account_handler as account_handler
-from dataactcore.models.userModel import User
-from dataactcore.interfaces.db import GlobalDB
 from sqlalchemy import func
+
+from tests.unit.dataactbroker.test_account_handler import make_caia_user_dict, make_caia_token_dict
+import dataactbroker.handlers.account_handler as account_handler
+from dataactcore.models.userModel import User, UserAffiliation
+from dataactcore.interfaces.db import GlobalDB
+
+CAIA_RESPONSE_NO_PERMS = make_caia_user_dict("[]")
+CAIA_RESPONSE_W_PERMS = make_caia_user_dict("CGAC-999-R")
+CAIA_TOKEN_DICT = make_caia_token_dict('123456789')
 
 MAX_RESPONSE_NO_PERMS = {
     "cas:serviceResponse": {
@@ -37,10 +41,21 @@ MAX_RESPONSE_W_PERMS = {
     }
 }
 
+LOGIN_RESPONSE = {
+    "user_id": 1,
+    "name": "Test User",
+    "title": "Test User",
+    "skip_guide": False,
+    "website_admin": False,
+    "affiliations": [],
+    "session_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "message": "Login successful"
+}
+
 
 @patch('dataactbroker.handlers.account_handler.get_max_dict')
 @patch('dataactbroker.handlers.account_handler.AccountHandler.create_session_and_response')
-def test_no_perms_broker_user(create_session_mock, max_dict_mock, database, monkeypatch):
+def test_no_perms_broker_user_max(create_session_mock, max_dict_mock, database, monkeypatch):
     ah = max_login_func(create_session_mock, max_dict_mock, monkeypatch, MAX_RESPONSE_NO_PERMS)
     res = ah.max_login({})
     response = json.loads(res.get_data().decode("utf-8"))
@@ -53,9 +68,28 @@ def test_no_perms_broker_user(create_session_mock, max_dict_mock, database, monk
                                   "may request permissions at https://community.max.gov/x/fJwuRQ"
 
 
+@patch('dataactbroker.handlers.account_handler.get_caia_user_dict')
+@patch('dataactbroker.handlers.account_handler.get_caia_tokens')
+@patch('dataactbroker.handlers.account_handler.revoke_caia_access')
+@patch('dataactbroker.handlers.account_handler.AccountHandler.create_session_and_response')
+def test_no_perms_broker_user_caia(create_session_mock, revoke_caia_mock, caia_token_mock, caia_dict_mock, database,
+                                   monkeypatch):
+    ah = caia_login_func(create_session_mock, revoke_caia_mock, caia_token_mock, caia_dict_mock, monkeypatch,
+                         CAIA_RESPONSE_NO_PERMS)
+    res = ah.caia_login({})
+    sess = GlobalDB.db().session
+    # This is to prevent an integrity error with other tests that create users.
+    test_user = sess.query(User).filter(func.lower(User.email) == func.lower("test-user@email.com"))
+    affiliations = sess.query(UserAffiliation).filter_by(user_id=test_user.one().user_id).all()
+    test_user.delete(synchronize_session=False)
+    sess.commit()
+    assert res is True
+    assert affiliations == []
+
+
 @patch('dataactbroker.handlers.account_handler.get_max_dict')
 @patch('dataactbroker.handlers.account_handler.AccountHandler.create_session_and_response')
-def test_w_perms_broker_user(create_session_mock, max_dict_mock, database, monkeypatch):
+def test_w_perms_broker_user_max(create_session_mock, max_dict_mock, database, monkeypatch):
     ah = max_login_func(create_session_mock, max_dict_mock, monkeypatch, MAX_RESPONSE_W_PERMS)
     res = ah.max_login({})
     sess = GlobalDB.db().session
@@ -64,6 +98,53 @@ def test_w_perms_broker_user(create_session_mock, max_dict_mock, database, monke
         .delete(synchronize_session=False)
     sess.commit()
     assert res is True
+
+
+@patch('dataactbroker.handlers.account_handler.get_caia_user_dict')
+@patch('dataactbroker.handlers.account_handler.get_caia_tokens')
+@patch('dataactbroker.handlers.account_handler.revoke_caia_access')
+@patch('dataactbroker.handlers.account_handler.AccountHandler.create_session_and_response')
+def test_w_perms_broker_user_caia(create_session_mock, revoke_caia_mock, caia_token_mock, caia_dict_mock, database,
+                                  monkeypatch):
+    ah = caia_login_func(create_session_mock, revoke_caia_mock, caia_token_mock, caia_dict_mock, monkeypatch,
+                         CAIA_RESPONSE_W_PERMS)
+    res = ah.caia_login({})
+    sess = GlobalDB.db().session
+    # This is to prevent an integrity error with other tests that create users.
+    sess.query(User).filter(func.lower(User.email) == func.lower("test-user@email.com"))\
+        .delete(synchronize_session=False)
+    sess.commit()
+    assert res is True
+
+
+@patch('dataactbroker.handlers.account_handler.AccountHandler.create_session_and_response')
+def test_proxy_login_success(create_session_mock, database):
+    sess = GlobalDB.db().session
+    test_user = User(email='test-user@email.com')
+    sess.add(test_user)
+
+    ah = proxy_login_func(create_session_mock)
+    res = ah.proxy_login({})
+
+    # This is to prevent an integrity error with other tests that create users.
+    sess.query(User).filter(func.lower(User.email) == func.lower("test-user@email.com"))\
+        .delete(synchronize_session=False)
+
+    assert res.get('session_id') is not None
+
+
+@patch('dataactbroker.handlers.account_handler.AccountHandler.create_session_and_response')
+def test_proxy_login_invalid_user(create_session_mock, database):
+    ah = proxy_login_func(create_session_mock)
+    res = ah.proxy_login({})
+    response = json.loads(res.get_data().decode("utf-8"))
+
+    sess = GlobalDB.db().session
+    # This is to prevent an integrity error with other tests that create users.
+    sess.query(User).filter(func.lower(User.email) == func.lower("test-user@email.com"))\
+        .delete(synchronize_session=False)
+
+    assert response['message'] == "Invalid email"
 
 
 def max_login_func(create_session_mock, max_dict_mock, monkeypatch, max_response):
@@ -75,4 +156,27 @@ def max_login_func(create_session_mock, max_dict_mock, monkeypatch, max_response
     monkeypatch.setattr(account_handler, 'CONFIG_BROKER', {"parent_group": "test"})
     max_dict_mock.return_value = max_response
     create_session_mock.return_value = True
+    return ah
+
+
+def caia_login_func(create_session_mock, revoke_caia_mock, caia_token_mock, caia_dict_mock, monkeypatch, caia_response):
+    def json_return():
+        return {"code": "12345", "redirect_uri": "https://some.url.gov"}
+    request = type('Request', (object,), {"is_json": True, "headers": {"Content-Type": "application/json"},
+                                          "get_json": json_return})
+    ah = account_handler.AccountHandler(request=request)
+    caia_dict_mock.return_value = caia_response
+    caia_token_mock.return_value = CAIA_TOKEN_DICT
+    revoke_caia_mock.return_value = None
+    create_session_mock.return_value = True
+    return ah
+
+
+def proxy_login_func(create_session_mock):
+    def json_return():
+        return {"email": "test-user@email.com"}
+    request = type('Request', (object,), {"is_json": True, "headers": {"Content-Type": "application/json"},
+                                          "get_json": json_return})
+    ah = account_handler.AccountHandler(request=request)
+    create_session_mock.return_value = LOGIN_RESPONSE
     return ah


### PR DESCRIPTION
**High level description:**
Adding an endpoint for the API Proxy users to log into the Broker.

**Technical details:**
* Added additional tests for the CAIA login endpoint alongside the API Proxy endpoint.
* Included an API Proxy Token configuration (subject to change)

**Link to JIRA Ticket:**
[DEV-10749](https://federal-spending-transparency.atlassian.net/browse/DEV-10749)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Worked with Operations to determine the proper security of the endpoint
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated