### PR TITLE
[DEV-12828] DEFC Loader Fix: `dateIssued`

### DIFF
--- a/dataactcore/scripts/setup/load_defc.py
+++ b/dataactcore/scripts/setup/load_defc.py
@@ -84,7 +84,7 @@ def derive_pl_data(public_law):
         for char in ["'", '"', "`"]:
             short_title = short_title.replace(char, "")
 
-        date_approved = govinfo_data["dcMD"]["dateIssued"]
+        date_approved = govinfo_data["dcMD"]["origDateIssued"]
 
         url = govinfo_data["download"]["pdflink"]
         url = f"http:{url}"

--- a/tests/unit/dataactcore/scripts/test_load_defc.py
+++ b/tests/unit/dataactcore/scripts/test_load_defc.py
@@ -15,7 +15,7 @@ def mock_request_to_govinfo(url):
     if congress != "0":
         govinfo_data = {
             "title": f'Public Law {congress} - {law} - Test `Short Title` "{congress}-{law}"',
-            "dcMD": {"dateIssued": f"2{congress}-01-02"},
+            "dcMD": {"origDateIssued": f"2{congress}-01-02"},
             "download": {"pdflink": f"//test-pdf-link.gov/{congress}/{law}/{congress}-{law}.pdf"},
         }
     return govinfo_data


### PR DESCRIPTION
**High level description:**
The GovInfo endpoint we use to pull DEFC metadata has changed the format of its `dateIssued`. This replaces it with `origDateIssued`.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-12828](https://federal-spending-transparency.atlassian.net/browse/DEV-12828)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [ ] Confirmed locally and on production
- [x] Style Guide check completed
- [x] Merged concurrently with [Frontend#1234](https://github.com/fedspendingtransparency/data-act-broker-web-app/pull/1234)
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated


[DEV-12828]: https://federal-spending-transparency.atlassian.net/browse/DEV-12828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ