### PR TITLE
DEV-15631: Date comparison FABS44

### DIFF
--- a/dataactvalidator/config/sqlrules/fabs44_3_2.sql
+++ b/dataactvalidator/config/sqlrules/fabs44_3_2.sql
@@ -32,4 +32,4 @@ WHERE submission_id = {0}
                 WHERE zc_2.zip_code = fabs.legal_entity_zip5
                     AND COALESCE(sc_2.census_year, 2020) >= 2020) < 2)
     )
-    AND cast_as_date(action_date) > '01/03/2023';
+    AND cast_as_date(action_date) >= '01/03/2023';

--- a/tests/unit/dataactvalidator/test_fabs44_3_2.py
+++ b/tests/unit/dataactvalidator/test_fabs44_3_2.py
@@ -32,7 +32,7 @@ def test_success(database):
         legal_entity_zip5="12345",
         legal_entity_congressional="01",
         correction_delete_indicatr="c",
-        action_date="20230104",
+        action_date="20230103",
     )
     fabs_2 = FABSFactory(
         legal_entity_zip5="23456",


### PR DESCRIPTION
**High level description:**
Updating to include 01/03/2023 in the "not before that date" FABS44.3 rule

**Technical details:**
N/A

**Link to JIRA Ticket:**
[DEV-1234](https://federal-spending-transparency.atlassian.net/browse/DEV-1234)

The following are ALL required for the PR to be merged:
- [x] Backend review completed
- Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- Frontend impact assessment completed
- Documentation updated


[DEV-1234]: https://federal-spending-transparency.atlassian.net/browse/DEV-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ