### PR TITLE
[DEV-16057] Atomic checks for `upload_dabs_files` and `publish_dabs_submission`

### DIFF
--- a/dataactbroker/handlers/fileHandler.py
+++ b/dataactbroker/handlers/fileHandler.py
@@ -792,23 +792,33 @@ class FileHandler:
 
         sess = GlobalDB.db().session
         submission_id = submission.submission_id
-        # Check to make sure all jobs are finished
-        unfinished_jobs = (
-            sess.query(Job)
-            .filter(Job.submission_id == submission_id, Job.job_status_id != JOB_STATUS_DICT["finished"])
-            .count()
-        )
-        if unfinished_jobs > 0:
-            raise ResponseError("Submission has unfinished jobs and cannot be published", StatusCode.CLIENT_ERROR)
 
         # if it's an unpublished FABS submission that has only finished jobs, we can start the process
         log_derivation("Starting FABS submission publishing", submission_id)
 
-        # set publish_status to "publishing"
-        sess.query(Submission).filter_by(submission_id=submission_id).update(
-            {"publish_status_id": PUBLISH_STATUS_DICT["publishing"], "updated_at": get_utc_now()},
-            synchronize_session=False,
+        # set publish_status to "publishing" atomically, only if the submission is still unpublished and all of
+        # its jobs are still finished, so a concurrent upload or publish cannot slip in between the checks above
+        # and this status flip
+        unfinished_job_exists = (
+            sess.query(Job)
+            .filter(Job.submission_id == submission_id, Job.job_status_id != JOB_STATUS_DICT["finished"])
+            .exists()
         )
+        updated_rows = (
+            sess.query(Submission)
+            .filter(
+                Submission.submission_id == submission_id,
+                Submission.publish_status_id == PUBLISH_STATUS_DICT["unpublished"],
+                ~unfinished_job_exists,
+            )
+            .update(
+                {"publish_status_id": PUBLISH_STATUS_DICT["publishing"], "updated_at": get_utc_now()},
+                synchronize_session=False,
+            )
+        )
+        if updated_rows == 0:
+            sess.rollback()
+            raise ResponseError("Submission has unfinished jobs and cannot be published", StatusCode.CLIENT_ERROR)
         sess.commit()
 
         try:

--- a/dataactbroker/handlers/submission_handler.py
+++ b/dataactbroker/handlers/submission_handler.py
@@ -983,8 +983,27 @@ def process_dabs_publish(submission, file_manager):
     # Determine if this is the first time this submission is being published
     first_publish = submission.publish_status_id == PUBLISH_STATUS_DICT["unpublished"]
 
-    # set publish_status to "publishing"
-    submission.publish_status_id = PUBLISH_STATUS_DICT["publishing"]
+    # set publish_status to "publishing" atomically, only if the submission is still in the state verified by
+    # publish_checks.
+    updated_rows = (
+        sess.query(Submission)
+        .filter(
+            Submission.submission_id == submission.submission_id,
+            Submission.publishable.is_(True),
+            Submission.test_submission.is_(False),
+            Submission.publish_status_id.notin_(
+                [
+                    PUBLISH_STATUS_DICT["publishing"],
+                    PUBLISH_STATUS_DICT["reverting"],
+                    PUBLISH_STATUS_DICT["published"],
+                ]
+            ),
+        )
+        .update({"publish_status_id": PUBLISH_STATUS_DICT["publishing"]}, synchronize_session=False)
+    )
+    if updated_rows == 0:
+        sess.rollback()
+        raise ValueError("Submission was updated during publishing. Please revalidate before publishing.")
 
     # create the publish_history entry
     publish_history = PublishHistory(user_id=active_user_id, submission_id=submission.submission_id)

--- a/dataactcore/interfaces/function_bag.py
+++ b/dataactcore/interfaces/function_bag.py
@@ -407,6 +407,26 @@ def create_jobs(upload_files, submission, existing_submission=False):
     sess = GlobalDB.db().session
     submission_id = submission.submission_id
 
+    if existing_submission:
+        # Re-verify the submission's publish status in the same transaction that swaps the job files. This
+        # closes the race window with a concurrent publish: if the submission started publishing/reverting
+        # after the handler's initial check, no rows match and we abort before any job filenames are changed.
+        # Setting publishable to False here (atomically) also prevents a publish from starting once the swap
+        # has been committed but before the new files have been validated.
+        updated_rows = (
+            sess.query(Submission)
+            .filter(
+                Submission.submission_id == submission_id,
+                Submission.publish_status_id.notin_(
+                    [PUBLISH_STATUS_DICT["publishing"], PUBLISH_STATUS_DICT["reverting"]]
+                ),
+            )
+            .update({"publishable": False}, synchronize_session=False)
+        )
+        if updated_rows == 0:
+            sess.rollback()
+            raise ValueError("Existing submission must not be publishing or reverting")
+
     # create the file upload and single-file validation jobs and
     # set up the dependencies between them
     # before starting, sort the incoming list of jobs by letter

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -1761,7 +1761,7 @@ class FileTests(BaseTestAPI):
 
     def test_cross_file_status_reset_new_upload(self):
         """Test that cross-file resets when D file generation is called."""
-        submission = SubmissionFactory(publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
+        submission = SubmissionFactory(publish_status_id=PUBLISH_STATUS_DICT["unpublished"])
         self.session.add(submission)
         self.session.commit()
 

--- a/tests/integration/fileTests.py
+++ b/tests/integration/fileTests.py
@@ -1761,7 +1761,7 @@ class FileTests(BaseTestAPI):
 
     def test_cross_file_status_reset_new_upload(self):
         """Test that cross-file resets when D file generation is called."""
-        submission = SubmissionFactory()
+        submission = SubmissionFactory(publish_status_id=PUBLISH_STATUS_DICT['unpublished'])
         self.session.add(submission)
         self.session.commit()
 


### PR DESCRIPTION
**High level description:**
Adding atomic checks for `/v1/upload_dabs_files` and `/v1/publish_dabs_submission` endpoints.

**Technical details:**
Adds an additional setting of publishable to `False` for existing submissions via `/v1/upload_dabs_files` and ensuring the submission isn't publishing/reverting at the same time.

**Link to JIRA Ticket:**
[DEV-16057](https://federal-spending-transparency.atlassian.net/browse/DEV-16057)

The following are ALL required for the PR to be merged:
- [ ] Backend review completed
- [x] Style Guide check completed
- [x] Unit & integration tests updated with relevant test cases
- [x] Frontend impact assessment completed
- [x] Documentation updated


[DEV-16057]: https://federal-spending-transparency.atlassian.net/browse/DEV-16057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ