### PR TITLE
[DEV-11811] - Add legacy city codes (PW, FM, MH) to the city code loader

### DIFF
--- a/dataactcore/scripts/setup/load_location_data.py
+++ b/dataactcore/scripts/setup/load_location_data.py
@@ -220,6 +220,16 @@ def load_city_data(force_reload):
     with RetrieveFileFromUri(city_file_url, 'r').get_file_object() as city_file:
         new_data = parse_city_file(city_file)
 
+    # parse the legacy city code data
+    legacy_city_filename = 'NationalFedCodes_LEGACY.txt'
+    legacy_city_url = f'{CONFIG_BROKER["usas_public_reference_url"]}/{legacy_city_filename}'
+    with RetrieveFileFromUri(legacy_city_url, 'r').get_file_object() as legacy_city_file:
+        legacy_data = parse_city_file(legacy_city_file)
+
+    # only add legacy city code data if the state is not already in the new city data
+    add_legacy_data = legacy_data.loc[~legacy_data['state_code'].isin(new_data['state_code'].unique())]
+    new_data = pd.concat([new_data, add_legacy_data])
+
     diff_found = check_dataframe_diff(new_data, CityCode, ['city_code_id'], ['state_code', 'city_code'])
 
     if force_reload or diff_found:

--- a/tests/unit/dataactcore/utils/test_tracing.py
+++ b/tests/unit/dataactcore/utils/test_tracing.py
@@ -138,8 +138,8 @@ def test_logging_trace_spans(caplog, capsys):
 
     captured = capsys.readouterr()
     assert test_msg in caplog.text, "caplog.text did not seem to capture logging output during test"
-    assert hex(trace_id) in captured.out, "trace_id not found in logging output"
-    assert hex(span_id) in captured.out, "span_id not found in logging output"
+    assert f'{trace_id:x}' in captured.out, "trace_id not found in logging output"
+    assert f'{span_id:x}' in captured.out, "span_id not found in logging output"
     assert f"{test}_resource" in captured.out, "traced resource not found in logging output"
 
 


### PR DESCRIPTION
**High level description:**
This PR re-adds missing legacy city codes that is not present for certain "states".

**Technical details:**
I tested this locally using a  minio container to replicate the S3 functionality.  

**Note:**
I also fixed an unrelated test that was randomly failing. See [comment](https://github.com/fedspendingtransparency/data-act-broker-backend/pull/2680#discussion_r1884475378).

**Link to JIRA Ticket:**
[DEV-111811](https://federal-spending-transparency.atlassian.net/browse/DEV-11811)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Style Guide check completed
