### PR TITLE
[DEV-15540] Additional Detached File Gen Check

### DIFF
--- a/dataactbroker/handlers/generation_handler.py
+++ b/dataactbroker/handlers/generation_handler.py
@@ -266,6 +266,6 @@ def check_detached_generation(job_id):
     Returns:
         Response object with keys job_id, status, file_type, url, message, start, and end.
     """
-    response_dict = generation_helper.check_file_generation(job_id)
+    response_dict = generation_helper.check_file_generation(job_id, detached=True)
 
     return JsonResponse.create(StatusCode.OK, response_dict)

--- a/dataactbroker/helpers/generation_helper.py
+++ b/dataactbroker/helpers/generation_helper.py
@@ -194,11 +194,12 @@ def start_dabs_generation(job, start_date, end_date, agency_code):
     logger.debug(log_data)
 
 
-def check_file_generation(job_id):
+def check_file_generation(job_id, detached=False):
     """Check the status of a file generation
 
     Args:
         job_id: upload Job ID
+        detached: whether the job_id provided should be detached or not
     Return:
         Dict with keys: job_id, status, file_type, message, url, start, end
     """
@@ -222,6 +223,12 @@ def check_file_generation(job_id):
         response_dict["end"] = ""
         response_dict["status"] = "invalid"
         response_dict["message"] = "No generation job found with the specified ID"
+        return response_dict
+    if detached and upload_job.submission_id is not None:
+        response_dict["start"] = ""
+        response_dict["end"] = ""
+        response_dict["status"] = "invalid"
+        response_dict["message"] = "Job ID not associated with a detached file generation."
         return response_dict
 
     response_dict["file_type"] = lookups.FILE_TYPE_DICT_LETTER[upload_job.file_type_id]

--- a/tests/unit/dataactbroker/test_generation_helper.py
+++ b/tests/unit/dataactbroker/test_generation_helper.py
@@ -685,6 +685,11 @@ def test_check_submission_d_file_generation(database):
     assert response_dict["status"] == "failed"
     assert response_dict["message"] == "Generated file had file-level errors"
 
+    # Detached D File Generation but providing a job id tied to a submission
+    response_dict = check_file_generation(job.job_id, detached=True)
+    assert response_dict["status"] == "invalid"
+    assert response_dict["message"] == "Job ID not associated with a detached file generation."
+
 
 @pytest.mark.usefixtures("job_constants")
 def test_copy_file_generation_to_job_detached(monkeypatch, database):


### PR DESCRIPTION
**High level description:**
Adding a check to `/v1/check_detached_generation_status` to return an invalid error when the job_id provided is attached to a submission.

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-15540](https://federal-spending-transparency.atlassian.net/browse/DEV-15540)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated
