### PR TITLE
DEV-9898 Fix: Null Cross-file Filenames included in `get_submission_files`

### DIFF
--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -365,7 +365,7 @@ def get_submission_files(jobs):
     """
     job_list = []
     for job in jobs:
-        if job.filename not in job_list:
+        if job.filename and job.filename not in job_list:
             job_list.append(job.filename)
     return job_list
 


### PR DESCRIPTION
**High level description:**
Fixes a bug caused by DEV-9898 due to `null`s being included in the DABS file list.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-9898](https://federal-spending-transparency.atlassian.net/browse/DEV-9898)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated