### PR TITLE
[DEV-15395] JsonResponse.debug_mode fixes

### DIFF
--- a/dataactbroker/app.py
+++ b/dataactbroker/app.py
@@ -64,7 +64,7 @@ def create_app():
     if local and not os.path.exists(broker_file_path):
         os.makedirs(broker_file_path)
 
-    JsonResponse.debugMode = flask_app.debug
+    JsonResponse.debug_mode = flask_app.debug
 
     if CONFIG_SERVICES["cross_origin_url"] == "*":
         CORS(flask_app, supports_credentials=False, allow_headers="*", expose_headers="X-Session-Id")
@@ -131,7 +131,9 @@ def create_app():
 
     @flask_app.errorhandler(Exception)
     def handle_exception(exception):
-        wrapped = ResponseError(str(exception), StatusCode.INTERNAL_ERROR, type(exception))
+        logger.exception("Unhandled exception in request.")
+        message = str(exception) if JsonResponse.debug_mode else "An unexpected error occurred."
+        wrapped = ResponseError(message, StatusCode.INTERNAL_ERROR, type(exception))
         return JsonResponse.error(wrapped, wrapped.status)
 
     # Add routes for modules here

--- a/dataactcore/utils/jsonResponse.py
+++ b/dataactcore/utils/jsonResponse.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class JsonResponse:
     """Used to create an http response object containing JSON"""
 
-    debug_mode = True
+    debug_mode = False
 
     @staticmethod
     def create(code, dictionary_data):

--- a/dataactvalidator/health_check.py
+++ b/dataactvalidator/health_check.py
@@ -18,7 +18,7 @@ def create_app():
         """Confirm server running."""
         return "Validator is running"
 
-    JsonResponse.debugMode = flask_app.debug
+    JsonResponse.debug_mode = flask_app.debug
 
     return flask_app
 

--- a/tests/integration/baseTestAPI.py
+++ b/tests/integration/baseTestAPI.py
@@ -15,7 +15,7 @@ from dataactcore.scripts.setup.setup_job_tracker_db import setup_job_tracker_db
 from dataactcore.scripts.setup.setup_error_db import setup_error_db
 from dataactcore.scripts.setup.setup_validation_db import setup_validation_db
 from dataactcore.scripts.setup.database_setup import create_database, run_migrations
-from dataactcore.config import CONFIG_BROKER, CONFIG_DB
+from dataactcore.config import CONFIG_BROKER, CONFIG_SERVICES, CONFIG_DB
 import dataactcore.config
 from dataactcore.scripts.setup.setup_emails import setup_emails
 from dataactvalidator.health_check import create_app as create_validator_app
@@ -124,11 +124,12 @@ class BaseTestAPI(unittest.TestCase):
         cls.admin_password = admin_password
         cls.local = CONFIG_BROKER["local"]
 
-    def setUp(self):
+    def setUp(self, debug=False):
         """Set up broker unit tests."""
+        CONFIG_SERVICES["debug"] = debug
         app = create_broker_app()
         app.config["TESTING"] = True
-        app.config["DEBUG"] = False
+        app.config["DEBUG"] = debug
         self.app = TestApp(app)
 
     @classmethod

--- a/tests/integration/base_api_tests.py
+++ b/tests/integration/base_api_tests.py
@@ -1,0 +1,34 @@
+from tests.integration.baseTestAPI import BaseTestAPI
+
+from dataactcore.utils.statusCode import StatusCode
+
+SPECIFIC_ERROR_MSG = "Specfiic error!"
+GENERAL_ERROR_MSG = "An unexpected error occurred."
+
+
+def setup_broken_endpoint(app):
+    @app.route("/endpoint")
+    def handle():
+        raise Exception(SPECIFIC_ERROR_MSG)
+
+
+class BaseAPITestsDebugOn(BaseTestAPI):
+    def setUp(self):
+        super(BaseAPITestsDebugOn, self).setUp(debug=True)
+        setup_broken_endpoint(self.app.app)
+
+    def test_error_debug_on(self):
+        response = self.app.get("/endpoint", headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, StatusCode.INTERNAL_ERROR)
+        self.assertEqual(response.json["message"], SPECIFIC_ERROR_MSG)
+
+
+class BaseAPITestsDebugOff(BaseTestAPI):
+    def setUp(self):
+        super(BaseAPITestsDebugOff, self).setUp(debug=False)
+        setup_broken_endpoint(self.app.app)
+
+    def test_error_debug_off(self):
+        response = self.app.get("/endpoint", headers={"x-session-id": self.session_id}, expect_errors=True)
+        self.assertEqual(response.status_code, StatusCode.INTERNAL_ERROR)
+        self.assertEqual(response.json["message"], GENERAL_ERROR_MSG)


### PR DESCRIPTION
**High level description:**
* Fixed typos for JsonResponse.debug_mode
* Defaulted JsonResponse.debug_mode to `False` (confirmed it's set to `CONFIG_SERVICES['debug']` which is True on all environments except production)
* Updated error message when JsonResponse.debug_mode is `False`

**Technical details:**
* Added `debug` argument to the integration tests `setUp` to toggle this functionality (defaults to `False`).

**Link to JIRA Ticket:**
[DEV-15395](https://federal-spending-transparency.atlassian.net/browse/DEV-15395)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated

[DEV-15395]: https://federal-spending-transparency.atlassian.net/browse/DEV-15395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ