### PR TITLE
Fix: SAM API - Bump to 15 Retries

### DIFF
--- a/dataactcore/utils/sam_recipient.py
+++ b/dataactcore/utils/sam_recipient.py
@@ -731,7 +731,7 @@ def give_up(e):
 
 @limits(calls=RATE_LIMIT_CALLS, period=RATE_LIMIT_PERIOD)
 @sleep_and_retry
-@on_exception(expo, RETRY_REQUEST_EXCEPTIONS, max_tries=10, logger=logger, giveup=give_up)
+@on_exception(expo, RETRY_REQUEST_EXCEPTIONS, max_tries=15, logger=logger, giveup=give_up)
 def _request_sam_api(url, request_type, headers=None, params=None, body=None):
     """ Calls one of the SAM APIs and returns its content
 


### PR DESCRIPTION
**High level description:**
Bumping max retries from 10 to 15. With 10, it's already waiting 4 minutes and each retry exponentially increases the wait time, so that should bump it up to last least ten minutes.

**Technical details:**
N/A

**Link to JIRA Ticket:**
N/A

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Tested
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated