### PR TITLE
DEV-13432: ActionType lookup updates

### DIFF
--- a/dataactcore/models/lookups.py
+++ b/dataactcore/models/lookups.py
@@ -182,11 +182,18 @@ SUBMISSION_TYPE = [
 SUBMISSION_TYPE_DICT = {item.name: item.id for item in SUBMISSION_TYPE}
 
 ACTION_TYPE = [
-    LookupType(1, "A", "New"),
-    LookupType(2, "B", "Continuation"),
-    LookupType(3, "C", "Revision"),
-    LookupType(4, "D", "Adjustment to Completed Project"),
-    LookupType(4, "E", "Aggregate Mixed"),
+    LookupType(1, "A1", "New Award"),
+    LookupType(2, "A2", "Renewal Award"),
+    LookupType(3, "B1", "Continuation"),
+    LookupType(4, "C1", "Termination Initiated: Material Failure to Comply"),
+    LookupType(5, "C2", "Termination Initiated: Mutual Consent"),
+    LookupType(6, "C3", "Termination Initiated: Recipient-Initiated"),
+    LookupType(7, "C4", "Termination Initiated: No Longer Effectuates Program Goals or Agency Priorities"),
+    LookupType(8, "D1", "Closeout"),
+    LookupType(9, "E1", "Recipient Change"),
+    LookupType(10, "EX", "Other Action, Non-Financial"),
+    LookupType(11, "FX", "Other Action, Financial"),
+    LookupType(12, "G1", "Mixed Aggregate"),
 ]
 ACTION_TYPE_DICT = {item.name: item.desc for item in ACTION_TYPE}
 

--- a/tests/unit/dataactbroker/test_fabs_derivations.py
+++ b/tests/unit/dataactbroker/test_fabs_derivations.py
@@ -1255,12 +1255,12 @@ def test_derive_labels(database):
 
     # Testing for valid values of each
     submission_id = initialize_test_row(
-        database, cdi="c", action_type="a", assist_type="02", busi_type="d", busi_fund="non", submission_id=3
+        database, cdi="c", action_type="a1", assist_type="02", busi_type="d", busi_fund="non", submission_id=3
     )
     fabs_derivations(database.session, submission_id)
     database.session.commit()
     fabs_obj = get_derived_fabs(database, submission_id)
-    assert fabs_obj.action_type_description == ACTION_TYPE_DICT["A"]
+    assert fabs_obj.action_type_description == ACTION_TYPE_DICT["A1"]
     assert fabs_obj.assistance_type_desc == ASSISTANCE_TYPE_DICT["02"]
     assert fabs_obj.correction_delete_ind_desc == CORRECTION_DELETE_IND_DICT["C"]
     assert fabs_obj.record_type_description == RECORD_TYPE_DICT[2]


### PR DESCRIPTION
**High level description:**
Updating FABS ActionTypes lookup

**Technical details:**
Changing the old FABS ActionTypes to the new ones

**Link to JIRA Ticket:**
[DEV-13432](https://federal-spending-transparency.atlassian.net/browse/DEV-13432)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation updated


[DEV-13432]: https://federal-spending-transparency.atlassian.net/browse/DEV-13432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ