### PR TITLE
DEV-11620: filter non b ussgl gtas comparison

### DIFF
--- a/dataactcore/utils/fileBOC.py
+++ b/dataactcore/utils/fileBOC.py
@@ -249,6 +249,8 @@ def sum_gtas_boc(session, period, year, agency_code):
     agency_filters = tas_agency_filter(session, agency_code, TASLookup)
     exists_query = session.query(TASLookup).filter(TASLookup.display_tas == boc_model.display_tas,
                                                    or_(*agency_filters)).exists()
+    ussgl_list = ['480100', '480110', '480200', '483100', '483200', '487100', '487200', '488100', '488200', '490100',
+                  '490110', '490200', '490800', '490800', '493100', '497100', '497200', '498100', '498200']
     sum_boc = session.query(
         boc_model.display_tas,
         boc_model.allocation_transfer_agency,
@@ -267,7 +269,8 @@ def sum_gtas_boc(session, period, year, agency_code):
         func.sum(boc_model.dollar_amount * case([(boc_model.debit_credit == 'D', 1)], else_=-1)).
         label('sum_dollar_amount')
     ).filter(boc_model.fiscal_year == year, boc_model.period == period,
-             func.rpad(boc_model.budget_object_class, 4, '9') != '9999', exists_query).\
+             func.rpad(boc_model.budget_object_class, 4, '9') != '9999',
+             boc_model.ussgl_number.in_(ussgl_list), exists_query).\
         group_by(boc_model.display_tas, boc_model.allocation_transfer_agency, boc_model.agency_identifier,
                  boc_model.beginning_period_of_availa, boc_model.ending_period_of_availabil,
                  boc_model.availability_type_code, boc_model.main_account_code, boc_model.sub_account_code,

--- a/dataactcore/utils/fileBOC.py
+++ b/dataactcore/utils/fileBOC.py
@@ -1,3 +1,5 @@
+import re
+
 from collections import OrderedDict
 from sqlalchemy import or_, and_, func, values, column
 from sqlalchemy.sql.expression import case, literal
@@ -249,8 +251,8 @@ def sum_gtas_boc(session, period, year, agency_code):
     agency_filters = tas_agency_filter(session, agency_code, TASLookup)
     exists_query = session.query(TASLookup).filter(TASLookup.display_tas == boc_model.display_tas,
                                                    or_(*agency_filters)).exists()
-    ussgl_list = ['480100', '480110', '480200', '483100', '483200', '487100', '487200', '488100', '488200', '490100',
-                  '490110', '490200', '490800', '490800', '493100', '497100', '497200', '498100', '498200']
+    ussgl_list = list(set([re.findall(r'ussgl(\d+)_.*', col.name)[0] for col in fileb_model.__table__.columns if
+                           col.name.startswith('ussgl')]))
     sum_boc = session.query(
         boc_model.display_tas,
         boc_model.allocation_transfer_agency,


### PR DESCRIPTION
**High level description:**
Filtering out non-file B USSGLs from the GTAS BOC data when making a GTAS Comparison Report

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-11620](https://federal-spending-transparency.atlassian.net/browse/DEV-11620)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Merged after [Backend#2671](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/2671)
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation updated