### PR TITLE
[DEV-12660] Raw park.csv export

### DIFF
--- a/dataactcore/scripts/pipeline/load_park.py
+++ b/dataactcore/scripts/pipeline/load_park.py
@@ -87,22 +87,6 @@ def export_public_park(raw_data):
         Args:
             raw_data: the raw csv data analyzed from the latest program activity file
     """
-    updated_cols = {
-        'FY': 'FISCAL_YEAR',
-        'PD': 'PERIOD',
-        'ALLOC_XFER_AGENCY': 'ALLOCATION_TRANSFER_AGENCY_IDENTIFIER_CODE',
-        'AID': 'AGENCY_IDENTIFIER_CODE',
-        'MAIN_ACCT': 'MAIN_ACCOUNT_CODE',
-        'SUB_ACCT': 'SUB_ACCOUNT_CODE',
-        'COMPOUND_KEY': 'COMPOUND_KEY',
-        'PARK': 'PARK_CODE',
-        'PARK_NAME': 'PARK_NAME',
-        'RECORD_UPDATE_TS': 'RECORD_UPDATE_TIMESTAMP',
-        'FILE_UPDATE_TS': 'FILE_UPDATE_TIMESTAMP'
-    }
-    raw_data = raw_data[list(updated_cols.keys())]
-    raw_data.columns = [list(updated_cols.values())]
-
     export_name = 'park.csv'
     logger.info('Exporting loaded PARK file to {}'.format(export_name))
     raw_data.to_csv(export_name, index=0)

--- a/tests/unit/dataactcore/scripts/test_load_park.py
+++ b/tests/unit/dataactcore/scripts/test_load_park.py
@@ -87,9 +87,8 @@ def test_export_park(mocked_get_park_file, mocked_get_current_date, mocked_get_s
         actual_headers = export_park.readline()
     remove_exported_file()
 
-    expected_headers = ('FISCAL_YEAR,PERIOD,ALLOCATION_TRANSFER_AGENCY_IDENTIFIER_CODE,AGENCY_IDENTIFIER_CODE,'
-                        'MAIN_ACCOUNT_CODE,SUB_ACCOUNT_CODE,COMPOUND_KEY,PARK_CODE,PARK_NAME,RECORD_UPDATE_TIMESTAMP,'
-                        'FILE_UPDATE_TIMESTAMP\n')
+    expected_headers = ('FY,PD,ALLOC_XFER_AGENCY,AID,MAIN_ACCT,SUB_ACCT,COMPOUND_KEY,PARK,PARK_NAME,RECORD_UPDATE_TS,'
+                        'FILE_UPDATE_TS\n')
     assert expected_headers == actual_headers
 
     remove_metrics_file()


### PR DESCRIPTION
**High level description:**
Simply exports the `park.csv` the same as the original file (without cleaning up the headers).

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-12660](https://federal-spending-transparency.atlassian.net/browse/DEV-12660)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Documentation updated

[DEV-12600]: https://federal-spending-transparency.atlassian.net/browse/DEV-12600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEV-12660]: https://federal-spending-transparency.atlassian.net/browse/DEV-12660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ