### PR TITLE
DEV-11160: FH Rework - Agency, Subtier, and Office Names

### DIFF
--- a/dataactcore/scripts/pipeline/load_federal_hierarchy.py
+++ b/dataactcore/scripts/pipeline/load_federal_hierarchy.py
@@ -200,7 +200,10 @@ def pull_offices(sess, filename, update_db, pull_all, updated_date_from, export_
                 # office in the database, we're going to add all these in one dataframe, find the appropriate
                 # values grouping by their office codes, and update the incoming record going in the database
                 date_cols = ['effective_start_date', 'effective_end_date']
-                dates_df_cols = ['office_code'] + date_cols
+                type_cols = ['contract_funding_office', 'contract_awards_office', 'financial_assistance_awards_office',
+                             'financial_assistance_funding_office']
+                shared_cols = date_cols + type_cols
+                shared_df_cols = ['office_code'] + shared_cols
 
                 # Merge with the already existing offices in the database
                 existing_offices_df = pd.read_sql(existing_offices.statement, existing_offices.session.bind,
@@ -212,30 +215,35 @@ def pull_offices(sess, filename, update_db, pull_all, updated_date_from, export_
                 # otherwise, it'd be impossible for an active office to become inactive
                 if not pull_all:
                     existing_offices_df['effective_end_date'].fillna('2000-01-02 00:00', inplace=True)
-                dates_df = pd.concat([existing_offices_df[dates_df_cols], offices[dates_df_cols]])
+                shared_df = pd.concat([existing_offices_df[shared_df_cols], offices[shared_df_cols]])
 
                 # Sorted by the effective end date and grouped by the office code...
                 #   Get the earliest effective start date ("min")
+                #   Set the boolean orgtypecols to True if *any* of them are True over time
                 #   Get the latest effective end date or NULL if there's an active record
                 #       - for full loads, this will include the database record which could be active and null
                 #       - for iterative loads, this will ignore the database record if it's currently active (i.e. null)
                 #         by setting it to a really old date; otherwise it will pull the database end date too
-                dates_df.sort_values(by=['effective_end_date'], inplace=True)
-                dates_grouped = dates_df.groupby(by=['office_code'], sort=False, as_index=False, dropna=False)
+                shared_df.sort_values(by=['effective_end_date'], inplace=True)
+                shared_grouped = shared_df.groupby(by=['office_code'], sort=False, as_index=False, dropna=False)
                 # panda's aggregates ("first", "last", "min", "max") ignore NATs, so for the effective end dates, we're
                 # using sorting on end date and this function to effectively be "last" but include the NATs.
                 # If there is a NAT, it's considered "active".
-                dates_df = dates_grouped.agg({"effective_start_date": "min",
-                                              "effective_end_date": lambda x: x.values[-1]})
+                shared_df = shared_grouped.agg({"effective_start_date": "min",
+                                                "effective_end_date": lambda x: x.values[-1],
+                                                "contract_funding_office": "any",
+                                                "contract_awards_office": "any",
+                                                "financial_assistance_awards_office": "any",
+                                                "financial_assistance_funding_office": "any"})
 
                 # Merge it back into offices and drop duplicates
-                offices = offices.join(dates_df.set_index('office_code'), on='office_code', rsuffix='_derived')
+                offices = offices.join(shared_df.set_index('office_code'), on='office_code', rsuffix='_derived')
                 # doing the drop duplicates again on original offices df as it will still have the old duplicates
                 # they should be the same except for the date columns
                 offices.drop_duplicates(subset=['office_code'], keep='last', inplace=True)
                 # Doing the column switcheroo *after* dropping the duplicates and choosing the latest
-                offices.drop(columns=date_cols, inplace=True)
-                offices.rename(columns={f'{col}_derived': col for col in date_cols}, inplace=True)
+                offices.drop(columns=shared_cols, inplace=True)
+                offices.rename(columns={f'{col}_derived': col for col in shared_cols}, inplace=True)
 
                 offices['created_at'] = datetime.now()
                 offices['updated_at'] = datetime.now()

--- a/tests/unit/data/test_fh_full.json
+++ b/tests/unit/data/test_fh_full.json
@@ -268,7 +268,7 @@
         "orglist": [
             {
                 "fhorgid": 5,
-                "fhorgname": "TEST OFFICE 5",
+                "fhorgname": "TEST OFFICE 5 - OLD",
                 "fhorgtype": "OFFICE",
                 "level": 3,
                 "status": "INACTIVE",
@@ -279,15 +279,15 @@
                 "updatedby": "FPDSADMIN_NEW_ATOM_FEED",
                 "lastupdateddate": "2024-04-17 20:30",
                 "fhdeptindagencyorgid": 100000005,
-                "fhagencyorgname": "TEST AGENCY 5",
-                "agencycode": "0005",
-                "oldfpdsofficecode": "TEST OFFICE 5",
-                "aacofficecode": "W5",
-                "fullParentPathName": "TEST AGENCY 5.TEST AGENCY 5.TEST OFFICE 5",
+                "fhagencyorgname": "TEST AGENCY 5 - OLD",
+                "agencycode": "0050",
+                "oldfpdsofficecode": "TEST OFFICE 5 - OLD",
+                "aacofficecode": "W05",
+                "fullParentPathName": "TEST AGENCY 5 - OLD.TEST AGENCY 5 - OLD.TEST OFFICE 5 - OLD",
                 "fullParentPath": "100000005.100000005.5",
                 "cgaclist": [
                     {
-                        "cgac": "005"
+                        "cgac": "050"
                     }
                 ],
                 "fhorgofficetypelist": [
@@ -315,14 +315,14 @@
                 ],
                 "fhorgnamehistory": [
                     {
-                        "fhorgname": "TEST AGENCY 5",
+                        "fhorgname": "TEST AGENCY 5 - OLD",
                         "effectivedate": "2021-04-13 00:00"
                     }
                 ],
                 "fhorgparenthistory": [
                     {
                         "fhfullparentpathid": "100000005.W5",
-                        "fhfullparentpathname": "TEST AGENCY 5.TEST AGENCY 5.TEST OFFICE 5",
+                        "fhfullparentpathname": "TEST AGENCY 5 - OLD.TEST AGENCY 5 - OLD.TEST OFFICE 5 - NEW - OLD",
                         "effectivedate": "2021-04-13 00:00",
                         "codehierarchy": "0005.0005.W5",
                         "actiontype": "CREATE"
@@ -337,7 +337,7 @@
             },
             {
                 "fhorgid": 5,
-                "fhorgname": "TEST OFFICE 5",
+                "fhorgname": "TEST OFFICE 5 - NEW",
                 "fhorgtype": "OFFICE",
                 "level": 3,
                 "status": "ACTIVE",
@@ -349,9 +349,9 @@
                 "fhdeptindagencyorgid": 100000005,
                 "fhagencyorgname": "TEST AGENCY 5",
                 "agencycode": "0005",
-                "oldfpdsofficecode": "TEST OFFICE 5",
-                "aacofficecode": "W5",
-                "fullParentPathName": "TEST AGENCY 5.TEST AGENCY 5.TEST OFFICE 5",
+                "oldfpdsofficecode": "TEST OFFICE 5 - NEW",
+                "aacofficecode": "W05",
+                "fullParentPathName": "TEST AGENCY 5 - NEW.TEST AGENCY 5 - NEW.TEST OFFICE 5 - NEW",
                 "fullParentPath": "100000005.100000005.5",
                 "cgaclist": [
                     {
@@ -383,14 +383,14 @@
                 ],
                 "fhorgnamehistory": [
                     {
-                        "fhorgname": "TEST AGENCY 5",
+                        "fhorgname": "TEST AGENCY 5 - NEW",
                         "effectivedate": "2021-04-13 00:00"
                     }
                 ],
                 "fhorgparenthistory": [
                     {
                         "fhfullparentpathid": "100000005.W5",
-                        "fhfullparentpathname": "TEST AGENCY 5.TEST AGENCY 5.TEST OFFICE 5",
+                        "fhfullparentpathname": "TEST AGENCY 5 - NEW.TEST AGENCY 5 - NEW.TEST OFFICE 5 - NEW",
                         "effectivedate": "2021-04-13 00:00",
                         "codehierarchy": "0005.0005.W5",
                         "actiontype": "CREATE"
@@ -418,7 +418,7 @@
                 "fhagencyorgname": "TEST AGENCY 6",
                 "agencycode": "0006",
                 "oldfpdsofficecode": "TEST OFFICE 6",
-                "aacofficecode": "W6",
+                "aacofficecode": "W06",
                 "fullParentPathName": "TEST AGENCY 6.TEST AGENCY 6.TEST OFFICE 6",
                 "fullParentPath": "100000006.100000006.6",
                 "cgaclist": [
@@ -497,7 +497,7 @@
                 "fhagencyorgname": "TEST AGENCY 7",
                 "agencycode": "0007",
                 "oldfpdsofficecode": "TEST OFFICE 7",
-                "aacofficecode": "W7",
+                "aacofficecode": "W07",
                 "fullParentPathName": "TEST AGENCY 7.TEST AGENCY 7.TEST OFFICE 7",
                 "fullParentPath": "100000007.100000007.7",
                 "cgaclist": [
@@ -570,7 +570,7 @@
                 "fhagencyorgname": "TEST AGENCY 8",
                 "agencycode": "0008",
                 "oldfpdsofficecode": "TEST OFFICE 8",
-                "aacofficecode": "W8",
+                "aacofficecode": "W08",
                 "fullParentPathName": "TEST AGENCY 8.TEST AGENCY 8.TEST OFFICE 8",
                 "fullParentPath": "100000008.100000008.8",
                 "cgaclist": [
@@ -649,7 +649,7 @@
                 "fhagencyorgname": "TEST AGENCY 9",
                 "agencycode": "0009",
                 "oldfpdsofficecode": "TEST OFFICE 9",
-                "aacofficecode": "W9",
+                "aacofficecode": "W09",
                 "fullParentPathName": "TEST AGENCY 9.TEST AGENCY 9.TEST OFFICE 9",
                 "fullParentPath": "100000009.100000009.9",
                 "cgaclist": [

--- a/tests/unit/data/test_fh_full.json
+++ b/tests/unit/data/test_fh_full.json
@@ -295,11 +295,6 @@
                         "officetype": "CONTRACT FUNDING",
                         "officetypestartdate": "2021-04-13 00:00",
                         "officetypeenddate": null
-                    },
-                    {
-                        "officetype": "FINANCIAL ASSISTANCE FUNDING",
-                        "officetypestartdate": "2021-04-13 00:00",
-                        "officetypeenddate": null
                     }
                 ],
                 "fhorgaddresslist": [
@@ -364,11 +359,6 @@
                     }
                 ],
                 "fhorgofficetypelist": [
-                    {
-                        "officetype": "CONTRACT FUNDING",
-                        "officetypestartdate": "2021-04-13 00:00",
-                        "officetypeenddate": null
-                    },
                     {
                         "officetype": "FINANCIAL ASSISTANCE FUNDING",
                         "officetypestartdate": "2021-04-13 00:00",

--- a/tests/unit/data/test_fh_update.json
+++ b/tests/unit/data/test_fh_update.json
@@ -28,7 +28,7 @@
                 "fhagencyorgname": "TEST AGENCY 5",
                 "agencycode": "0005",
                 "oldfpdsofficecode": "TEST OFFICE 5",
-                "aacofficecode": "W5",
+                "aacofficecode": "W05",
                 "fullParentPathName": "TEST AGENCY 5.TEST AGENCY 5.TEST OFFICE 5",
                 "fullParentPath": "100000005.100000005.5",
                 "cgaclist": [
@@ -91,7 +91,7 @@
                 "fhagencyorgname": "TEST AGENCY 6",
                 "agencycode": "0006",
                 "oldfpdsofficecode": "TEST OFFICE 6",
-                "aacofficecode": "W6",
+                "aacofficecode": "W06",
                 "fullParentPathName": "TEST AGENCY 6.TEST AGENCY 6.TEST OFFICE 6",
                 "fullParentPath": "100000006.100000006.6",
                 "cgaclist": [
@@ -169,7 +169,7 @@
                 "fhagencyorgname": "TEST AGENCY 7",
                 "agencycode": "0007",
                 "oldfpdsofficecode": "TEST OFFICE 7",
-                "aacofficecode": "W7",
+                "aacofficecode": "W07",
                 "fullParentPathName": "TEST AGENCY 7.TEST AGENCY 7.TEST OFFICE 7",
                 "fullParentPath": "100000007.100000007.7",
                 "cgaclist": [
@@ -248,7 +248,7 @@
                 "fhagencyorgname": "TEST AGENCY 9",
                 "agencycode": "0009",
                 "oldfpdsofficecode": "TEST OFFICE 9",
-                "aacofficecode": "W9",
+                "aacofficecode": "W09",
                 "fullParentPathName": "TEST AGENCY 9.TEST AGENCY 9.TEST OFFICE 9",
                 "fullParentPath": "100000009.100000009.9",
                 "cgaclist": [

--- a/tests/unit/data/test_fh_update.json
+++ b/tests/unit/data/test_fh_update.json
@@ -37,16 +37,6 @@
                     }
                 ],
                 "fhorgofficetypelist": [
-                    {
-                        "officetype": "CONTRACT FUNDING",
-                        "officetypestartdate": "2021-04-13 00:00",
-                        "officetypeenddate": null
-                    },
-                    {
-                        "officetype": "FINANCIAL ASSISTANCE FUNDING",
-                        "officetypestartdate": "2021-04-13 00:00",
-                        "officetypeenddate": null
-                    }
                 ],
                 "fhorgaddresslist": [
                     {


### PR DESCRIPTION
**High level description:**
Updating the FH loader to keep only the latest agency code, subtier code, and office name.

**Technical details:**
Updated the test to sort the results by office code (not by subtier)

**Link to JIRA Ticket:**
[DEV-11160](https://federal-spending-transparency.atlassian.net/browse/DEV-11160)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Tested locally with an office that changes its name, agency, and subtier over time
- [x] Frontend impact assessment completed
- [x] Documentation updated