### PR TITLE
[DEV-11432] - Removing redundant columns from group by expressions

### DIFF
--- a/dataactvalidator/config/sqlrules/a18_cross_file.sql
+++ b/dataactvalidator/config/sqlrules/a18_cross_file.sql
@@ -3,13 +3,6 @@
 -- where PYA = "X".
 WITH appropriation_a18_{0} AS
     (SELECT row_number,
-        allocation_transfer_agency,
-        agency_identifier,
-        beginning_period_of_availa,
-        ending_period_of_availabil,
-        availability_type_code,
-        main_account_code,
-        sub_account_code,
         gross_outlay_amount_by_tas_cpe,
         account_num,
         submission_id,
@@ -29,13 +22,6 @@ FROM appropriation_a18_{0} AS approp
         AND approp.submission_id = op.submission_id
 WHERE UPPER(op.prior_year_adjustment) = 'X'
 GROUP BY approp.row_number,
-    approp.allocation_transfer_agency,
-    approp.agency_identifier,
-    approp.beginning_period_of_availa,
-    approp.ending_period_of_availabil,
-    approp.availability_type_code,
-    approp.main_account_code,
-    approp.sub_account_code,
     approp.gross_outlay_amount_by_tas_cpe,
     approp.display_tas,
     UPPER(op.prior_year_adjustment)

--- a/dataactvalidator/config/sqlrules/a19_cross_file.sql
+++ b/dataactvalidator/config/sqlrules/a19_cross_file.sql
@@ -3,13 +3,6 @@
 -- values in the object class and program activity file (B) where PYA = "X".
 WITH appropriation_a19_{0} AS
     (SELECT row_number,
-        allocation_transfer_agency,
-        agency_identifier,
-        beginning_period_of_availa,
-        ending_period_of_availabil,
-        availability_type_code,
-        main_account_code,
-        sub_account_code,
         obligations_incurred_total_cpe,
         account_num,
         submission_id,
@@ -29,13 +22,6 @@ FROM appropriation_a19_{0} AS approp
         AND approp.submission_id = op.submission_id
 WHERE UPPER(op.prior_year_adjustment) = 'X'
 GROUP BY approp.row_number,
-    approp.allocation_transfer_agency,
-    approp.agency_identifier,
-    approp.beginning_period_of_availa,
-    approp.ending_period_of_availabil,
-    approp.availability_type_code,
-    approp.main_account_code,
-    approp.sub_account_code,
     approp.obligations_incurred_total_cpe,
     approp.display_tas,
     UPPER(op.prior_year_adjustment)


### PR DESCRIPTION
**High level description:**
This PR removes the following columns that are redundant with `display_tas` from group by expressions and cte selects in the sql rules:
- `allocation_transfer_agency`
- `agency_identifier`
- `beginning_period_of_availa`
- `ending_period_of_availabil`
- `availability_type_code`
- `main_account_code`
- `sub_account_code`

**Technical details:**
The column `display_tas` is generated by concatenating the values of the above listed columns and these columns are always unique together.  One suggestion for followup is whether it would be beneficial to add a unique together constraint for these columns to enforce this behavior.  

**Link to JIRA Ticket:**
[DEV-11432](https://federal-spending-transparency.atlassian.net/browse/DEV-11432)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Style Guide check completed