### PR TITLE
DEV-11554: boc filter gtas report

### DIFF
--- a/dataactcore/utils/fileBOC.py
+++ b/dataactcore/utils/fileBOC.py
@@ -267,7 +267,7 @@ def sum_gtas_boc(session, period, year, agency_code):
         func.sum(boc_model.dollar_amount * case([(boc_model.debit_credit == 'D', 1)], else_=-1)).
         label('sum_dollar_amount')
     ).filter(boc_model.fiscal_year == year, boc_model.period == period,
-             func.rpad(boc_model.budget_object_class, 4, '9') != '9999', exists_query).\
+             func.coalesce(func.rpad(boc_model.budget_object_class, 4, '9'), '') != '9999', exists_query).\
         group_by(boc_model.display_tas, boc_model.allocation_transfer_agency, boc_model.agency_identifier,
                  boc_model.beginning_period_of_availa, boc_model.ending_period_of_availabil,
                  boc_model.availability_type_code, boc_model.main_account_code, boc_model.sub_account_code,

--- a/dataactcore/utils/fileBOC.py
+++ b/dataactcore/utils/fileBOC.py
@@ -79,7 +79,7 @@ def query_data(session, agency_code, period, year):
 
 
 def sum_published_file_b(session, submission_id):
-    """ Sums the specified published file B to ignore PAC/PAN
+    """ Sums the specified published file B to ignore PAC/PAN. Ignores BOC of 0, 00, 000, or 0000
 
         Args:
             session: The current DB session
@@ -125,7 +125,8 @@ def sum_published_file_b(session, submission_id):
         func.sum(fileb_model.ussgl498100_upward_adjustm_cpe).label('sum_ussgl498100_upward_adjustm_cpe'),
         func.sum(fileb_model.ussgl498200_upward_adjustm_cpe).label('sum_ussgl498200_upward_adjustm_cpe'),
         func.array_agg(fileb_model.row_number).label('row_numbers')
-    ).filter(fileb_model.submission_id == submission_id).\
+    ).filter(fileb_model.submission_id == submission_id,
+             func.rpad(fileb_model.object_class, 4, '0') != '0000').\
         group_by(fileb_model.display_tas, fileb_model.allocation_transfer_agency, fileb_model.agency_identifier,
                  fileb_model.beginning_period_of_availa, fileb_model.ending_period_of_availabil,
                  fileb_model.availability_type_code, fileb_model.main_account_code, fileb_model.sub_account_code,
@@ -234,7 +235,7 @@ def ussgl_published_file_b_cte(session, ussgl_vals, model):
 
 
 def sum_gtas_boc(session, period, year, agency_code):
-    """ Sums the GTAS BOC data for the given year/period/agency to ignore PYA since we don't have that to compare to
+    """ Sums the GTAS BOC data for the given year/period/agency to ignore BOC of 999 or 9999
 
         Args:
             session: The current DB session
@@ -265,7 +266,8 @@ def sum_gtas_boc(session, period, year, agency_code):
         boc_model.ussgl_number,
         func.sum(boc_model.dollar_amount * case([(boc_model.debit_credit == 'D', 1)], else_=-1)).
         label('sum_dollar_amount')
-    ).filter(boc_model.fiscal_year == year, boc_model.period == period, exists_query).\
+    ).filter(boc_model.fiscal_year == year, boc_model.period == period,
+             func.rpad(boc_model.budget_object_class, 4, '9') != '9999', exists_query).\
         group_by(boc_model.display_tas, boc_model.allocation_transfer_agency, boc_model.agency_identifier,
                  boc_model.beginning_period_of_availa, boc_model.ending_period_of_availabil,
                  boc_model.availability_type_code, boc_model.main_account_code, boc_model.sub_account_code,

--- a/tests/unit/dataactvalidator/validation_handlers/test_file_generation_manager.py
+++ b/tests/unit/dataactvalidator/validation_handlers/test_file_generation_manager.py
@@ -790,6 +790,10 @@ def test_generate_boc(database, monkeypatch):
     boc9 = GTASBOCFactory(period=6, fiscal_year=year, display_tas=tas4_str, dollar_amount=1.5, ussgl_number='480100',
                           begin_end='B', debit_credit='D', disaster_emergency_fund_code='Q', budget_object_class='1110',
                           reimbursable_flag='D', prior_year_adjustment_code='X', **tas4_dict)
+    # BOC of 999 should be ignored
+    boc10 = GTASBOCFactory(period=6, fiscal_year=year, display_tas=tas1_str, dollar_amount=1.5, ussgl_number='480100',
+                           begin_end='B', debit_credit='D', disaster_emergency_fund_code='Q', budget_object_class='999',
+                           reimbursable_flag='D', prior_year_adjustment_code='X', **tas1_dict)
 
     # The first two will end up in the same place, there is an implied "different PAC/PAN"
     pub_b1 = PublishedObjectClassProgramActivityFactory(submission_id=sub_id, display_tas=tas1_str,
@@ -813,14 +817,23 @@ def test_generate_boc(database, monkeypatch):
                                                         ussgl487100_downward_adjus_cpe=-4,
                                                         by_direct_reimbursable_fun='D', row_number=9,
                                                         prior_year_adjustment='', **tas2_dict)
+    # Object class of 000 should be ignored
+    pub_b4 = PublishedObjectClassProgramActivityFactory(submission_id=sub_id, display_tas=tas1_str,
+                                                        disaster_emergency_fund_code='Q', object_class='000',
+                                                        ussgl480100_undelivered_or_fyb=-0.5,
+                                                        ussgl480100_undelivered_or_cpe=1.5,
+                                                        ussgl487100_downward_adjus_cpe=8,
+                                                        by_direct_reimbursable_fun='D', row_number=1,
+                                                        prior_year_adjustment='X', begin_end_indicator='B',
+                                                        **tas1_dict)
 
     sub = SubmissionFactory(submission_id=sub_id, reporting_fiscal_year=year, reporting_fiscal_period=6,
                             publish_status_id=PUBLISH_STATUS_DICT['published'], cgac_code=agency_cgac)
     job = JobFactory(job_status_id=JOB_STATUS_DICT['running'], job_type_id=JOB_TYPE_DICT['file_upload'],
                      file_type_id=FILE_TYPE_DICT['boc_comparison'], filename=None, start_date='03/01/2017',
                      end_date='03/31/2017', submission=None)
-    sess.add_all([tas1, tas2, tas3, tas4, boc1, boc2, boc3, boc4, boc5, boc6, boc7, boc8, boc9, sub, job, pub_b1,
-                  pub_b2, pub_b3])
+    sess.add_all([tas1, tas2, tas3, tas4, boc1, boc2, boc3, boc4, boc5, boc6, boc7, boc8, boc9, boc10, sub, job, pub_b1,
+                  pub_b2, pub_b3, pub_b4])
     sess.commit()
 
     file_gen_manager = FileGenerationManager(sess, CONFIG_BROKER['local'], job=job)
@@ -863,11 +876,20 @@ def test_generate_boc(database, monkeypatch):
                 [boc8.budget_object_class, 'D', 'Q', 'Y', boc8.begin_end, str(year), '6', boc8.ussgl_number, '-2',
                  '0', '-2']
 
+    # TAS 1 but ignored because of BOC 999 or 000 (depending on the location)
+    expected6 = [tas1_str] + list(tas1_dict.values()) + \
+                [boc10.budget_object_class, 'D', 'Q', 'X', boc10.begin_end, str(year), '6', boc8.ussgl_number, '1.5',
+                 '0', '1.5']
+    expected7 = [tas1_str] + list(tas1_dict.values()) + \
+                ['0000', 'D', 'Q', 'X', 'B', str(year), '6', '480100', '0', '-0.5', '0.5']
+
     assert expected1 in file_rows
     assert expected2 in file_rows
     assert expected3 in file_rows
     assert expected4 not in file_rows
     assert expected5 in file_rows
+    assert expected6 not in file_rows
+    assert expected7 not in file_rows
 
 
 @pytest.mark.usefixtures("job_constants", "broker_files_tmp_dir")


### PR DESCRIPTION
**High level description:**
Removing 000 and 999 from GTAS Comparison Report

**Technical details:**
BOC 000 in file B and 999 in the BOC GTAS data (and their equivalents with more or less numbers) are all invalid but can be used as fillers and don't need to show up in the comparison report

**Link to JIRA Ticket:**
[DEV-11554](https://federal-spending-transparency.atlassian.net/browse/DEV-11554)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation updated