### PR TITLE
[DEV-15143] Dropping /v1/ from API Submission Guide instructions for …

### DIFF
--- a/APISubmissionGuide.md
+++ b/APISubmissionGuide.md
@@ -36,7 +36,7 @@ While the Submission API has been designed to be as easy to understand as possib
         - The root url will be replaced:
             - Before: `https://broker-api.usaspending.gov/`
             - After: `https://api.fiscal.treasury.gov/ap/exp/v1/data-act-broker/`
-            - **NOTE**: The API Proxy does **not** support endpoint URLs ending with a trailing slash (`/`). Please ensure that all your calls to the API do not include a trailing slash.
+            - **NOTE**: The API Proxy does **not** support endpoint URLs ending with a trailing slash (`/`). Please ensure that all your calls to the API do not include a trailing slash. Also, when referring to the endpoint documentation, the API proxy will drop the additional `/v1/` before the endpoint name (ex. `/v1/active_user` is just `/active_user`).
         - Two new headers must be added in every request:
             - `client_id`: The `Client ID` copied from earlier.
             - `client_secret`: The `Client Secret` copied from earlier.

--- a/APISubmissionGuide.md
+++ b/APISubmissionGuide.md
@@ -40,7 +40,7 @@ While the Submission API has been designed to be as easy to understand as possib
         - Two new headers must be added in every request:
             - `client_id`: The `Client ID` copied from earlier.
             - `client_secret`: The `Client Secret` copied from earlier.
-    - Simply call `/v1/active_user` (GET) to get a new session started and confirm the user is correct.
+    - Simply call `/active_user` (GET) to get a new session started and confirm the user is correct.
 - Troubleshooting
     - When finally logging into the Broker using the new credentials and you receive a message:
         - **"Authentication denied"**: The `client_id`/`client_secret` headers were not included. Make sure to include them.
@@ -51,51 +51,51 @@ While the Submission API has been designed to be as easy to understand as possib
 ## DABS Submission Process
 
 ### Upload B and C Files
-- Step 1: call `/v1/upload_dabs_files/` (POST) to create the submission.
+- Step 1: call `/upload_dabs_files/` (POST) to create the submission.
 	- For details on its use, click [here](./doc/api_docs/file/upload_dabs_files.md)
 - File A will be generated automatically at this point.
-- **NOTE**: If you would like to certify this submission, call `/v1/published_submissions/` (GET) to ensure there are no other submissions already published by the same agency in the same period.
+- **NOTE**: If you would like to certify this submission, call `/published_submissions/` (GET) to ensure there are no other submissions already published by the same agency in the same period.
     - For details on its use, click [here](./doc/api_docs/file/published_submissions.md)
 
 ### Validate A, B, C Files
 - File-level validation begins automatically on upload completion.
-- Check status of validations using `/v1/check_status/`. For details on its use, click [here](./doc/api_docs/file/check_status.md)
+- Check status of validations using `/check_status/`. For details on its use, click [here](./doc/api_docs/file/check_status.md)
 - Continue polling with `check_status` until the following keys have a `status` of `finished` or `failed`:
     - `appropriations`
     - `program_activity`
     - `award_financial`
     - **NOTE**: If any of these have a status of `ready` that means they were never started.
-- To get a general overview of the number of errors/warnings in the submission, along with all other metadata, `/v1/submission_metadata/` can be called. For details on its use, click [here](./doc/api_docs/file/submission_metadata.md)
-- To get detailed information on each of the jobs and the errors that occurred in each, `/v1/submission_data/` can be called. For details on its use, click [here](./doc/api_docs/file/submission_data.md)
-- If there are any errors and more granular detail is needed, get the error reports by calling `/v1/report_url/`. For details on its use, click [here](./doc/api_docs/file/report_url.md). In this case, `cross_type` should not be used.
+- To get a general overview of the number of errors/warnings in the submission, along with all other metadata, `/submission_metadata/` can be called. For details on its use, click [here](./doc/api_docs/file/submission_metadata.md)
+- To get detailed information on each of the jobs and the errors that occurred in each, `/submission_data/` can be called. For details on its use, click [here](./doc/api_docs/file/submission_data.md)
+- If there are any errors and more granular detail is needed, get the error reports by calling `/report_url/`. For details on its use, click [here](./doc/api_docs/file/report_url.md). In this case, `cross_type` should not be used.
 - If the automatically generated file A is not adequate for any reason, at this point a custom file A may be uploaded along with any files that have errors in them.
 - If a reupload is needed for any of the files, begin again from `upload_dabs_files` with these changes:
     - Only pass the keys of the files being updated (e.g. if only appropriations needs a reupload, you will pass `appropriations: "FILENAME"` as an entry in the payload but not the other two.
     - Add the key `existing_submission_id` with the ID of the submission as the content (string).
     - Response will update to not include the IDs and keys for any files that were not resubmitted
-- If for any reason one of the uploaded files need to be redownloaded, use the `/v1/get_file_url` route to get the signed url for it. For details on its use, click [here](./doc/api_docs/file/get_file_url.md)
+- If for any reason one of the uploaded files need to be redownloaded, use the `/get_file_url` route to get the signed url for it. For details on its use, click [here](./doc/api_docs/file/get_file_url.md)
 
 ### Generate D1, D2 Files
 - D File generation must be manually started ONLY AFTER all errors in A, B, C files have been fixed (warnings are allowed)
-- Step 1: Call `/v1/generate_file/` for each of the D files (two calls, one for D1 and one for D2). For details on its use, click [here](./doc/api_docs/generation/generate_file.md)
-- Step 2: Poll `/v1/check_generation_status/` for each D file individually to see if generation has completed. Pinging should continue until status is not `waiting` or `running`. For details on its use, click [here](./doc/api_docs/generation/check_generation_status.md)
+- Step 1: Call `/generate_file/` for each of the D files (two calls, one for D1 and one for D2). For details on its use, click [here](./doc/api_docs/generation/generate_file.md)
+- Step 2: Poll `/check_generation_status/` for each D file individually to see if generation has completed. Pinging should continue until status is not `waiting` or `running`. For details on its use, click [here](./doc/api_docs/generation/check_generation_status.md)
 
 ### Cross-file validations
 - Cross-file validation begins automatically upon successful completion of D file generation (no errors)
 - Poll using the `check_status` route in the same manner as described in `Validate A, B, C Files` except the key being looked at should be `cross`. The same endpoints can also be used to gather the submission metadata and cross-file job data.
-- To get a specific error/warning file, call `/v1/report_url/`. For details on its use, click [here](./doc/api_docs/file/report_url.md). In this case, `cross_type` should be used.
+- To get a specific error/warning file, call `/report_url/`. For details on its use, click [here](./doc/api_docs/file/report_url.md). In this case, `cross_type` should be used.
 - If a file needs to be fixed, follow the same steps as in the `Validate A, B, C Files` section
 
 ### Generate E, F Files
 - Once cross-file validation completes with 0 errors (warnings are acceptable), E/F file generation can begin.
-- Call `/v1/generate_file/` to generate E and F files, will require being called twice (once for E and once for F). For details on its use, click [here](./doc/api_docs/generation/generate_file.md)
-- Poll `/v1/check_generation_status/` for each file individually to see if generation has completed. Pinging should continue until status is not `waiting` or `running`. For details on its use, click [here](./doc/api_docs/generation/check_generation_status.md)
+- Call `/generate_file/` to generate E and F files, will require being called twice (once for E and once for F). For details on its use, click [here](./doc/api_docs/generation/generate_file.md)
+- Poll `/check_generation_status/` for each file individually to see if generation has completed. Pinging should continue until status is not `waiting` or `running`. For details on its use, click [here](./doc/api_docs/generation/check_generation_status.md)
 
 ### Review and Add Comments
 - Once the E and F files are generated successfully, the results can be reviewed using a series of calls.
-- To see what comments exist for each file, call `/v1/get_submission_comments`. For details on its use, click [here](./doc/api_docs/file/get_submission_comments.md)
-- To get the total obligations throughout the file, call `/v1/get_obligations`. For details on its use, click [here](./doc/api_docs/file/get_obligations.md)
-- To update the comments on files, call `/v1/update_submission_comments`. For details on its use, click [here](./doc/api_docs/file/update_submission_comments.md)
+- To see what comments exist for each file, call `/get_submission_comments`. For details on its use, click [here](./doc/api_docs/file/get_submission_comments.md)
+- To get the total obligations throughout the file, call `/get_obligations`. For details on its use, click [here](./doc/api_docs/file/get_obligations.md)
+- To update the comments on files, call `/update_submission_comments`. For details on its use, click [here](./doc/api_docs/file/update_submission_comments.md)
 
 ### Certify Submission
 - Certification must be done through the broker website
@@ -103,17 +103,17 @@ While the Submission API has been designed to be as easy to understand as possib
 ## FABS Submission Process
 
 ### Upload FABS File
-- Call `/v1/upload_fabs_file/`
+- Call `/upload_fabs_file/`
 - For details on its use, click [here](./doc/api_docs/file/upload_fabs_file.md)
 
 ### Validate FABS File
 - Validations are automatically started once the upload completes.
-- Check status of validations using `/v1/check_status/`. For details on its use, click [here](./doc/api_docs/file/check_status.md)
+- Check status of validations using `/check_status/`. For details on its use, click [here](./doc/api_docs/file/check_status.md)
 - Continue polling with `check_status` until the `fabs` key has a `status` of `finished` or `failed`.
     - **NOTE**: If it has a status of `ready` that means it was never started.
-- To get a general overview of the number of errors/warnings in the submission, along with all other metadata, `/v1/submission_metadata/` can be called. For details on its use, click [here](./doc/api_docs/file/submission_metadata.md)
-- To get detailed information on the validation job and the errors that occurred in it, `/v1/submission_data/` can be called. For details on its use, click [here](./doc/api_docs/file/submission_data.md)
-- If there are any errors and more granular detail is needed, get the error reports by calling `/v1/report_url/`. For details on its use, click [here](./doc/api_docs/file/report_url.md). In this case, `cross_type` should not be used.
+- To get a general overview of the number of errors/warnings in the submission, along with all other metadata, `/submission_metadata/` can be called. For details on its use, click [here](./doc/api_docs/file/submission_metadata.md)
+- To get detailed information on the validation job and the errors that occurred in it, `/submission_data/` can be called. For details on its use, click [here](./doc/api_docs/file/submission_data.md)
+- If there are any errors and more granular detail is needed, get the error reports by calling `/report_url/`. For details on its use, click [here](./doc/api_docs/file/report_url.md). In this case, `cross_type` should not be used.
 - If a reupload is needed, begin again from `upload_fabs_file` with these changes:
     - `upload_fabs_file` Payload:
         - `fabs`: string, name of file being uploaded


### PR DESCRIPTION
**High level description:**
Dropping references to `/v1` for API submission guide instructions because the API Proxy drops the `/v1/` from the calls.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-15143](https://federal-spending-transparency.atlassian.net/browse/DEV-15143)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated


[DEV-15143]: https://federal-spending-transparency.atlassian.net/browse/DEV-15143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ