### PR TITLE
Fix: sam subaward nightly dup fix

### DIFF
--- a/dataactcore/scripts/pipeline/generate_sam_fabs_export.py
+++ b/dataactcore/scripts/pipeline/generate_sam_fabs_export.py
@@ -110,7 +110,7 @@ def get_award_updates_query(start_date=None, end_date=None):
                     high_comp_officer5_amount,
                     ROW_NUMBER() OVER (PARTITION BY
                         UPPER(afa_generated_unique)
-                        ORDER BY updated_at DESC
+                        ORDER BY updated_at, published_fabs_id DESC
                     ) AS row_num
                 FROM published_fabs
                 WHERE {query_filter}) duplicates

--- a/dataactcore/scripts/pipeline/generate_sam_fabs_export.py
+++ b/dataactcore/scripts/pipeline/generate_sam_fabs_export.py
@@ -110,7 +110,7 @@ def get_award_updates_query(start_date=None, end_date=None):
                     high_comp_officer5_amount,
                     ROW_NUMBER() OVER (PARTITION BY
                         UPPER(afa_generated_unique)
-                        ORDER BY updated_at, published_fabs_id DESC
+                        ORDER BY updated_at DESC, published_fabs_id DESC
                     ) AS row_num
                 FROM published_fabs
                 WHERE {query_filter}) duplicates

--- a/tests/unit/dataactcore/scripts/test_generate_sam_fabs_export.py
+++ b/tests/unit/dataactcore/scripts/test_generate_sam_fabs_export.py
@@ -41,18 +41,21 @@ def test_status(database):
 
 def test_ignore_duplicates(database):
     sess = database.session
-    pf1 = PublishedFABSFactory(updated_at=datetime.now() - timedelta(hours=1), afa_generated_unique='activerecord',
-                               is_active=False, award_description='older entry')
-    pf2 = PublishedFABSFactory(updated_at=datetime.now() + timedelta(minutes=1), afa_generated_unique='activerecord',
-                               is_active=True, award_description='newer entry')
-    sess.add_all([pf1, pf2])
+    now = datetime.now()
+    pf1 = PublishedFABSFactory(published_fabs_id=1, updated_at=now - timedelta(hours=1),
+                               afa_generated_unique='activerecord', is_active=False, award_description='older entry')
+    pf2 = PublishedFABSFactory(published_fabs_id=2, updated_at=now + timedelta(minutes=1),
+                               afa_generated_unique='activerecord', is_active=False, award_description='newer entry')
+    pf3 = PublishedFABSFactory(published_fabs_id=3, updated_at=now + timedelta(minutes=1),
+                               afa_generated_unique='activerecord', is_active=True, award_description='even newer entry')
+    sess.add_all([pf1, pf2, pf3])
     sess.commit()
 
     results = sess.execute(get_award_updates_query(datetime.now().strftime('%m/%d/%y')))
     result_list = results.all()
 
     assert len(result_list) == 1
-    assert result_list[0].project_description == 'newer entry'
+    assert result_list[0].project_description == 'even newer entry'
 
 
 def test_grouping(database):

--- a/tests/unit/dataactcore/scripts/test_generate_sam_fabs_export.py
+++ b/tests/unit/dataactcore/scripts/test_generate_sam_fabs_export.py
@@ -47,7 +47,8 @@ def test_ignore_duplicates(database):
     pf2 = PublishedFABSFactory(published_fabs_id=2, updated_at=now + timedelta(minutes=1),
                                afa_generated_unique='activerecord', is_active=False, award_description='newer entry')
     pf3 = PublishedFABSFactory(published_fabs_id=3, updated_at=now + timedelta(minutes=1),
-                               afa_generated_unique='activerecord', is_active=True, award_description='even newer entry')
+                               afa_generated_unique='activerecord', is_active=True,
+                               award_description='even newer entry')
     sess.add_all([pf1, pf2, pf3])
     sess.commit()
 


### PR DESCRIPTION
**High level description:**
Simply updates the script that exports FABS records to SAM to sort by `published_fabs_id` in addition to `updated_at`.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-12580](https://federal-spending-transparency.atlassian.net/browse/DEV-12580)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Confirmed fixes examples they provided.
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation updated