### PR TITLE
[DEV-14158] Add FABS checks to /v1/restart_validation

### DIFF
--- a/doc/api_docs/file/restart_validation.md
+++ b/doc/api_docs/file/restart_validation.md
@@ -32,6 +32,8 @@ Possible HTTP Status Codes:
 - 400:
     - Submission does not exist
     - Missing `submission_id`
+    - `is_fabs` does not match submission 
     - Submission is revalidating or publishing
+    - Submission is an already published FABS submission
 - 401: Login required
 - 403: Permission denied, user does not have permission to edit this submission

--- a/tests/integration/fabs_upload_tests.py
+++ b/tests/integration/fabs_upload_tests.py
@@ -116,6 +116,15 @@ class FABSUploadTests(BaseTestAPI):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json["message"], "Submission has already been published")
 
+    def test_revalidation_already_published(self):
+        """Test a revalidation failure because the FABS submission is already published"""
+        params = {"submission_id": self.published_submission, "is_fabs": True}
+        response = self.app.post_json(
+            "/v1/restart_validation/", params, headers={"x-session-id": self.session_id}, expect_errors=True
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["message"], "Submission has already been published")
+
     def test_unfinished_job(self):
         """Test a publish failure because the submission has a running job"""
         submission = {"submission_id": self.running_submission}
@@ -133,6 +142,24 @@ class FABSUploadTests(BaseTestAPI):
         )
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json["message"], "Submission is not a FABS submission")
+
+    def test_revalidation_not_fabs(self):
+        """Test a revalidation failure because the submission is not FABS"""
+        params = {"submission_id": self.other_submission, "is_fabs": True}
+        response = self.app.post_json(
+            "/v1/restart_validation/", params, headers={"x-session-id": self.session_id}, expect_errors=True
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["message"], "Submission is not a FABS submission")
+
+    def test_revalidation_not_dabs(self):
+        """Test a revalidation failure because the submission is not DABS"""
+        params = {"submission_id": self.fabs_submission, "is_fabs": False}
+        response = self.app.post_json(
+            "/v1/restart_validation/", params, headers={"x-session-id": self.session_id}, expect_errors=True
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["message"], "Submission is not a DABS submission")
 
     def test_upload_fabs_file_wrong_permissions_wrong_user(self):
         self.login_user()


### PR DESCRIPTION
**High level description:**
Adds several checks to `/v1/restart_validation`
* Blocks if the submission is FABS and already published
* is_fabs is True and the submission is DABS
* is_fabs is False and the submission is FABS

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-14158](https://federal-spending-transparency.atlassian.net/browse/DEV-14158)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated


[DEV-14158]: https://federal-spending-transparency.atlassian.net/browse/DEV-14158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ