### PR TITLE
DEV-10862: FABS Validator Custom Non-Senstive Rules

### DIFF
--- a/dataactvalidator/validation_handlers/validator.py
+++ b/dataactvalidator/validation_handlers/validator.py
@@ -220,8 +220,8 @@ def validate_file_by_sql(job, file_type, short_to_long_dict, batch_results=False
     file_id = FILE_TYPE_DICT[file_type]
     rules = sess.query(RuleSql).filter_by(file_id=file_id, rule_cross_file_flag=False)
 
-    # Only run non-sensitive rules for FABS, CGAC 999
-    if sess.query(Submission).filter_by(submission_id=job.submission_id, cgac_code='999', is_fabs=True).one_or_none():
+    # Only run non-sensitive rules for CGAC 999
+    if sess.query(Submission).filter_by(submission_id=job.submission_id, cgac_code='999').one_or_none():
         rules = rules.filter_by(sensitive=False)
 
     errors = []
@@ -428,8 +428,10 @@ def failure_row_to_tuple(rule, flex_data, cols, col_headers, file_id, sql_failur
     # Create strings for fields and values
     values_list = ['{}: {}'.format(header, str(sql_failure[field] if sql_failure[field] is not None else ''))
                    for field, header in zip(cols, col_headers)]
+    values_list = sorted(values_list)
     flex_list = ['{}: {}'.format(flex_field.header, flex_field.cell if flex_field.cell is not None else '')
                  for flex_field in flex_data[row]]
+    flex_list = sorted(flex_list)
     # Create unique id string
     unique_id = ', '.join(unique_id_fields)
 

--- a/tests/integration/error_warning_file_tests.py
+++ b/tests/integration/error_warning_file_tests.py
@@ -563,7 +563,7 @@ class ErrorWarningTests(BaseTestValidator):
                               ' unobligatedbalance_cpe',
                 'Rule Message': 'StatusOfBudgetaryResourcesTotal_CPE= ObligationsIncurredTotalByTAS_CPE +'
                                 ' UnobligatedBalance_CPE.',
-                'Value Provided': 'statusofbudgetaryresourcestotal_cpe: , obligationsincurredtotalbytas_cpe: 8.08,'
+                'Value Provided': 'obligationsincurredtotalbytas_cpe: 8.08, statusofbudgetaryresourcestotal_cpe: ,'
                                   ' unobligatedbalance_cpe: 2.02',
                 'Expected Value': 'StatusOfBudgetaryResourcesTotal_CPE must equal the sum of these elements:'
                                   ' ObligationsIncurredTotalByTAS_CPE + UnobligatedBalance_CPE. The Broker cannot'
@@ -616,11 +616,12 @@ class ErrorWarningTests(BaseTestValidator):
                                 ' BudgetAuthorityUnobligatedBalanceBroughtForward_FYB +'
                                 ' AdjustmentsToUnobligatedBalanceBroughtForward_CPE + OtherBudgetaryResourcesAmount_CPE'
                                 ' + GTAS SF 133 Line 1902.',
-                'Value Provided': 'totalbudgetaryresources_cpe: 10.1, budgetauthorityappropriatedamount_cpe: 0.01,'
-                                  ' budgetauthorityunobligatedbalancebroughtforward_fyb: 3.03,'
+                'Value Provided': 'GTAS SF133 Line 1902: 0,'
                                   ' adjustmentstounobligatedbalancebroughtforward_cpe: 2.02,'
+                                  ' budgetauthorityappropriatedamount_cpe: 0.01,'
+                                  ' budgetauthorityunobligatedbalancebroughtforward_fyb: 3.03,'
                                   ' otherbudgetaryresourcesamount_cpe: 4.04,'
-                                  ' GTAS SF133 Line 1902: 0',
+                                  ' totalbudgetaryresources_cpe: 10.1',
                 'Expected Value': 'TotalBudgetaryResources_CPE must equal the sum of these elements:'
                                   ' BudgetAuthorityAppropriatedAmount_CPE +'
                                   ' BudgetAuthorityUnobligatedBalanceBroughtForward_FYB +'

--- a/tests/unit/dataactvalidator/validation_handlers/test_validator.py
+++ b/tests/unit/dataactvalidator/validation_handlers/test_validator.py
@@ -73,7 +73,7 @@ def test_run_only_sensitive_rules(database):
     sess.add_all([rule_fabs_sensitive, rule_fabs_not_sensitive])
 
     # normal FABS submission
-    normal_fabs_sub = SubmissionFactory(submission_id='1', is_fabs=True, cgac_code='097')
+    normal_fabs_sub = SubmissionFactory(submission_id='1', cgac_code='097')
     normal_fabs_job = JobFactory(job_id='1', submission_id=normal_fabs_sub.submission_id, file_type=fabs_file_type)
     sess.add_all([normal_fabs_sub, normal_fabs_job])
 
@@ -83,7 +83,7 @@ def test_run_only_sensitive_rules(database):
     assert len(failures) == 2
 
     # Excluding Sensitive Rules
-    sensitive_fabs_sub = SubmissionFactory(submission_id='2', is_fabs=True, cgac_code='999')
+    sensitive_fabs_sub = SubmissionFactory(submission_id='2', cgac_code='999')
     sensitive_fabs_job = JobFactory(job_id='2', submission_id=sensitive_fabs_sub.submission_id,
                                     file_type=fabs_file_type)
     sess.add_all([sensitive_fabs_sub, sensitive_fabs_job])


### PR DESCRIPTION
**High level description:**
Updating the FABS validator to only run non-sensitive rules for a specific agency.

**Technical details:**
Also sorts the flex values and values provided lists in the error warning report to fix issues with testing.

**Link to JIRA Ticket:**
[DEV-10862](https://federal-spending-transparency.atlassian.net/browse/DEV-10862)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated